### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,5 @@ script:
   - cd build
   - qmake ../edbee-lib.pro && make -j2
   - cd edbee-test
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then cd edbee-test.app/Contents/MacOS/; fi
   - ./edbee-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ before_script:
   - mkdir build
 script:
   - cd build
-  - qmake ../edbee-lib.pro && make -j2
+  - if [ "${CC}" = "clang" ] && [ "${TRAVIS_OS_NAME}" = "linux" ]; then SPEC="-spec linux-clang"; fi
+  - qmake ${SPEC} ../edbee-lib.pro && make -j2
   - cd edbee-test
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then cd edbee-test.app/Contents/MacOS/; fi
   - ./edbee-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     - qt56base
     - qt56multimedia
     - qt56tools
+    - xvfb
 compiler:
   - gcc
   - clang
@@ -22,6 +23,10 @@ matrix:
 before_install: ./CI/travis.before_install.sh
 install: ./CI/travis.install.sh
 before_script:
+  - "export DISPLAY=:99.0"
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sh -e /etc/init.d/xvfb start; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok ) & fi
+  - sleep 3 # give xvfb some time to start
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then PATH="/usr/local/opt/qt5/bin:$PATH"; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then source /opt/qt56/bin/qt56-env.sh; fi
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: cpp
+os:
+  - osx
+  - linux
+dist: trusty
+sudo: false
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:beineri/opt-qt562-trusty'
+    packages:
+    - qt56base
+    - qt56multimedia
+    - qt56tools
+compiler:
+  - gcc
+  - clang
+matrix:
+  exclude:
+  - os: osx
+    compiler: gcc
+before_install: ./CI/travis.before_install.sh
+install: ./CI/travis.install.sh
+before_script:
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then PATH="/usr/local/opt/qt5/bin:$PATH"; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then source /opt/qt56/bin/qt56-env.sh; fi
+  - mkdir build
+script:
+  - cd build
+  - qmake ../edbee-lib.pro && make -j2
+  - cd edbee-test
+  - ./edbee-test

--- a/CI/travis.before_install.sh
+++ b/CI/travis.before_install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+  echo Before install on OSX.
+  ./CI/travis.osx.before_install.sh;
+fi

--- a/CI/travis.install.sh
+++ b/CI/travis.install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+  echo Install on OSX.
+  ./CI/travis.osx.install.sh;
+fi
+if [ ! -z "${CXX}" ]; then
+  echo "Testing (possibly updated) compiler version:"
+  ${CXX} --version;
+fi

--- a/CI/travis.osx.before_install.sh
+++ b/CI/travis.osx.before_install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ev
+brew update

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ev
+BREWS="qt5"
+for i in $BREWS; do
+  brew outdated | grep -q $i && brew upgrade $i
+done
+for i in $BREWS; do
+  brew list | grep -q $i || brew install $i
+done


### PR DESCRIPTION
This adds compilation and (more importantly) running the `edbee-test` subproject on travis, using the macOS and precise ubuntu images to make the project more independent for testing.

 You will need to register with https://travis-ci.org/ and enable the `edbee-lib` project (see https://docs.travis-ci.com/user/for-beginners). If you need help setting up travis, let me know!

The build specifications are as follows:
- Ubuntu 14.04 LTS "Precise" and macOS 10.11 with XCode 7.3.1 images
- Ubuntu uses Qt 5.6 for compiling, macOS uses the latest homebrew Qt (5.8 atm).
- Both use xvfb as X-Server emulation for the tests
- Ubuntu is set up to use both clang and gcc for compiling in different jobs.