### PR TITLE
Silence warning in `LineOffsetVector::applyChange` from Qt6

### DIFF
--- a/edbee-lib/edbee/util/lineoffsetvector.cpp
+++ b/edbee-lib/edbee/util/lineoffsetvector.cpp
@@ -42,7 +42,7 @@ void LineOffsetVector::applyChange(TextBufferChange change)
 
 //qlog_info() << "- before: " << toUnitTestString() ;
 //qlog_info() << "- offsetList_.replace(" << change.line() << "," << change.lineCount() << ": " << offsets << ")";
-    offsetList_.replace( line, change.lineCount(), change.newLineOffsets().constBegin().operator->(), change.newLineCount() );
+    offsetList_.replace( line, change.lineCount(), change.newLineOffsets().constData(), change.newLineCount() );
 //qlog_info() << "- after: " << toUnitTestString();
 
 

--- a/edbee-lib/edbee/util/lineoffsetvector.cpp
+++ b/edbee-lib/edbee/util/lineoffsetvector.cpp
@@ -42,7 +42,7 @@ void LineOffsetVector::applyChange(TextBufferChange change)
 
 //qlog_info() << "- before: " << toUnitTestString() ;
 //qlog_info() << "- offsetList_.replace(" << change.line() << "," << change.lineCount() << ": " << offsets << ")";
-    offsetList_.replace( line, change.lineCount(), change.newLineOffsets().constBegin(), change.newLineCount() );
+    offsetList_.replace( line, change.lineCount(), change.newLineOffsets().constBegin().operator->(), change.newLineCount() );
 //qlog_info() << "- after: " << toUnitTestString();
 
 


### PR DESCRIPTION
This silences the last build warning we have from edbee (which is nice), HOWEVER, I did not double-check that the code semantics are still right and I do not know how to test this, so leaving it up to you @gamecreature to say if this if the right fix.

Original warning:

```
/home/vadi/Programs/Mudlet/3rdparty/edbee-lib/edbee-lib/edbee/util/lineoffsetvector.cpp: In member function ‘void edbee::LineOffsetVector::applyChange(edbee::TextBufferChange)’:
/home/vadi/Programs/Mudlet/3rdparty/edbee-lib/edbee-lib/edbee/util/lineoffsetvector.cpp:45:24: warning: ‘QList<T>::const_iterator::operator const T*() const [with T = int]’ is deprecated: Use operator* or operator-> rather than relying on the implicit conversion between a QList/QVector::const_iterator and a raw pointer [-Wdeprecated-declarations]
   45 |     offsetList_.replace( line, change.lineCount(), change.newLineOffsets().constBegin(), change.newLineCount() );
      |     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /media/vadi/SSDer/Programs/Qt/6.4.3/gcc_64/include/QtCore/qvector.h:7,
                 from /media/vadi/SSDer/Programs/Qt/6.4.3/gcc_64/include/QtCore/QVector:1,
                 from /home/vadi/Programs/Mudlet/3rdparty/edbee-lib/edbee-lib/edbee/util/lineoffsetvector.h:10,
                 from /home/vadi/Programs/Mudlet/3rdparty/edbee-lib/edbee-lib/edbee/util/lineoffsetvector.cpp:6:
/media/vadi/SSDer/Programs/Qt/6.4.3/gcc_64/include/QtCore/qlist.h:223:16: note: declared here
  223 |         inline operator const T*() const { return i; }
      |                ^~~~~~~~
```