### PR TITLE
Fix remove some depreciation warnings for qt6 and other warnings and spelling errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 edbee.lib:
 
 - fix #136, BREAKING CHANGE: return type TextEditorController::executeCommand changed to void.
-  - changed TextEditorController slot argumens to fully-qualified types.
+  - changed TextEditorController slot arguments to fully-qualified types.
 - ref #136, remove TextDocumentController readonly methods from slots
 - Fix out-of-bounds write in TextDocumentSerializer
 - add #135, QAccessibleTextInterface support
 - add TextBuffer::emitTextChanged is extended with the oldText. SIGNAL void emitTextChanged( TextBufferChange* change, QString oldText = QString()); (WARNING: signal interface changes )
 - fix #133, Added Qt 6.3.0 compatibility
 - fix #132, Writing diacritics in Linux
-- ref #128, Build in supprort for virtual characters. Alternate position/cursor calculations via TextLayout
+- ref #128, Build in support for virtual characters. Alternate position/cursor calculations via TextLayout
 - ref #127,
   - Option to show Unicode BIDI characters (CVE-2021-425740). (as red icons for now)
   - It is configurable via 'TexteditorConfig::renderBidiContolCharacters', and defaults to true
@@ -19,7 +19,7 @@ edbee.lib:
 - fix #121, Standard Keys not working correctly (Fixed by fetching ALL keybindings via QKeySequence::keyBinding)
 - fix #119, Missing `case MoveCaretToWordBoundary:` in `switch` statement
 - fix #118, Missing `override` specifier in command header files
-- fix #115, basic Tripple-click support
+- fix #115, basic Triple-click support
 - fix #114, Double-click + drag should end at word boundaries
 - #112, Workaround for missing Qt::endl in Qt 5.12
 - Support for sticky-selection in replaceSelection methods. (Required for InpuMethod entry)
@@ -31,7 +31,7 @@ edbee.lib:
 - ref #106, Missing round function on SuSE. (Changed to qRound)
 - ref #99, Speed improvements for markAll. (Added beginChanges and endChanges, to  prevent updating)
 - fix #96, Added support for readonly mode, via widget->setReadonly() or controller->setReadonly
-- fix #90, Fixed several Qt deprecation warnings. Chagned 0 to nullptr. Possible incompatibility with older releases!
+- fix #90, Fixed several Qt deprecation warnings. Changed 0 to nullptr. Possible incompatibility with older releases!
 - add #101, Support for JSON based grammar files.
 - fix #67, PlacholderText support via TextEditorWidget::setPlaceholderText. (uses 70% opacity of foreground color)
 - fix #98, Missing header include in Qt 5.15rc
@@ -59,7 +59,7 @@ edbee.lib:
 	- Line numbers of lines with selection are rendered with 100% opacity
 - fix #38, Margin line-number font size is now set to the font size of the editor. It also renders number with an opacity of 0.5.
 - fix #32, Changing showWhiteSpace option does not trigger a redraw
-- add #31, Support for rendering borderedTextRanges. These are textranges rendered with borders, that aren't selected. TextEditorController has a member 'borderedTextRanges()'. Altering this rangeset (and updating the view controller::update) renderes borders aroudn the given ranges
+- add #31, Support for rendering borderedTextRanges. These are textranges rendered with borders, that aren't selected. TextEditorController has a member 'borderedTextRanges()'. Altering this rangeset (and updating the view controller::update) renders borders around the given ranges
 - fix #30, Edbee crashes when you cut/copy with nothing selected. (Bug in clipboard operation)
 - fix #27, Theme loading/handling bugfixes
 	- Theme-colors with alpha channels are parsed correctly. (QColor expects #AARRGGBB, theme uses #RRGGBBAA)
@@ -69,7 +69,7 @@ edbee.lib:
 - fix #26, Changing a theme in the ThemeManager, now updates the ThemePointer used by the renderer. (Fixes corruption on theme reloading)
 - fix #25, Removed the 'memory ok :-D' message
 - fix #24, Clearing the undostack unregistered all controllers incorrectly
-- fix #23, Scope invaldating optimization wasn't working correctly. Removed optimization for now
+- fix #23, Scope invalidating optimization wasn't working correctly. Removed optimization for now
 - fix #19, Workaround-hack for non-bmp-unicode character movement. (experimental)
 - Added DebugCommand::DumpCharacterCodes (for dumping hex-character codes)
 - fix #14, MinGW compatibility: Disabled memoryLeak detection and fixed mingw compilation (different library-name is generated for mingw)
@@ -86,7 +86,7 @@ edbee.lib:
 - fix #6, Theme Manager only attempts to load a theme if a theme path has been set.
 - fix, updated Onigmo (Oniguruma-mod) library to version 6.1.1 (Fixes memory corruption with lexing)
 - fix, removed config.h reference from simpleprofiler.h (Which caused compilation via to fail, refs issue #1)
-- fix, mouse double click didn't select wordt anymore. (Issue with newer Qt version??)
+- fix, mouse double click didn't select word any more. (Issue with newer Qt version??)
 - fix, moveCaret after the last character didn't work correctly on the if the last line didn't end with a newline
 - fix, Syntax highlighting didn't work on the last line of the document. (First highlight after the first enter)
 - fix, onig.pri, it contained strange references to qslog
@@ -118,9 +118,9 @@ All lines above refer to github-issue numbers
 - fix #124, Line breaks (\n) are rendered with QTextLayout, which results in a strange character on a Linux environment (github issue 2)
 - fix #123, Updated oniguruma to 5.13.5 to solve a segfault on Ubuntu 13 (64bits)
 - fix #122, Library can't be compiled on Linux, unix  is a predefined word on unix
-- fix #118, The width of the editor component should add an extra spacing so the caret isn't placed agains the right window border
+- fix #118, The width of the editor component should add an extra spacing so the caret isn't placed against the right window border
 - fix #117, The last line doesn't show the caret marker in the line-number column
-- fix #116, The linenumber column isn't updated properly when the number of digets increases.
+- fix #116, The line-number column isn't updated properly when the number of digits increases.
 - fix #114, Added a factory keymap so the editor works out of the box
 - fix #103, Renamed the *TextChange related classes. So it's more clear what the changes represent
 - fix #73, Complete rewrite of coalescing (change-merging) algorithm, so all textchanges are mergable. (Fixes #98,#97,#95,#41,#99,#100,#101)
@@ -137,8 +137,8 @@ All lines above refer to github-issue numbers
 - fix #66, Grammar type detection (by filename) detected the wrong grammars. (it forgot to check the '.' )
 - fix #40, text now is by default case insensitive
 - fix #30, #32, Searching selection via the findcommand now result in soft undoable changes
-- fix #20, Changing TextEditorConfig now automaticly updates the state of edbee.
-- fix #21, Improved fallback pallette when a theme cannot be loaded. (fixes complete black screen)
+- fix #20, Changing TextEditorConfig now automatically updates the state of edbee.
+- fix #21, Improved fallback palette when a theme cannot be loaded. (fixes complete black screen)
 - fix #16, linespacing issue, the space always was at least 1 pixel
 - fix #2, made it possible to configure TextEditorConfig. (was hardcoded)
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ You can contribute via github
 - Push to the branch (git push origin my-new-feature)
 - Create new Pull Request
 
-Of course you can also contribute by contacting me via twitter @gamecreature or drop me al message
+Of course you can also contribute by contacting me via twitter @gamecreature or drop me a message
 via the email-address supplied at [https://github.com/gamecreature](https://github.com/gamecreature)
 
 Issues?

--- a/edbee-lib/doc/coding-style.md
+++ b/edbee-lib/doc/coding-style.md
@@ -43,7 +43,7 @@ QList<Item*> itemRefList_;
 Method definitions
 ------------------
 
-Seperate methods from eachother with 2 blank lines.  This improves the visible separation of method bodies.
+Separate methods from each other with 2 blank lines.  This improves the visible separation of method bodies.
 
 
 Ownership
@@ -77,7 +77,7 @@ Memory Leak Detection and include order
 ---------------------------------------
 
 We use custom memory leak detection. To enable this leak detection it is required to include 'debug.h'
-Uou must include "debug.h" in every Source file AFTER all pre-compiled items and header files. Example:
+You must include "debug.h" in every Source file AFTER all pre-compiled items and header files. Example:
 
 ~~~{.cpp} 
 // first you should include the source's header file. (This allows you to see if the headers users 'missing' dependencies'

--- a/edbee-lib/edbee/commands/commentcommand.cpp
+++ b/edbee-lib/edbee/commands/commentcommand.cpp
@@ -309,7 +309,7 @@ static int insertBlockComment( TextEditorController* controller, TextRange& rang
 {
     TextDocument* doc = controller->textDocument();
 
-    // for safety I don't use the range anymore. It's adjusted automaticly, but could in theory vanish
+    // for safety I don't use the range anymore. It's adjusted automatically, but could in theory vanish
     int min = range.min();
     int max = range.max();
 

--- a/edbee-lib/edbee/edbee.cpp
+++ b/edbee-lib/edbee/edbee.cpp
@@ -81,7 +81,7 @@ void Edbee::setGrammarPath( const QString& grammarPath )
 }
 
 
-/// Setst the path where to find the theme files
+/// Sets the path where to find the theme files
 /// @param themePath the path to find the themes
 void Edbee::setThemePath( const QString& themePath )
 {
@@ -89,7 +89,7 @@ void Edbee::setThemePath( const QString& themePath )
 }
 
 
-/// This method automaticly initializes the edbee library it this hasn't already been done
+/// This method automatically initializes the edbee library it this hasn't already been done
 void Edbee::autoInit()
 {
     if( !inited_ ) {
@@ -222,7 +222,7 @@ void Edbee::shutdown()
 }
 
 
-/// Call this method to automaticly shutdown the texteditor manager on shutdown
+/// Call this method to automatically shutdown the texteditor manager on shutdown
 /// (This method listens to the qApp::aboutToQuit signal
 void Edbee::autoShutDownOnAppExit()
 {
@@ -288,7 +288,7 @@ TextKeyMapManager* Edbee::keyMapManager()
 }
 
 
-/// Rreturns the dynamicvariables object
+/// Returns the dynamicvariables object
 DynamicVariables* Edbee::environmentVariables()
 {
     Q_ASSERT(inited_);

--- a/edbee-lib/edbee/models/changes/abstractrangedchange.cpp
+++ b/edbee-lib/edbee/models/changes/abstractrangedchange.cpp
@@ -137,7 +137,7 @@ bool AbstractRangedChange::merge( AbstractRangedChange* change )
 }
 
 
-/// This method checks if this textchange is overlapped by the second text change
+/// This method checks if this textchange is overlapped by the second textchange
 /// overlapping is an exclusive overlap, which means the changes are really on top of eachother
 /// to test if the changes are touching use isTouchedBy
 /// @param secondChange the other change to compare it to

--- a/edbee-lib/edbee/models/changes/linedatalistchange.cpp
+++ b/edbee-lib/edbee/models/changes/linedatalistchange.cpp
@@ -24,7 +24,7 @@ LineDataListChange::LineDataListChange( TextLineDataManager* manager, int line, 
     : managerRef_(manager)
     , offset_(line)
     , docLength_(newLength)
-    , oldListList_(0)
+    , oldListList_(nullptr)
     , contentLength_(length)
 {
 }

--- a/edbee-lib/edbee/models/changes/linedatalistchange.cpp
+++ b/edbee-lib/edbee/models/changes/linedatalistchange.cpp
@@ -16,7 +16,7 @@ class TextLineDataManager;
 
 
 /// The line data text change constructor
-/// @param manger the line data manager
+/// @param manager the line data manager
 /// @param line the starting line of the change
 /// @param length the number of lines affected
 /// @param newLength the new number of lines

--- a/edbee-lib/edbee/models/changes/mergablechangegroup.cpp
+++ b/edbee-lib/edbee/models/changes/mergablechangegroup.cpp
@@ -289,7 +289,7 @@ void MergableChangeGroup::giveChange(TextDocument* doc, Change* change)
         delete newSelection_;
         newSelection_ = selectionChange->takeRangeSet();
 
-        /// we can simply delete the change, the ComplexTextChange automaticly records the last change selection on the undoGroupEnd
+        /// we can simply delete the change, the ComplexTextChange automatically records the last change selection on the undoGroupEnd
         delete change;
         return;
     }

--- a/edbee-lib/edbee/models/textautocompleteprovider.h
+++ b/edbee-lib/edbee/models/textautocompleteprovider.h
@@ -48,9 +48,9 @@ namespace TextAutoCompleteKind {
 }
 
 
-/// An autocomplete item that's being returned
+/// An autocomplete item that is being returned
 /// Currently simply a string.
-/// It's placed in a seperate class for future extentions (LSP: https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textDocument_completion)
+/// It is placed in a separate class for future extensions (LSP: https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textDocument_completion)
 class EDBEE_EXPORT TextAutoCompleteItem {
 public:
     TextAutoCompleteItem( const QString& label, const int kind = 0, const QString& detail = "", const QString& documentation = "");

--- a/edbee-lib/edbee/models/textdocument.cpp
+++ b/edbee-lib/edbee/models/textdocument.cpp
@@ -303,7 +303,7 @@ Change *TextDocument::executeAndGiveChange(Change* change, int coalesceId )
         return documentFilter()->filterChange( this, change, coalesceId );
     } else {
 
-        beginUndoGroup();   // automaticly group changes together (when changes happend on emition)
+        beginUndoGroup();   // automatically group changes together (when changes happen on emission)
         change->execute( this );
         Change* result = giveChangeWithoutFilter( change, coalesceId );
         Q_UNUSED(result)

--- a/edbee-lib/edbee/models/textdocumentscopes.cpp
+++ b/edbee-lib/edbee/models/textdocumentscopes.cpp
@@ -192,7 +192,7 @@ void MultiLineScopedTextRange::setGrammarRule(TextGrammarRule* rule)
 }
 
 
-/// Returnst he active grammar rule
+/// Returns the active grammar rule
 TextGrammarRule* MultiLineScopedTextRange::grammarRule() const
 {
     return ruleRef_;
@@ -940,7 +940,7 @@ TextScopeList TextDocumentScopes::scopesAtOffset( int offset, bool includeEnd  )
 }
 
 
-/// This method returns all scoped ranges at the given offest
+/// This method returns all scoped ranges at the given offset
 /// Hmmm this is almost exactly the same implementation as the scopesAtOffset method !? (perhaps we should refactor this)
 ///
 /// Warning you MUST destroy (qDeleteAll) the list with scoped textranges returned by this list

--- a/edbee-lib/edbee/models/texteditorconfig.cpp
+++ b/edbee-lib/edbee/models/texteditorconfig.cpp
@@ -296,7 +296,7 @@ void TextEditorConfig::setUndoGroupPerSpace(bool enable)
 }
 
 
-/// should the caret-offset been shown. The texteditor can signal a
+/// should the caret-offset be shown. The texteditor can signal a
 /// statusbar text to a slot. This text can optionally contain the
 /// current caret offset
 bool TextEditorConfig::showCaretOffset() const

--- a/edbee-lib/edbee/models/texteditorkeymap.cpp
+++ b/edbee-lib/edbee/models/texteditorkeymap.cpp
@@ -102,7 +102,7 @@ QKeySequence TextEditorKeyMap::getSequence(const QString& name) const
 }
 
 
-/// Returns al list of all keysequences for the given command
+/// Returns a list of all keysequences for the given command
 /// This method will also search the parents for the given keysequences
 QList<TextEditorKey*> TextEditorKeyMap::getAll(const QString& name) const
 {

--- a/edbee-lib/edbee/models/textrange.cpp
+++ b/edbee-lib/edbee/models/textrange.cpp
@@ -202,7 +202,7 @@ void TextRange::moveCaretByCharGroup(TextDocument *doc, int amount, const QStrin
                 }
             }
 
-            // al other characters are valid
+            // all other characters are valid
             if( !found ) {
                 QString str = characterGroups.join("");
                 str.append(whitespace);
@@ -778,7 +778,7 @@ void TextRangeSetBase::expandToWords(const QString& whitespace, const QStringLis
 
 
 /// Selects the word at the given offset
-/// @param offset the offset of the wordt to select
+/// @param offset the offset of the word to select
 void TextRangeSetBase::selectWordAt(int offset, const QString& whitespace, const QStringList& characterGroups )
 {
     TextRange newRange(offset,offset);
@@ -789,7 +789,7 @@ void TextRangeSetBase::selectWordAt(int offset, const QString& whitespace, const
 
 
 /// Toggles a word selection at the given location
-/// The idea is the following, double-click an empty place to select the wordt at the given location
+/// The idea is the following, double-click an empty place to select the word at the given location
 /// Double click an existing selection to remove the selection (and caret)
 void TextRangeSetBase::toggleWordSelectionAt(int offset, const QString& whitespace, const QStringList& characterGroups)
 {
@@ -848,7 +848,7 @@ void TextRangeSetBase::moveCaretsByCharGroup(int amount, const QString& whitespa
 }
 
 
-/// Moves al carets to the given line boundary (line-boundary automaticly switches between column 0 and first non-whitespace character)
+/// Moves all carets to the given line boundary (line-boundary automatically switches between column 0 and first non-whitespace character)
 /// @param direction the direction < 0 to the start of the line (or first char)  > 0 to the end of the line
 /// @param whitespace the characters to see as whitespace
 void TextRangeSetBase::moveCaretsToLineBoundary(int direction , const QString& whitespace)
@@ -936,7 +936,7 @@ void TextRangeSetBase::mergeOverlappingRanges( bool joinBorders )
 
 
 
-/// This mehtod  sets the first range item
+/// This method sets the first range item
 /// @param anchor the anchor of the selection
 /// @param caret the caret position
 /// @param index the default range index (default 0)
@@ -979,7 +979,7 @@ TextDocument*TextRangeSetBase::textDocument() const
 
 /// This method adds (or removes) the given spatial length at the given location.
 ///
-/// It adjusts all locations, anchors with the given locations. It automaticly moves carets,
+/// It adjusts all locations, anchors with the given locations. It automatically moves carets,
 /// 'removes' selection etc.
 ///
 /// @param pos the position to add the spatial length to

--- a/edbee-lib/edbee/models/textrange.cpp
+++ b/edbee-lib/edbee/models/textrange.cpp
@@ -1232,6 +1232,7 @@ bool DynamicTextRangeSet::deleteMode() const
 /// This method is notified if a change happens to the textbuffer
 void DynamicTextRangeSet::textChanged(edbee::TextBufferChange change, QString oldText)
 {
+    Q_UNUSED(oldText)
     changeSpatial( change.offset(), change.length(), change.newTextLength(), stickyMode_, deleteMode_ );
 }
 

--- a/edbee-lib/edbee/models/textrange.h
+++ b/edbee-lib/edbee/models/textrange.h
@@ -103,7 +103,7 @@ private:
 /// This abstract class represents a set of textranges
 /// The ranges are kept ordered and will not contain overlapping regions.
 ///
-/// Every method automaticly orders and merges overlapping ranges.
+/// Every method automatically orders and merges overlapping ranges.
 /// Except when the changing_ flag is != 0. The sorting and merging only happens
 /// when changing is 0. This way it possible to add/update muliple rages without the direct
 /// performance hit of sorting and merging.

--- a/edbee-lib/edbee/models/textsearcher.cpp
+++ b/edbee-lib/edbee/models/textsearcher.cpp
@@ -256,9 +256,9 @@ void TextSearcher::markAll(TextRangeSet *rangeset)
 /// @param widget the widget to find the next item
 bool TextSearcher::findNext(TextEditorWidget* widget )
 {
-    QScopedPointer<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
-    if( findNext( newRangeSet.data() ) ) {
-        widget->controller()->changeAndGiveTextSelection( newRangeSet.take() );
+    std::unique_ptr<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
+    if( findNext( newRangeSet.get() ) ) {
+        widget->controller()->changeAndGiveTextSelection( newRangeSet.release() );
         return true;
     }
     return false;
@@ -269,9 +269,9 @@ bool TextSearcher::findNext(TextEditorWidget* widget )
 /// @param widget the widget to search in
 bool TextSearcher::findPrev( TextEditorWidget* widget)
 {
-    QScopedPointer<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
-    if( findPrev( newRangeSet.data() ) ) {
-        widget->controller()->changeAndGiveTextSelection( newRangeSet.take() );
+    std::unique_ptr<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
+    if( findPrev( newRangeSet.get() ) ) {
+        widget->controller()->changeAndGiveTextSelection( newRangeSet.release() );
         return true;
     }
     return false;
@@ -282,9 +282,9 @@ bool TextSearcher::findPrev( TextEditorWidget* widget)
 /// @param widget the widget to search in
 bool TextSearcher::selectNext( TextEditorWidget* widget )
 {
-    QScopedPointer<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
-    if( selectNext( newRangeSet.data() ) ) {
-        widget->controller()->changeAndGiveTextSelection( newRangeSet.take() );
+    std::unique_ptr<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
+    if( selectNext( newRangeSet.get() ) ) {
+        widget->controller()->changeAndGiveTextSelection( newRangeSet.release() );
         return true;
     }
     return false;
@@ -295,9 +295,9 @@ bool TextSearcher::selectNext( TextEditorWidget* widget )
 /// @param widget the widget to to search in
 bool TextSearcher::selectPrev( TextEditorWidget* widget )
 {
-    QScopedPointer<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
-    if( selectPrev( newRangeSet.data() ) ) {
-        widget->controller()->changeAndGiveTextSelection( newRangeSet.take() );
+    std::unique_ptr<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
+    if( selectPrev( newRangeSet.get() ) ) {
+        widget->controller()->changeAndGiveTextSelection( newRangeSet.release() );
         return true;
     }
     return false;
@@ -309,9 +309,9 @@ bool TextSearcher::selectPrev( TextEditorWidget* widget )
 /// @param selection the selection to change
 bool TextSearcher::selectAll( TextEditorWidget* widget )
 {
-    QScopedPointer<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
-    if( selectAll( newRangeSet.data() ) ) {
-        widget->controller()->changeAndGiveTextSelection( newRangeSet.take() );
+    std::unique_ptr<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
+    if( selectAll( newRangeSet.get() ) ) {
+        widget->controller()->changeAndGiveTextSelection( newRangeSet.release() );
         return true;
     }
     return false;
@@ -323,7 +323,7 @@ bool TextSearcher::selectAll( TextEditorWidget* widget )
 /// @param selectAllTexts if true then all occurences are selected
 void TextSearcher::selectUnderExpand( TextEditorWidget* widget, bool selectAllTexts )
 {
-    QScopedPointer<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
+    std::unique_ptr<TextRangeSet> newRangeSet( new TextRangeSet( widget->textSelection() ) );
     bool runSelect = true;  // should the select be called
 
     // when no selection is used select it
@@ -345,14 +345,14 @@ void TextSearcher::selectUnderExpand( TextEditorWidget* widget, bool selectAllTe
     // next select the next word
     if( runSelect) {
         if( selectAllTexts ) {
-            selectAll( newRangeSet.data() );
+            selectAll( newRangeSet.get() );
         } else {
-            selectNext( newRangeSet.data() );
+            selectNext( newRangeSet.get() );
         }
     }
 
     // set the new rangeset
-    widget->controller()->changeAndGiveTextSelection( newRangeSet.take() );
+    widget->controller()->changeAndGiveTextSelection( newRangeSet.release() );
 
 }
 

--- a/edbee-lib/edbee/texteditorcontroller.cpp
+++ b/edbee-lib/edbee/texteditorcontroller.cpp
@@ -42,7 +42,7 @@ namespace edbee {
 
 /// The constructor
 /// @param widget the widget this controller is associated with
-/// @paarm parent the QObject parent of the controlle
+/// @paarm parent the QObject parent of the controller
 TextEditorController::TextEditorController( TextEditorWidget* widget, QObject *parent)
     : QObject(parent)
     , widgetRef_(widget)
@@ -67,7 +67,7 @@ TextEditorController::TextEditorController( TextEditorWidget* widget, QObject *p
     // create the text renderer
     textRenderer_ = new TextRenderer( this );
 
-    // create a text document ( this sould happen AFTER the creation of the renderer)
+    // create a text document (this should happen AFTER the creation of the renderer)
     giveTextDocument( new CharTextDocument() );
 
     // Now all objects have been created we can init them
@@ -106,8 +106,8 @@ void TextEditorController::notifyStateChange()
 }
 
 
-/// sets the document and tranfers the ownership of the textdocument to this class
-/// @param doc the new document for this controlelr
+/// sets the document and transfers the ownership of the textdocument to this class
+/// @param doc the new document for this controller
 void TextEditorController::giveTextDocument(TextDocument* doc)
 {
     if( doc != textDocument_ ) {
@@ -171,7 +171,7 @@ void TextEditorController::setTextDocument(TextDocument* doc)
 /// @param autoScroll the new autoscroll to caret setting. This can be one of the following values:
 ///  - AutoScrollAlways => Always scroll the view so the caret is visible
 //   - AutoScrollWhenFocus => Only scroll the view when the editor has got the focus
-//   - AutoScrollNever => Never perform automatic scolling
+//   - AutoScrollNever => Never perform automatic scrolling
 void TextEditorController::setAutoScrollToCaret(TextEditorController::AutoScrollToCaret autoScroll)
 {
      autoScrollToCaret_ = autoScroll;
@@ -254,7 +254,7 @@ TextRenderer*TextEditorController::textRenderer() const
 
 
 /// returns the bordered textranges
-/// These are textranges that are rendered with a border, but aren't truely selected
+/// These are textranges that are rendered with a border, but aren't truly selected
 TextRangeSet *TextEditorController::borderedTextRanges() const
 {
     return borderedTextRanges_;
@@ -271,7 +271,7 @@ void TextEditorController::setKeyMap(TextEditorKeyMap* keyMap)
 }
 
 
-/// gives a keymap to the editor. The ownership is transfered to this controller
+/// gives a keymap to the editor. The ownership is transferred to this controller
 /// @param keyMap the new keymap to give to the controller
 void TextEditorController::giveKeyMap(TextEditorKeyMap* keyMap)
 {
@@ -289,7 +289,7 @@ TextEditorKeyMap*TextEditorController::keyMap() const
 
 
 /// set a commandmap
-/// the ownership is NOT transfered to this object. The old owned command-map is deleted
+/// the ownership is NOT transferred to this object. The old owned command-map is deleted
 /// @parm commandMap the new commandMap of this object
 void TextEditorController::setCommandMap(TextEditorCommandMap* commandMap)
 {
@@ -340,7 +340,7 @@ void TextEditorController::giveTextSearcher(TextSearcher* searcher)
 }
 
 
-/// Returnst the associated text searcher object
+/// Returns the associated text searcher object
 /// @return the textsearcher object
 TextSearcher *TextEditorController::textSearcher()
 {
@@ -410,7 +410,7 @@ void TextEditorController::updateAfterConfigChange()
 {
     textRenderer()->setThemeByName( textDocument()->config()->themeName() );
 
-    // we need to figure out a betrer way to do this
+    // we need to figure out a better way to do this
     QFont font = textDocument()->config()->font();
     widget()->setFont( font );
     widget()->textEditorComponent()->setFont( font );
@@ -498,14 +498,14 @@ void TextEditorController::scrollOffsetVisible(int offset)
 }
 
 
-/// This method makes sure caret 1 is vible
+/// This method makes sure caret 1 is visible
 void TextEditorController::scrollCaretVisible()
 {
     scrollOffsetVisible( textSelection()->range(0).caret() );
 }
 
 
-/// This method adds a textchange on the stack that simply stores the current text-selection
+/// This method adds a text change on the stack that simply stores the current text-selection
 /// @param coalsceId the coalescing identifier for merging/coalescing undo operations
 void TextEditorController::storeSelection(int coalesceId)
 {
@@ -535,7 +535,7 @@ void TextEditorController::executeCommand( edbee::TextEditorCommand* textCommand
 
 /// Executes a command with the given name
 ///
-/// When the name hasn't been supplied. This functiona assumes the command is triggered by a QAction
+/// When the name hasn't been supplied. This function assumes the command is triggered by a QAction
 /// and it will retrieve the command-name from the QAction data method
 ///
 /// @param name of the command to execute
@@ -605,7 +605,7 @@ void TextEditorController::replaceSelection(const QStringList& texts, int coales
 
 
 ///  Replaces the given rangeset with the given text
-/// @param reangeSet hte ranges to replace
+/// @param rangeset the ranges to replace
 /// @param text the text to replace the selection with
 /// @param coalesceId the identifier for grouping undo operations
 void TextEditorController::replaceRangeSet(edbee::TextRangeSet& rangeSet, const QString& text, int coalesceId, bool stickySelection)
@@ -620,7 +620,7 @@ void TextEditorController::replaceRangeSet(edbee::TextRangeSet& rangeSet, const 
 
 
 /// Replaces the given ranges with the given texts. Different text per range is possible
-/// @param rangeSet the rangeset to fille
+/// @param rangeSet the rangeset to fill
 /// @param text the texts to fill the given ranges with.
 /// @param coalesceId the identifier for grouping undo operations
 void TextEditorController::replaceRangeSet(edbee::TextRangeSet& rangeSet, const QStringList& texts, int coalesceId, bool stickySelection)
@@ -675,7 +675,7 @@ void TextEditorController::moveCaretToOffset(int offset, bool keepAnchors, int r
     return executeCommand( &command );
 }
 
-/// Move the caret and the anchor to the given offeset
+/// Move the caret and the anchor to the given offset
 /// @param caret the caret location
 /// @param anchor the anchor location
 /// The rangeIndex is used to specify which range to move.. (Defaults to -1 which changes to a single range)
@@ -715,7 +715,7 @@ void TextEditorController::changeAndGiveTextSelection(edbee::TextRangeSet* range
 
 
 /// This method performs an undo operation. By supplying soft only
-/// controller based operations are undone. When suppplying false a Document operation is being undone
+/// controller based operations are undone. When supplying false a Document operation is being undone
 void TextEditorController::undo(bool soft)
 {
     textDocument()->textUndoStack()->undo( soft ? this : nullptr, soft );
@@ -723,7 +723,7 @@ void TextEditorController::undo(bool soft)
 
 
 /// This method performs an redo operation. By supplying soft only controller based operations are redone.
-/// When suppplying false a Document operation is being redone
+/// When supplying false a Document operation is being redone
 /// @param soft perform a soft undo?
 void TextEditorController::redo(bool soft)
 {

--- a/edbee-lib/edbee/texteditorcontroller.h
+++ b/edbee-lib/edbee/texteditorcontroller.h
@@ -34,8 +34,8 @@ class TextSelection;
 class UndoableTextCommand;
 
 
-/// The texteditor works via the controller. The controller is the central point/mediater
-/// which maps/controls all messages between the different editor componenents
+/// The texteditor works via the controller. The controller is the central point/mediator
+/// which maps/controls all messages between the different editor components
 class EDBEE_EXPORT TextEditorController : public QObject
 {
     Q_OBJECT
@@ -167,11 +167,11 @@ private:
     TextEditorCommandMap* commandMap_;        ///< the ownership
     TextEditorCommandMap* commandMapRef_;     ///< A reference to the command
     TextRenderer* textRenderer_;              ///< The text renderer
-    TextCaretCache* textCaretCache_;          ///< The text-caret cache. (For remembering the x-position of the current carrets)
+    TextCaretCache* textCaretCache_;          ///< The text-caret cache. (For remembering the x-position of the current carets)
 
     TextSearcher* textSearcher_;              ///< The text-searcher
     
-    AutoScrollToCaret autoScrollToCaret_;     ///< This flags tells the editor to automaticly scrol to the caret
+    AutoScrollToCaret autoScrollToCaret_;     ///< This flags tells the editor to automatically scroll to the caret
 
 
     // extra highlight text

--- a/edbee-lib/edbee/texteditorwidget.cpp
+++ b/edbee-lib/edbee/texteditorwidget.cpp
@@ -56,7 +56,7 @@ TextEditorWidget::TextEditorWidget(QWidget* parent)
     , autoScrollMargin_(50)
     , readonly_(false)
 {
-    // auto initialize edbee if this hasn't been done alread
+    // auto initialize edbee if this hasn't been done already
     Edbee::instance()->autoInit();
 
     // create the controller
@@ -100,7 +100,7 @@ TextEditorWidget::TextEditorWidget(QWidget* parent)
 
     setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
 
-    editCompRef_->installEventFilter(this);     // recieve events for the ability to emit focus events
+    editCompRef_->installEventFilter(this);     // receive events for the ability to emit focus events
 }
 
 
@@ -142,7 +142,7 @@ void TextEditorWidget::scrollTopToLine(int line)
 }
 
 
-/// Returns the confirguation object for this widget
+/// Returns the configuration object for this widget
 TextEditorConfig* TextEditorWidget::config() const
 {
     return textDocument()->config();
@@ -212,7 +212,7 @@ void TextEditorWidget::resetCaretTime()
 }
 
 
-/// This method performs a full update. Which means it callibirates the scrollbars
+/// This method performs a full update. Which means it calibrates the scrollbars
 /// invalidates all caches, redraws the screen and updates the scrollbars
 void TextEditorWidget::fullUpdate()
 {
@@ -285,7 +285,7 @@ void TextEditorWidget::setReadonly(bool value)
 }
 
 
-/// This mehtod is called when a resize happens
+/// This method is called when a resize happens
 /// @param event the event of the editor widget
 void TextEditorWidget::resizeEvent(QResizeEvent* event)
 {
@@ -293,7 +293,7 @@ void TextEditorWidget::resizeEvent(QResizeEvent* event)
     updateRendererViewport();
 }
 
-/// a basic event-filter for recieving focus-events of the editor
+/// a basic event-filter for receiving focus-events of the editor
 /// @param obj the object to filter the events for
 /// @param event the event to filter
 bool TextEditorWidget::eventFilter(QObject* obj, QEvent* event)
@@ -342,7 +342,7 @@ void TextEditorWidget::updateLineAtOffset(int offset)
 }
 
 
-/// updates the character before and at the given offest
+/// updates the character before and at the given offset
 /// @param offset the offset of the area to repaint.
 /// @param width the width of the area to update (default is 8 pixels)
 void TextEditorWidget::updateAreaAroundOffset(int offset, int width )

--- a/edbee-lib/edbee/texteditorwidget.h
+++ b/edbee-lib/edbee/texteditorwidget.h
@@ -30,8 +30,8 @@ class TextSelection;
 
 
 /// This is the general edbee widget
-/// This core functionality of this widget is divided in several seperate
-/// compnents. (TextEditorComponent: the main editor, TextMarginComponent: the sidebar with line numbers)
+/// The core functionality of this widget is divided in several separate
+/// components. (TextEditorComponent: the main editor, TextMarginComponent: the sidebar with line numbers)
 class EDBEE_EXPORT TextEditorWidget : public QWidget
 {
     Q_OBJECT

--- a/edbee-lib/edbee/util/gapvector.h
+++ b/edbee-lib/edbee/util/gapvector.h
@@ -20,7 +20,7 @@ namespace edbee {
 template <typename T>
 class EDBEE_EXPORT GapVector {
 public:
-    GapVector( int capacity=16 ) : items_(0), capacity_(0), gapBegin_(0), gapEnd_(0)  {
+    GapVector( int capacity=16 ) : items_(nullptr), capacity_(0), gapBegin_(0), gapEnd_(0)  {
         items_    = new T[capacity];
         capacity_ = capacity;
         gapBegin_ = 0;

--- a/edbee-lib/edbee/util/test.cpp
+++ b/edbee-lib/edbee/util/test.cpp
@@ -368,7 +368,7 @@ int TestEngine::run(TestCase* test)
     currentTestRef_ = test;
     currentTestRef_->setEngine(this);
 
-    // retrieve the meta object  and invoke al private slots
+    // retrieve the meta object and invoke all private slots
     const QMetaObject *metaObject = test->metaObject();
 
     // retrieve all methods

--- a/edbee-lib/edbee/util/textcodec.cpp
+++ b/edbee-lib/edbee/util/textcodec.cpp
@@ -45,7 +45,7 @@ TextCodecManager::~TextCodecManager()
 }
 
 
-/// Registers the given codec. The ownership of this codec is transfered to the codec manger
+/// Registers the given codec. The ownership of this codec is transfered to the codec manager
 /// @param codec the codec to register.
 void TextCodecManager::giveTextCodec( TextCodec* codec )
 {

--- a/edbee-lib/edbee/util/util.h
+++ b/edbee-lib/edbee/util/util.h
@@ -24,11 +24,11 @@ public:
 
 
     /// This method calculates 2 intersections between 2 ranges.
-    /// @param exclusive als het exclusief is dan wordt een overlap niet inclusief. In other words:
+    /// @param exclusive if it is exclusive then an overlap will not be included. In other words:
     ///			- Inclusive:  end < begin
     ///			- Exclusive:  end <= begin
-    /// @param resultBegin a pointer to the variable recieving the result
-    /// @param resultEnd a pointer to the variable recieving the result
+    /// @param resultBegin a pointer to the variable receiving the result
+    /// @param resultEnd a pointer to the variable receiving the result
     /// @return false => no overlap, true => overlap
     template<typename T>
     bool intersection( T begin1, T end1, T begin2, T end2, bool exclusive=false, T* resultBegin=0, T* resultEnd=0 )

--- a/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
+++ b/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
@@ -66,16 +66,13 @@ static int V2D(TextEditorWidget* widget, int vOffset)
 /// returns the virtual length of the textdocument
 static int VLEN(TextEditorWidget* widget)
 {
-#ifndef WINDOWS_END_LINE_READ_ERROR_FIX
+#if ! defined(WINDOWS_END_LINE_READ_ERROR_FIX)
     return widget->textDocument()->length();
-#endif
-
-#ifdef WINDOWS_LAST_LINE_ERROR_FIX
+#elif defined(WINDOWS_LAST_LINE_ERROR_FIX)
     return widget->textDocument()->length() + widget->textDocument()->lineCount();
 #else
     return widget->textDocument()->length() + widget->textDocument()->lineCount() - 1;
 #endif
-
 }
 
 /// Converts the given text to a virtual text
@@ -94,10 +91,9 @@ static const QString VTEXT(QString str)
 /// It prepends every newline with a space
 static const QString VTEXT(TextDocument* doc)
 {
-#ifndef WINDOWS_END_LINE_READ_ERROR_FIX
+#if ! defined(WINDOWS_END_LINE_READ_ERROR_FIX)
     return doc->text();
-#endif
-#ifdef WINDOWS_LAST_LINE_ERROR_FIX
+#elif defined(WINDOWS_LAST_LINE_ERROR_FIX)
     QString result = VTEXT(doc->text());
     return result + WINDOWS_EMPTY_LINE_FIX;
 #else
@@ -106,22 +102,22 @@ static const QString VTEXT(TextDocument* doc)
 }
 
 
-/// Return a part of text, translating the virtual characteers
+/// Return a part of text, translating the virtual characters
 /// It prepends every newline with a space
-/// It  assumers an extra space + newline is placed at the end of the document
+/// It assumes an extra space + newline is placed at the end of the document
 static const QString VTEXT_PART(TextDocument* doc, int offset, int length)
 {
-#ifndef WINDOWS_END_LINE_READ_ERROR_FIX
-    if(length < 0) { return QString(); }
+#if ! defined(WINDOWS_END_LINE_READ_ERROR_FIX)
+    if(length < 0) {
+        return QString();
+    }
 
     return doc->textPart(offset, qMin(length, doc->length() - offset));
-#endif
-    int docLength = doc->length();
-#ifdef WINDOWS_LAST_LINE_ERROR_FIX
-    int endOffset = qMin(offset + length, docLength + 2);
 #else
-    int endOffset = qMin(offset + length, docLength);
-#endif
+    int docLength = doc->length();
+#if defined(WINDOWS_LAST_LINE_ERROR_FIX)
+        int endOffset = qMin(offset + length, docLength + 2);
+#endif // WINDOWS_LAST_LINE_ERROR_FIX - First use
     //qDebug() << "VTEXT_PART: " << offset << ", " << length << " :: docLength: " << docLength << ", endOffset: " << endOffset;
 
     QString txt;
@@ -131,14 +127,15 @@ static const QString VTEXT_PART(TextDocument* doc, int offset, int length)
         txt = VTEXT(doc->textPart(offset, len));
     }
 
-#ifdef WINDOWS_LAST_LINE_ERROR_FIX
+#if defined(WINDOWS_LAST_LINE_ERROR_FIX)
     //qDebug() << " - B  endOffset: " << endOffset << " >= " << docLength;
     if( endOffset >= docLength ) {
         txt.append(WINDOWS_EMPTY_LINE_FIX);
     }
-#endif
+#endif // WINDOWS_LAST_LINE_ERROR_FIX - Second use
     //qDebug() << " => " << txt;
     return txt;
+#endif // WINDOWS_END_LINE_READ_ERROR_FIX
 }
 
 

--- a/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
+++ b/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
@@ -39,6 +39,7 @@ static int D2V(TextEditorWidget* widget, int offset)
     int line = widget->textDocument()->lineFromOffset(offset);
     return offset + line;
 #else
+    Q_UNUSED(widget)
     return offset;
 #endif
 }
@@ -47,18 +48,19 @@ static int D2V(TextEditorWidget* widget, int offset)
 static int V2D(TextEditorWidget* widget, int vOffset)
 {
 #ifdef WINDOWS_END_LINE_READ_ERROR_FIX
-  TextDocument* doc = widget->textDocument();
-  int displacement = 0;
-  for( int i=0, cnt = doc->lineCount(); i < cnt; ++i ) {
-      int lineVOffset = doc->offsetFromLine(i) + i;
+    TextDocument* doc = widget->textDocument();
+    int displacement = 0;
+    for( int i=0, cnt = doc->lineCount(); i < cnt; ++i ) {
+        int lineVOffset = doc->offsetFromLine(i) + i;
 
-      if( vOffset < lineVOffset) {
-        return vOffset - displacement; // remove the newline count
-      }
-      displacement = i;
-  }
-  return vOffset - displacement;
+        if( vOffset < lineVOffset) {
+            return vOffset - displacement; // remove the newline count
+        }
+        displacement = i;
+    }
+    return vOffset - displacement;
 #else
+    Q_UNUSED(widget)
     return vOffset;
 #endif
 }
@@ -393,6 +395,7 @@ int AccessibleTextEditorWidget::offsetAtPoint(const QPoint &point) const
 /// Ensures that the text between startIndex and endIndex is visible.
 void AccessibleTextEditorWidget::scrollToSubstring(int startIndex, int endIndex)
 {
+    Q_UNUSED(endIndex)
     // qDebug() << " scrollToSubstring >>" << startIndex << ", " << endIndex;
     controller()->scrollOffsetVisible(V2D(textWidget(), startIndex));
 }
@@ -402,6 +405,9 @@ void AccessibleTextEditorWidget::scrollToSubstring(int startIndex, int endIndex)
 /// In addition the range of the attributes is returned in startOffset and endOffset.
 QString AccessibleTextEditorWidget::attributes(int offset, int *startOffset, int *endOffset) const
 {
+    Q_UNUSED(offset)
+    Q_UNUSED(startOffset)
+    Q_UNUSED(endOffset)
     // qDebug() << " attributes >>" << offset << ", " << *startOffset << ", " <<  *endOffset;
     return QString();
 }

--- a/edbee-lib/edbee/views/components/texteditorcomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorcomponent.cpp
@@ -483,10 +483,13 @@ void TextEditorComponent::mouseDoubleClickEvent( QMouseEvent* event )
 
         if( event->modifiers()&Qt::ControlModifier ) {
             // get the location of the double
-            int x = event->x();
-            int y = event->y();
-            int line = textRenderer()->rawLineIndexForYpos( y );
-            int col = textRenderer()->columnIndexForXpos( line, x );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            auto eventPos = event->pos();
+#else
+            auto eventPos = event->position().toPoint();
+#endif
+            int line = textRenderer()->rawLineIndexForYpos( eventPos.y() );
+            int col = textRenderer()->columnIndexForXpos( line, eventPos.x() );
 
             // add the word there
             SelectionCommand toggleWordSelectionAtCommand( SelectionCommand::ToggleWordSelectionAt, textDocument()->offsetFromLineAndColumn(line,col) );
@@ -510,12 +513,14 @@ void TextEditorComponent::mouseMoveEvent(QMouseEvent* event )
     if( event->buttons() & Qt::LeftButton ) {
         TextRenderer* renderer = textRenderer();
 
-        int x = event->x();
-        int y = event->y();
-
-        int line = renderer->rawLineIndexForYpos( y );
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        auto eventPos = event->pos();
+#else
+        auto eventPos = event->position().toPoint();
+#endif
+        int line = renderer->rawLineIndexForYpos( eventPos.y() );
         int col = 0;
-        if( line >= 0 ) { col = renderer->columnIndexForXpos( line, x ); }
+        if( line >= 0 ) { col = renderer->columnIndexForXpos( line, eventPos.x() ); }
         if( line < 0 ) { line = 0; }
 
         if( clickCount_ == 2 ) {

--- a/edbee-lib/edbee/views/components/texteditorcomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorcomponent.cpp
@@ -640,7 +640,7 @@ void TextEditorComponent::updateLineAtOffset(int offset)
 }
 
 
-/// updates the character before and at the given offest
+/// updates the character before and at the given offset
 void TextEditorComponent::updateAreaAroundOffset(int offset, int width )
 {
     TextRenderer* ren = textRenderer();

--- a/edbee-lib/edbee/views/components/textmargincomponent.cpp
+++ b/edbee-lib/edbee/views/components/textmargincomponent.cpp
@@ -341,7 +341,11 @@ void TextMarginComponent::renderLineNumber(QPainter* painter, int startLine, int
 /// This method sends the the mouse movement events to the delegate
 void TextMarginComponent::mouseMoveEvent(QMouseEvent* event)
 {
-    int y = event->y() + top_;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    int y = event->pos().y() + top_;
+#else
+    int y = event->position().toPoint().y() + top_;
+#endif
     int line = renderer()->lineIndexForYpos( y );
     delegate()->mouseMoveEvent(line, event);
     QWidget::mouseMoveEvent(event);
@@ -352,9 +356,12 @@ void TextMarginComponent::mouseMoveEvent(QMouseEvent* event)
 /// This method sends the the mouse movement events to the delegate
 void TextMarginComponent::mousePressEvent(QMouseEvent* event)
 {
-    int y = event->y() + top_;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    int y = event->pos().y() + top_;
+#else
+    int y = event->position().toPoint().y() + top_;
+#endif
     int line = renderer()->lineIndexForYpos( y );
-
     delegate()->mousePressEvent( line, event );
     QWidget::mousePressEvent(event);
 

--- a/edbee-lib/edbee/views/textcaretcache.cpp
+++ b/edbee-lib/edbee/views/textcaretcache.cpp
@@ -84,7 +84,7 @@ void TextCaretCache::add(int offset)
     add( offset, xpos );
 }
 
-/// This method should be called if the caret moves from th
+/// This method should be called if the caret moves
 void TextCaretCache::caretMovedFromOldOffsetToNewOffset(int oldOffset, int newOffset)
 {
 //    qlog_info() << "[CACHE:move]" << oldOffset<< " => " << newOffset << " << " << xPosCache_.contains(oldOffset);

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -550,7 +550,7 @@ void TextRenderer::resetCaretTime()
 }
 
 
-/// this method returnst true if the caret is visible
+/// this method returns true if the caret is visible
 bool TextRenderer::shouldRenderCaret()
 {
     if( caretTime_ < 0 ) { return false; }


### PR DESCRIPTION
@gamecreature I've been working on getting Mudlet to build in a Qt 6 environment and found a few things that I think need fixing to work. As such I've put together a number of commits which address different things that were producing warnings when built against Qt 6.4.1 on Linux (and one or two things that also do so in Qt 5.15.2). I suspect you might want to examine and, hopefully, cherry-pick each of these commits in order rather than just merging the whole lot in one swell foop. Anyhow I hope they are of use...