### PR TITLE
Fix crash in Qt6

### DIFF
--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
@@ -59,8 +59,6 @@ TextEditorAutoCompleteComponent::TextEditorAutoCompleteComponent(TextEditorContr
 
     listWidgetRef_->setFocus();
 
-    hide();
-
     infoTipRef_ = new FakeToolTip(controllerRef_, this);
 
     QPalette p = listWidgetRef_->palette();


### PR DESCRIPTION
hide() was being called right within the widget construction, which was causing crashes in Qt6: https://github.com/Mudlet/Mudlet/issues/7209