### PR TITLE
Revise: fix QString::split(...) for older Qt Versions

### DIFF
--- a/edbee-test/edbee/models/textrangetest.cpp
+++ b/edbee-test/edbee/models/textrangetest.cpp
@@ -32,7 +32,11 @@ do { \
 /// @param definition the definition. In the format  anchor>caret,anchor>caret
 static void addRanges( TextRangeSet* sel, const QString& definition )
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QStringList ranges = definition.split(",", Qt::SkipEmptyParts);
+#else
+    QStringList ranges = definition.split(",", QString::SkipEmptyParts);
+#endif
     foreach( QString range, ranges ) {
         QStringList values = range.split(">");
         Q_ASSERT(values.length() == 2);


### PR DESCRIPTION
A use of the above in the test code fails to build on anything older than Qt 5.14 as the `enum` used is only present in that and newer versions. Previously the `enum` was a member of the `QString` class rather than the `Qt` namespace...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>