### PR TITLE
Fix theme loading

### DIFF
--- a/edbee-lib/edbee/views/texttheme.cpp
+++ b/edbee-lib/edbee/views/texttheme.cpp
@@ -405,9 +405,9 @@ TextTheme* TextThemeManager::readThemeFile( const QString& fileName, const QStri
 /// @return the theme with the given name
 TextTheme* TextThemeManager::theme(const QString& name)
 {
-    if( name.isEmpty() || themePath_.isEmpty() ) { return 0; }
+    if( name.isEmpty() ) { return 0; }
     TextTheme* theme=themeMap_.value(name);
-    if( !theme ) {
+    if( !theme && !themePath_.isEmpty()) {
         QString filename = QString("%1/%2.tmTheme").arg(themePath_).arg(name);
         TextTheme* theme = readThemeFile( filename );
         if( !theme ) {


### PR DESCRIPTION
A theme won't get loaded if no fallback themePath_ is supplied even if it's loaded into the themeMap already. The fallback should only matter when a theme wasn't actually found.

Credit to @tomcss for discovering the problem.