### PR TITLE
Fix an issue with forward declaration of edbee::TextEditorScrollArea

### DIFF
--- a/edbee-lib/edbee/texteditorwidget.h
+++ b/edbee-lib/edbee/texteditorwidget.h
@@ -8,6 +8,7 @@
 //#include <QAbstractScrollArea>
 #include <QStringList>
 #include <QWidget>
+#include "views/texteditorscrollarea.h"
 
 class QResizeEvent;
 class QScrollBar;


### PR DESCRIPTION
The class is being used before its header is actually included.

Fixes https://github.com/edbee/edbee-lib/issues/15.