### PR TITLE
Really, only enable memory leak detection with EDBEE_DEBUG

### DIFF
--- a/edbee-lib/edbee/util/mem/debug_new.cpp
+++ b/edbee-lib/edbee/util/mem/debug_new.cpp
@@ -15,7 +15,7 @@
 #include <malloc.h>
 #endif
 
-
+#if defined(EDBEE_DEBUG)
 #define debug_new_log // printf
 
 /// Logs a malloc operation
@@ -112,7 +112,7 @@ void  operator delete[] (void* p) throw()
 {
     return debug_free(p, "unknown", 0);
 }
-
+#endif
 
 
 namespace edbee {


### PR DESCRIPTION
Memory leak detection was supposed to be turned off with https://github.com/edbee/edbee-lib/commit/198eb20f55103407af88ca178ef24ceab35cd61a, but I still experienced issue with other memory leak tools (https://bugs.kde.org/show_bug.cgi?id=410107).

Upon inspection only the header declarations were disabled and not the actual functions themselves, and putting this `#if` around the functions _actually_ does the trick.