### PR TITLE
Fix: revise QT version for changes to recursive mutexes

### DIFF
--- a/edbee-lib/edbee/util/mem/debug_allocs.cpp
+++ b/edbee-lib/edbee/util/mem/debug_allocs.cpp
@@ -33,7 +33,7 @@ DebugAllocationList::DebugAllocationList()
     , running_(false)
     , started_(false)
 {
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
     mutex_ = new EdbeeRecursiveMutex( QMutex::Recursive );
 #else
     mutex_ = new EdbeeRecursiveMutex();
@@ -65,7 +65,7 @@ void DebugAllocationList::clear()
 }
 
 
-/// Retuns the mutex for thread-safety
+/// Returns the mutex for thread-safety
 EdbeeRecursiveMutex* DebugAllocationList::mutex()
 {
     return mutex_;

--- a/edbee-lib/edbee/util/mem/debug_allocs.h
+++ b/edbee-lib/edbee/util/mem/debug_allocs.h
@@ -12,7 +12,7 @@
 
 
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
     #define EdbeeRecursiveMutex QMutex
 #else
     #define EdbeeRecursiveMutex QRecursiveMutex


### PR DESCRIPTION
The changes to QMutex were actually introduced in Qt 5.14 and not 6.0 and some versions of Qt 5.15 are now throwing depracation warnings if they encounter the older form.