### PR TITLE
Added selection clipboard copy and paste for unix like system

### DIFF
--- a/edbee-lib/edbee/views/components/texteditorcomponent.h
+++ b/edbee-lib/edbee/views/components/texteditorcomponent.h
@@ -52,6 +52,7 @@ protected:
     void inputMethodEvent( QInputMethodEvent* m );
     QVariant inputMethodQuery( Qt::InputMethodQuery p ) const;
     virtual void mousePressEvent( QMouseEvent* event );
+    virtual void mouseReleaseEvent( QMouseEvent* event );
     virtual void mouseDoubleClickEvent( QMouseEvent* event );
     virtual void mouseMoveEvent( QMouseEvent* event );
     virtual void focusInEvent( QFocusEvent* event );


### PR DESCRIPTION
Linux users always use selection and middle click to copy and paste text. Because edbee is not based on a Qt text editor, it is not implemented.
This small modification make edbee-lib able to accept middle click to paste this special clipboard and to copy selection to it.