### PR TITLE
Read font from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- (2025-03-13) TextMarginComponent uses config font instead of the textWidget font
 - (2025-03-05) [v0.11.1] Regression, autoInit was invoked too late the new contructor setup of #156
 - (2025-03-04) Update license headers
 - (2025-03-04) Update doxygen so it uses Doxygen Awesome

--- a/edbee-lib/edbee/views/components/textmargincomponent.cpp
+++ b/edbee-lib/edbee/views/components/textmargincomponent.cpp
@@ -153,14 +153,11 @@ void TextMarginComponent::init()
 void TextMarginComponent::updateMarginFont()
 {
     delete marginFont_;
-    if( renderer()->textWidget() ) {
-        const QFont& font = editorWidget()->config()->font();
-        marginFont_ = new QFont( editorWidget()->config()->font().family());
-        if( font.pointSizeF() > 0 ) marginFont_->setPointSizeF( font.pointSizeF() );
-        if( font.pixelSize() > 0 ) marginFont_->setPixelSize( font.pixelSize() );
-    } else {
-        marginFont_ = new QFont( QFont().family(), 10 ); // fallback for test-suite
-    }
+
+    const QFont& font = editorWidget()->config()->font();
+    marginFont_ = new QFont(font.family());
+    if( font.pointSizeF() > 0 ) marginFont_->setPointSizeF( font.pointSizeF() );
+    if( font.pixelSize() > 0 ) marginFont_->setPixelSize( font.pixelSize() );
 }
 
 

--- a/edbee-lib/edbee/views/components/textmargincomponent.cpp
+++ b/edbee-lib/edbee/views/components/textmargincomponent.cpp
@@ -154,8 +154,8 @@ void TextMarginComponent::updateMarginFont()
 {
     delete marginFont_;
     if( renderer()->textWidget() ) {
-        const QFont& font = editorWidget()->font();
-        marginFont_ = new QFont( editorWidget()->font().family());
+        const QFont& font = editorWidget()->config()->font();
+        marginFont_ = new QFont( editorWidget()->config()->font().family());
         if( font.pointSizeF() > 0 ) marginFont_->setPointSizeF( font.pointSizeF() );
         if( font.pixelSize() > 0 ) marginFont_->setPixelSize( font.pixelSize() );
     } else {

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -299,7 +299,7 @@ TextLayout *TextRenderer::textLayoutForLineForPlaceholder(int line)
             option.setFlags( QTextOption::ShowTabsAndSpaces );        /// TODO: Make an option to show spaces and tabs
         }
 
-        textLayout->qTextLayout()->setFont( textWidget()->font() );
+        textLayout->qTextLayout()->setFont( textWidget()->config()->font() );
         textLayout->qTextLayout()->setTextOption( option );
 
         // add extra format (no format)
@@ -356,7 +356,7 @@ TextLayout *TextRenderer::textLayoutForLineNormal(int line)
             option.setFlags( QTextOption::ShowTabsAndSpaces );        /// TODO: Make an option to show spaces and tabs
         }
 
-        textLayout->qTextLayout()->setFont( textWidget()->font() );
+        textLayout->qTextLayout()->setFont( textWidget()->config()->font() );
         //qlog_info() << "font: " <<   textWidget()->font().pointSizeF();
         textLayout->qTextLayout()->setTextOption( option );
 

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -299,7 +299,7 @@ TextLayout *TextRenderer::textLayoutForLineForPlaceholder(int line)
             option.setFlags( QTextOption::ShowTabsAndSpaces );        /// TODO: Make an option to show spaces and tabs
         }
 
-        textLayout->qTextLayout()->setFont( textWidget()->config()->font() );
+        textLayout->qTextLayout()->setFont( textWidget()->font() );
         textLayout->qTextLayout()->setTextOption( option );
 
         // add extra format (no format)
@@ -356,7 +356,7 @@ TextLayout *TextRenderer::textLayoutForLineNormal(int line)
             option.setFlags( QTextOption::ShowTabsAndSpaces );        /// TODO: Make an option to show spaces and tabs
         }
 
-        textLayout->qTextLayout()->setFont( textWidget()->config()->font() );
+        textLayout->qTextLayout()->setFont( textWidget()->font() );
         //qlog_info() << "font: " <<   textWidget()->font().pointSizeF();
         textLayout->qTextLayout()->setTextOption( option );
 


### PR DESCRIPTION
I had a further look into issue https://github.com/edbee/edbee-lib/issues/155

I think the probem is that `TextEditorWidget` inherits from `QWidget`. Here `QWidget` already has a method `font()`, see [documentation](https://doc.qt.io/qt-6/qwidget.html#font-prop) which returns the font assigned to the widget. 

I am not a Qt specialist, but if font is read from `widget()->config()->font()` it fixes the problem from the issue. I suspect that is because the `widget->setFont()` is either never called or called to late in my specific case. I honestly don't know, I did not got that deep.

With this PR, the font is read from config object. I am not sure if that is OK by you, but in worst case it could potentially help us to further investigate this in case the solution proposed here is not acceptable.

BTW: I only tested the changes on my side. I would recommend you do the same on your side. 