### PR TITLE
QT5.8 Ambiguity Errors Fix

### DIFF
--- a/edbee-lib/edbee/io/baseplistparser.cpp
+++ b/edbee-lib/edbee/io/baseplistparser.cpp
@@ -115,15 +115,15 @@ QVariant BasePListParser::readNextPlistType( int level )
 {
     if( readNextElement("",level) ) {
         // reads a dictionary
-        if( xml_->name().compare( "dict", Qt::CaseInsensitive ) == 0 ) {
+        if( xml_->name().compare( QString("dict"), Qt::CaseInsensitive ) == 0 ) {
             return readDict();
 
         // reads an array
-        } else if( xml_->name().compare( "array", Qt::CaseInsensitive ) == 0 ) {
+        } else if( xml_->name().compare( QString("array"), Qt::CaseInsensitive ) == 0 ) {
             return readList( );
 
         // reads a string
-        } else if( xml_->name().compare( "string", Qt::CaseInsensitive ) == 0 ) {
+        } else if( xml_->name().compare( QString("string"), Qt::CaseInsensitive ) == 0 ) {
             return readElementText();
         }
     }


### PR DESCRIPTION
QStringRef compare now takes additional types of argument, so the compiler choked on the given string literals. I encompassed them with a QString() to satisfy the ambiguity.