### PR TITLE
Compile fix for README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Of course it would also be nice to fill the editor with a file. you can use the 
 
 edbee::TextEditorWidget* widget =  new edbee::TextEditorWidget();
 edbee::TextDocumentSerializer serializer( widget->textDocument() );
-if( !serializer.load( "your-filename.rb" ) ) {
+QFile file( QStringLiteral("your-filename.rb") );
+if( !serializer.load( &file ) ) {
     QMessageBox::warning(this, tr("Error opening file"), tr("Error opening file!\n%1").arg(serializer.errorString()) );
 }
 


### PR DESCRIPTION
`TextDocumentSerializer::load` takes a `QIODevice*` as input and at least for me this implicit convert from `const char*` doesn't work but I have many of those disabled in my codebase, but it may just be that the readme is outdated as well.

Anyway this should make it work regardless.