### PR TITLE
Feature/type refactor 163

### DIFF
--- a/cmake-qt5-osx.sh
+++ b/cmake-qt5-osx.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cmake -DBUILD_WITH_QT5=1 -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)" -DCMAKE_OSX_SYSROOT=macosx
+make

--- a/edbee-lib/edbee-lib.pro
+++ b/edbee-lib/edbee-lib.pro
@@ -9,6 +9,23 @@ QT += core gui widgets
 # for the time being:
 greaterThan(QT_MAJOR_VERSION,5): QT += core5compat
 
+QMAKE_CXXFLAGS += -O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough -Werror=format-security \
+  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fstrict-flex-arrays=3 \
+  -fstack-protector-strong -fexceptions \
+  -D_GLIBCXX_ASSERTIONS \
+  -isystem $$[QT_INSTALL_HEADERS]
+
+# Doesn't work on arm:
+# -fcf-protection=full
+# -fstack-clash-protection
+
+QMAKE_CXXFLAGS += -isystem "$$[QT_INSTALL_LIBS]/QtWidgets.framework/Headers" \
+                  -isystem "$$[QT_INSTALL_LIBS]/QtXml.framework/Headers" -isystem "$$[QT_INSTALL_LIBS]/QtGui.framework/Headers" \
+                  -isystem "$$[QT_INSTALL_LIBS]/QtCore.framework/Headers"
+
+QMAKE_LDFLAGS=-Wl,-z,nodlopen -Wl,-z,noexecstack \
+  -Wl,-z,relro -Wl,-z,now \
+  -Wl,--as-needed -Wl,--no-copy-dt-needed-entries
 
 TARGET = edbee
 TEMPLATE = lib

--- a/edbee-lib/edbee/commands/commentcommand.h
+++ b/edbee-lib/edbee/commands/commentcommand.h
@@ -19,15 +19,13 @@ class TextEditorController;
 class EDBEE_EXPORT CommentCommand : public TextEditorCommand
 {
 public:
-    CommentCommand( bool block );
-    virtual void execute( TextEditorController* controller ) override;
+    CommentCommand(bool block);
+    virtual void execute(TextEditorController* controller) override;
     virtual QString toString() override;
 
 private:
 
     bool block_;                ///< When this flag is set it uses a block comment (if possible)
-
 };
-
 
 } // edbee

--- a/edbee-lib/edbee/commands/debugcommand.cpp
+++ b/edbee-lib/edbee/commands/debugcommand.cpp
@@ -24,39 +24,41 @@ DebugCommand::DebugCommand(DebugCommandType command)
 void DebugCommand::execute(TextEditorController* controller)
 {
     switch( command_ ) {
-        case DumpScopes: dumpScopes( controller ); break;
-        case RebuildScopes: rebuildScopes( controller ); break;
-        case DumpUndoStack: dumpUndoStack( controller ); break;
-        case DumpCharacterCodes: dumpCharacterCodes( controller ); break;
+        case DumpScopes: dumpScopes(controller); break;
+        case RebuildScopes: rebuildScopes(controller); break;
+        case DumpUndoStack: dumpUndoStack(controller); break;
+        case DumpCharacterCodes: dumpCharacterCodes(controller); break;
     }
-
 }
+
 
 QString DebugCommand::toString()
 {
     return "DebugCommand";
 }
 
+
 bool DebugCommand::readonly()
 {
     return true;
 }
 
+
 /// This method dumps the scopes
-void DebugCommand::dumpScopes( TextEditorController* controller )
+void DebugCommand::dumpScopes(TextEditorController* controller)
 {
     TextDocumentScopes* scopes = controller->textDocument()->scopes();
     QString dump = "\nMultiLineScopes:---\n";
-    dump.append( QString(scopes->toString()).replace("|","\n") );
+    dump.append(QString(scopes->toString()).replace("|","\n"));
 
     dump.append("\nPer Line:---\n");
-    for( int i=0; i<scopes->scopedLineCount(); ++i ) {
+    for (size_t i = 0; i < scopes->scopedLineCount(); ++i) {
         ScopedTextRangeList* range = scopes->scopedRangesAtLine(i);
-        dump.append( QStringLiteral("%1: %2\n").arg(i).arg( range->toString() ) );
+        dump.append(QStringLiteral("%1: %2\n").arg(i).arg( range->toString()));
     }
-
     qlog_info() << dump;
 }
+
 
 /// rebuilds all scopes
 void DebugCommand::rebuildScopes(TextEditorController* controller)
@@ -67,7 +69,7 @@ void DebugCommand::rebuildScopes(TextEditorController* controller)
 
     /// lex the complete document
     scopes->removeScopesAfterOffset(0);
-    lexer->lexRange( 0, document->length() );
+    lexer->lexRange(0, document->length());
 }
 
 /// dumps the undostack
@@ -78,7 +80,7 @@ void DebugCommand::dumpUndoStack(TextEditorController* controller)
 
 
 /// dumps the character codes (around the FIRST caret)
-void DebugCommand::dumpCharacterCodes(TextEditorController *controller)
+void DebugCommand::dumpCharacterCodes(TextEditorController* controller)
 {
     static size_t count = 3;       // 2 chars before caret and 2 chars after caret
 
@@ -89,20 +91,18 @@ void DebugCommand::dumpCharacterCodes(TextEditorController *controller)
     QString line;
 
     // iterate over the characters
-    int start = qMax(range.caret() - count, 0u);
-    int end = qMin(range.caret() + count, controller->textDocument()->length()-1 );
-    for( int i=start; i<=end; ++i ) {
+    size_t start = qMax(range.caret() - count, 0u);
+    size_t end = qMin(range.caret() + count, controller->textDocument()->length()-1 );
+    for (size_t i = start; i <= end; ++i) {
         QChar c = controller->textDocument()->charAt(i);
-        if( i == range.caret() ) {
+        if (i == range.caret()) {
             line.append("| ");
         }
 
-        line.append( QString::number((int)c.unicode(), 16) );
+        line.append(QString::number((int)c.unicode(), 16));
         line.append(" ");
     }
-
     qlog_info() << "charcodes: " <<  line;
 }
-
 
 } // edbee

--- a/edbee-lib/edbee/commands/debugcommand.cpp
+++ b/edbee-lib/edbee/commands/debugcommand.cpp
@@ -91,7 +91,7 @@ void DebugCommand::dumpCharacterCodes(TextEditorController* controller)
     QString line;
 
     // iterate over the characters
-    size_t start = qMax(range.caret() - count, 0u);
+    size_t start = qMax(range.caret() - count, static_cast<size_t>(0));
     size_t end = qMin(range.caret() + count, controller->textDocument()->length()-1 );
     for (size_t i = start; i <= end; ++i) {
         QChar c = controller->textDocument()->charAt(i);

--- a/edbee-lib/edbee/commands/debugcommand.cpp
+++ b/edbee-lib/edbee/commands/debugcommand.cpp
@@ -80,7 +80,7 @@ void DebugCommand::dumpUndoStack(TextEditorController* controller)
 /// dumps the character codes (around the FIRST caret)
 void DebugCommand::dumpCharacterCodes(TextEditorController *controller)
 {
-    static int count = 3;       // 2 chars before caret and 2 chars after caret
+    static size_t count = 3;       // 2 chars before caret and 2 chars after caret
 
     // get the current range
     TextSelection* sel = controller->textSelection();
@@ -89,7 +89,7 @@ void DebugCommand::dumpCharacterCodes(TextEditorController *controller)
     QString line;
 
     // iterate over the characters
-    int start = qMax(range.caret() - count, 0);
+    int start = qMax(range.caret() - count, 0u);
     int end = qMin(range.caret() + count, controller->textDocument()->length()-1 );
     for( int i=start; i<=end; ++i ) {
         QChar c = controller->textDocument()->charAt(i);

--- a/edbee-lib/edbee/commands/debugcommand.h
+++ b/edbee-lib/edbee/commands/debugcommand.h
@@ -9,7 +9,6 @@
 
 namespace edbee {
 
-
 /// A debug command, for simply suppling/dumping some editor state information to the console
 class EDBEE_EXPORT DebugCommand : public TextEditorCommand
 {
@@ -22,7 +21,7 @@ public:
         DumpCharacterCodes
     };
 
-    DebugCommand( DebugCommandType command );
+    DebugCommand(DebugCommandType command);
 
     virtual void execute(TextEditorController* controller) override;
     virtual QString toString() override;
@@ -30,15 +29,14 @@ public:
 
 protected:
 
-    void dumpScopes( TextEditorController* controller );
-    void rebuildScopes( TextEditorController* controller );
+    void dumpScopes(TextEditorController* controller);
+    void rebuildScopes(TextEditorController* controller);
 
-    void dumpUndoStack( TextEditorController* controller );
-    void dumpCharacterCodes( TextEditorController* controller );
+    void dumpUndoStack(TextEditorController* controller);
+    void dumpCharacterCodes(TextEditorController* controller);
 private:
 
     DebugCommandType command_;      ///< the command to execute
-
 };
 
 } // edbee

--- a/edbee-lib/edbee/commands/duplicatecommand.cpp
+++ b/edbee-lib/edbee/commands/duplicatecommand.cpp
@@ -13,52 +13,48 @@
 
 namespace edbee {
 
-
 /// Executes the duplication command
 /// @param controller the active controller
 void DuplicateCommand::execute(TextEditorController* controller)
 {
     // create a new range set and the new texts
-    TextRangeSet newRanges( controller->textSelection() );
-    TextRangeSet* newSelection = new TextRangeSet( controller->textSelection() );
+    TextRangeSet newRanges( controller->textSelection());
+    TextRangeSet* newSelection = new TextRangeSet(controller->textSelection());
     QStringList newTexts;
     TextDocument* doc = controller->textDocument();
 
     // iterate over all range and build the new texts to insert
-    int delta = 0;
-    for( int i=0, cnt=newRanges.rangeCount(); i<cnt; ++i ) {
+    size_t delta = 0;
+    for (size_t i = 0, cnt = newRanges.rangeCount(); i < cnt; ++i) {
         TextRange& range = newRanges.range(i);
 
         // when the range is empty we need to use the complete line line (inclusive the newline)
-        if( range.isEmpty() ) {
-
+        if (range.isEmpty()) {
             // get the complete line
-            int line = doc->lineFromOffset( range.caret() );
-            range.setCaret( doc->offsetFromLine(line) );
-            range.setAnchor( range.caret() );
-            newTexts.append( QStringLiteral("%1\n").arg(doc->lineWithoutNewline(line)) );
+            size_t line = doc->lineFromOffset(range.caret());
+            range.setCaret(doc->offsetFromLine(line));
+            range.setAnchor(range.caret());
+            newTexts.append(QStringLiteral("%1\n").arg(doc->lineWithoutNewline(line)));
 
         } else {
-
             // append the new text, and change the insert position to the place before the caret :)
-            newTexts.append( doc->textPart( range.min(), range.length() ) );
+            newTexts.append(doc->textPart(range.min(), range.length()));
             range.maxVar() = range.min();
         }
 
         // change the spatial of the new selection
         // insert the spatial at the caret position.
         // we only insert text so the length = 0 and the new length is the length of the inserted text
-        int length = newTexts.last().length();
-        newSelection->changeSpatial( range.caret() + delta, 0, length );
+        size_t length = static_cast<size_t>(newTexts.last().length());
+        newSelection->changeSpatial(range.caret() + delta, 0, length);
         delta += length;
-
     }
 
     // replace the texts
     doc->beginChanges(controller);
-    doc->replaceRangeSet( newRanges, newTexts );
-    doc->giveSelection( controller,  newSelection );
-    doc->endChanges( CoalesceId_Duplicate );
+    doc->replaceRangeSet(newRanges, newTexts);
+    doc->giveSelection(controller,  newSelection);
+    doc->endChanges(CoalesceId_Duplicate);
 }
 
 
@@ -67,6 +63,5 @@ QString DuplicateCommand::toString()
 {
     return "DuplicateCommand";
 }
-
 
 } // edbee

--- a/edbee-lib/edbee/commands/duplicatecommand.h
+++ b/edbee-lib/edbee/commands/duplicatecommand.h
@@ -12,11 +12,10 @@ namespace edbee {
 
 /// The Duplicate command.
 /// Duplicates the selected line or text
-///
 class EDBEE_EXPORT DuplicateCommand : public TextEditorCommand
 {
 public:
-    virtual void execute( TextEditorController* controller ) override;
+    virtual void execute(TextEditorController* controller) override;
     virtual QString toString() override;
 };
 

--- a/edbee-lib/edbee/commands/movelinecommand.cpp
+++ b/edbee-lib/edbee/commands/movelinecommand.cpp
@@ -25,55 +25,29 @@ MoveLineCommand::~MoveLineCommand()
 }
 
 
-/// Calculates the new ranges after moving
-/*
-static void calculateNewSelectionRanges( TextDocument* doc, TextRangeSet& newCaretSelection, int direction )
-{
-    for( int i=0,cnt=newCaretSelection.rangeCount(); i<cnt; ++i) {
-        TextRange& range = newCaretSelection.range(i);
-        int& min = range.minVar();
-        int& max = range.maxVar();
-
-        if( direction < 0 ) {
-            int line = doc->lineFromOffset(min);
-            int len = doc->lineLength(line-1);
-            min -= len;
-            max -= len;
-        } else {
-            int line = doc->lineFromOffset(max);
-            int len = doc->lineLength(line+1);
-            min += len;
-            max += len;
-        }
-    }
-}
-*/
-
-
 /// all carets in the newCaretSelection are changed in the movedRange
-void updateNewCaretSelectionForMove( TextDocument* doc, TextRangeSet& newCaretSelection, TextRange& movedRange, int direction )
+void updateNewCaretSelectionForMove(TextDocument* doc, TextRangeSet& newCaretSelection, TextRange& movedRange, int direction)
 {
-    for( int i=0, cnt=newCaretSelection.rangeCount(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = newCaretSelection.rangeCount(); i < cnt; ++i) {
         TextRange& newRange = newCaretSelection.range(i);
-        if( movedRange.min() <= newRange.min() && newRange.max() <= movedRange.max() ) {
-            int min = movedRange.min();
-            int max = movedRange.max();
+        if (movedRange.min() <= newRange.min() && newRange.max() <= movedRange.max()) {
+            size_t min = movedRange.min();
+            size_t max = movedRange.max();
 
-            int delta=0;
-            if( direction < 0 ) {
-                int line = doc->lineFromOffset(min);
-                delta = - doc->lineLength(line-1);
+            ptrdiff_t delta = 0;
+            if (direction < 0) {
+                size_t line = doc->lineFromOffset(min);
+                delta = - static_cast<ptrdiff_t>(doc->lineLength(line - 1));
             } else {
-                int line = doc->lineFromOffset(max-1); // -1 exclude the last newline
-                delta = doc->lineLength(line+1);
+                size_t line = doc->lineFromOffset(max - 1); // -1 exclude the last newline
+                delta = static_cast<ptrdiff_t>(doc->lineLength(line + 1));
             }
 
-            newRange.setCaretBounded( doc, newRange.caret()+delta);
-            newRange.setAnchorBounded( doc, newRange.anchor()+delta);
+            newRange.setCaretBounded(doc, static_cast<ptrdiff_t>(newRange.caret()) + delta);
+            newRange.setAnchorBounded(doc, static_cast<ptrdiff_t>(newRange.anchor()) + delta);
         }
     }
 }
-
 
 
 void MoveLineCommand::execute(TextEditorController *controller)
@@ -82,41 +56,44 @@ void MoveLineCommand::execute(TextEditorController *controller)
     TextDocument* doc = controller->textDocument();
 
     // expand the selection in full-lines
-    TextRangeSet moveRangeSet( *sel );
+    TextRangeSet moveRangeSet(*sel);
     moveRangeSet.expandToFullLines(1);
     moveRangeSet.mergeOverlappingRanges(true);
 
     // because of the full-line expansion, we can assume that 0 means at the first line
     // moving up on the first line is impossible
-    int firstOffset = moveRangeSet.firstRange().minVar();
-    if( firstOffset + direction_ <= 0 ) return;
+    size_t firstOffset = moveRangeSet.firstRange().minVar();
+    if (static_cast<ptrdiff_t>(firstOffset) + direction_ <= 0) return;
 
-    int lastOffset = moveRangeSet.lastRange().maxVar();
-    if( lastOffset + direction_ > doc->length() ) return;
+    size_t lastOffset = moveRangeSet.lastRange().maxVar();
+    if (static_cast<ptrdiff_t>(lastOffset) + direction_ > static_cast<ptrdiff_t>(doc->length())) return;
 
     // Calculate the new caret positions
     TextRangeSet newCaretSelection( *sel );
-    for( int i=0,cnt=moveRangeSet.rangeCount(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = moveRangeSet.rangeCount(); i < cnt; ++i) {
         TextRange& range = moveRangeSet.range(i);
-        updateNewCaretSelectionForMove( doc, newCaretSelection, range, direction_ );
+        updateNewCaretSelectionForMove(doc, newCaretSelection, range, direction_);
     }
 
     // move the text in the correct direciton
     controller->beginUndoGroup();
-    for( int i=0,cnt=moveRangeSet.rangeCount(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = moveRangeSet.rangeCount(); i < cnt; ++i) {
         TextRange& range = moveRangeSet.range(i);
 
-        int line = doc->lineFromOffset(range.min());
+        size_t line = doc->lineFromOffset(range.min());
         QString text = doc->textPart(range.min(), range.length());
 
-        controller->replace( range.min(), range.length(), QStringLiteral(), 0);               // remove the line
-        controller->replace( doc->offsetFromLine(line+direction_), 0, text, 0 ); // add the line back
+        controller->replace(range.min(), range.length(), QStringLiteral(), 0);               // remove the line
+
+        ptrdiff_t replaceOffset = static_cast<ptrdiff_t>(line) + direction_;
+        Q_ASSERT(replaceOffset >= 0);
+        controller->replace(doc->offsetFromLine(static_cast<size_t>(replaceOffset)), 0, text, 0); // add the line back
     }
 
     *sel = newCaretSelection; // change the selection
 
     int coalesceID = CoalesceId_MoveLine + direction_ + 10;
-    controller->endUndoGroup(coalesceID,false);
+    controller->endUndoGroup(coalesceID, false);
 }
 
 

--- a/edbee-lib/edbee/commands/movelinecommand.h
+++ b/edbee-lib/edbee/commands/movelinecommand.h
@@ -9,11 +9,10 @@
 
 namespace edbee {
 
-/// moves
 class EDBEE_EXPORT MoveLineCommand : public TextEditorCommand
 {
 public:
-    MoveLineCommand( int direction );
+    MoveLineCommand(int direction);
     virtual ~MoveLineCommand();
 
     virtual void execute( TextEditorController* controller ) override;

--- a/edbee-lib/edbee/commands/newlinecommand.cpp
+++ b/edbee-lib/edbee/commands/newlinecommand.cpp
@@ -127,7 +127,7 @@ void NewlineCommand::executeSpecialNewline(TextEditorController* controller, boo
             QString text = QStringLiteral("\n%1").arg(smart ? calculateSmartIndent(controller, newRange) : "");
 
             // replaces the text
-            doc->replace(qMax(0u, newRange.caret()), 0, text);
+            doc->replace(qMax(static_cast<size_t>(0), newRange.caret()), 0, text);
             newRange.setCaret(pos + static_cast<size_t>(text.length()));
             newRange.reset();
 

--- a/edbee-lib/edbee/commands/newlinecommand.h
+++ b/edbee-lib/edbee/commands/newlinecommand.h
@@ -37,5 +37,4 @@ private:
     NewLineType newLineType_;       ///< The current newline type
 };
 
-
 } // edbee

--- a/edbee-lib/edbee/commands/newlinecommand.h
+++ b/edbee-lib/edbee/commands/newlinecommand.h
@@ -5,7 +5,6 @@
 
 #include "edbee/exports.h"
 
-
 #include "edbee/texteditorcommand.h"
 
 
@@ -24,16 +23,14 @@ public:
         AddLineAfter = 2
     };
 
+    NewlineCommand(NewLineType method);
 
-    NewlineCommand( NewLineType method );
+    QString calculateSmartIndent(TextEditorController* controller, TextRange& range);
 
-    QString calculateSmartIndent( TextEditorController* controller, TextRange& range );
+    virtual void executeNormalNewline(TextEditorController* controller);
+    virtual void executeSpecialNewline(TextEditorController* controller, bool nextLine);
 
-    virtual void executeNormalNewline( TextEditorController* controller );
-
-    virtual void executeSpecialNewline( TextEditorController* controller, bool nextLine );
-
-    virtual void execute( TextEditorController* controller ) override;
+    virtual void execute(TextEditorController* controller) override;
     virtual QString toString() override;
 
 private:

--- a/edbee-lib/edbee/commands/pastecommand.cpp
+++ b/edbee-lib/edbee/commands/pastecommand.cpp
@@ -47,28 +47,28 @@ void PasteCommand::execute(TextEditorController* controller)
     TextRangeSet* sel    = controller->textSelection();
 
     // a line-based paste
-    if( mimeData && mimeData->hasFormat( CopyCommand::EDBEE_TEXT_TYPE ) ) {
+    if (mimeData && mimeData->hasFormat(CopyCommand::EDBEE_TEXT_TYPE)) {
         TextRangeSet newRanges(doc);
-        for( int i=0,cnt=sel->rangeCount(); i<cnt; ++i ) {
+        for (size_t i = 0,cnt = sel->rangeCount(); i < cnt; ++i) {
             TextRange& range = sel->range(i);
-            int line   = doc->lineFromOffset( range.min() );
-            int offset = doc->offsetFromLine(line);
-            newRanges.addRange(offset,offset);
+            size_t line   = doc->lineFromOffset(range.min());
+            size_t offset = doc->offsetFromLine(line);
+            newRanges.addRange(offset, offset);
         }
 
-        controller->replaceRangeSet( newRanges, text, commandId() );
+        controller->replaceRangeSet(newRanges, text, commandId());
         return;
 
     // normal paste
     } else {
-        if( !text.isEmpty() ) {
-            int lineCount = text.count("\n") + 1;
-            int rangeCount = controller->textSelection()->rangeCount();
+        if (!text.isEmpty()) {
+            size_t lineCount = static_cast<size_t>(text.count("\n")) + 1;
+            size_t rangeCount = controller->textSelection()->rangeCount();
 
             // multi-line/caret copy paste
-            if( lineCount == rangeCount ) {
+            if (lineCount == rangeCount) {
                 QStringList texts = text.split("\n");
-                controller->replaceRangeSet( *controller->textSelection(), texts, commandId() );
+                controller->replaceRangeSet(*controller->textSelection(), texts, commandId());
 
             // this the normal operation
             } else {

--- a/edbee-lib/edbee/commands/pastecommand.h
+++ b/edbee-lib/edbee/commands/pastecommand.h
@@ -23,7 +23,7 @@ public:
 
     virtual int commandId();
 
-    virtual void execute( TextEditorController* controller ) override;
+    virtual void execute(TextEditorController* controller) override;
     virtual QString toString() override;
 };
 

--- a/edbee-lib/edbee/commands/removecommand.cpp
+++ b/edbee-lib/edbee/commands/removecommand.cpp
@@ -27,7 +27,7 @@ RemoveCommand::RemoveCommand(RemoveMode removeMode, Direction direction)
 }
 
 
-/// This method returns the coalesceId to use
+/// Returns the coalesceId to use
 /// Currently all commands in the same direction will get the same coalesceId
 /// @return the coalesceId to use
 int RemoveCommand::coalesceId() const
@@ -59,7 +59,7 @@ size_t RemoveCommand::smartBackspace(TextDocument* doc, size_t caret)
     if (caret <= firstNoneWhitespaceCharPos && lineStartOffset < firstNoneWhitespaceCharPos) {
         // retrieve the whitespace-start-part of the line
         QString linePrefix = doc->textPart(lineStartOffset, firstNoneWhitespaceCharPos-lineStartOffset);
-        QList<size_t> lineColumnOffsets = Util().tabColumnOffsets(linePrefix, config->indentSize());
+        QList<size_t> lineColumnOffsets = Util().tabColumnOffsets(linePrefix, static_cast<unsigned int>(config->indentSize()));
 
         // when we're exactly at a columnOffset, we need to get the previous
         size_t lastColumnOffset = lineColumnOffsets.last() + lineStartOffset;
@@ -124,10 +124,10 @@ void RemoveCommand::rangesForRemoveLine(TextEditorController* controller, TextRa
     TextDocument* doc = controller->textDocument();
 
     // process all carets
-    int offset = direction_ == Left ? -1 : 0;
+    ptrdiff_t offset = direction_ == Left ? -1 : 0;
     for (size_t rangeIdx = ranges->rangeCount() - 1; rangeIdx >= 0; --rangeIdx) {
         TextRange& range = ranges->range(rangeIdx);
-        QChar chr = doc->charAtOrNull(range.caret() + offset);
+        QChar chr = doc->charAtOrNull(static_cast<size_t>(static_cast<ptrdiff_t>(range.caret()) + offset));
         if (chr == '\n') {
             range.moveCaret(doc,directionSign());
         } else {
@@ -207,6 +207,5 @@ int RemoveCommand::directionSign() const
 {
     return direction_ == Left ? -1 : 1;
 }
-
 
 } // edbee

--- a/edbee-lib/edbee/commands/removecommand.cpp
+++ b/edbee-lib/edbee/commands/removecommand.cpp
@@ -59,7 +59,7 @@ size_t RemoveCommand::smartBackspace(TextDocument* doc, size_t caret)
     if (caret <= firstNoneWhitespaceCharPos && lineStartOffset < firstNoneWhitespaceCharPos) {
         // retrieve the whitespace-start-part of the line
         QString linePrefix = doc->textPart(lineStartOffset, firstNoneWhitespaceCharPos-lineStartOffset);
-        QList<size_t> lineColumnOffsets = Util().tabColumnOffsets( linePrefix, config->indentSize());
+        QList<size_t> lineColumnOffsets = Util().tabColumnOffsets(linePrefix, config->indentSize());
 
         // when we're exactly at a columnOffset, we need to get the previous
         size_t lastColumnOffset = lineColumnOffsets.last() + lineStartOffset;

--- a/edbee-lib/edbee/commands/removecommand.cpp
+++ b/edbee-lib/edbee/commands/removecommand.cpp
@@ -68,7 +68,7 @@ size_t RemoveCommand::smartBackspace(TextDocument* doc, size_t caret)
         }
 
         // we need to got the given number of characters
-        return qMax(0u, caret - (caret - lastColumnOffset));
+        return qMax(static_cast<size_t>(0), caret - (caret - lastColumnOffset));
 
     }
     return caret == 0 ? 0 : caret - 1;
@@ -125,7 +125,7 @@ void RemoveCommand::rangesForRemoveLine(TextEditorController* controller, TextRa
 
     // process all carets
     ptrdiff_t offset = direction_ == Left ? -1 : 0;
-    for (size_t rangeIdx = ranges->rangeCount() - 1; rangeIdx >= 0; --rangeIdx) {
+    for (size_t rangeIdx = ranges->rangeCount() - 1; rangeIdx != std::string::npos; --rangeIdx) {
         TextRange& range = ranges->range(rangeIdx);
         QChar chr = doc->charAtOrNull(static_cast<size_t>(static_cast<ptrdiff_t>(range.caret()) + offset));
         if (chr == '\n') {

--- a/edbee-lib/edbee/commands/removecommand.h
+++ b/edbee-lib/edbee/commands/removecommand.h
@@ -38,26 +38,23 @@ public:
         Right                           ///< Remove the item to ther right
     };
 
-
-    RemoveCommand( int removeMode, int direction );
+    RemoveCommand(RemoveMode removeMode, Direction direction);
 
     int coalesceId() const;
-    int smartBackspace( TextDocument* doc, int caret );
+    size_t smartBackspace(TextDocument* doc, size_t caret);
 
-    void rangesForRemoveChar( TextEditorController* controller, TextRangeSet* ranges );
-    void rangesForRemoveWord( TextEditorController* controller, TextRangeSet* ranges );
-    void rangesForRemoveLine( TextEditorController* controller, TextRangeSet* ranges );
+    void rangesForRemoveChar(TextEditorController* controller, TextRangeSet* ranges);
+    void rangesForRemoveWord(TextEditorController* controller, TextRangeSet* ranges);
+    void rangesForRemoveLine(TextEditorController* controller, TextRangeSet* ranges);
 
-    virtual void execute( TextEditorController* controller ) override;
+    virtual void execute(TextEditorController* controller) override;
     virtual QString toString() override;
 
 private:
     int directionSign() const;
 
-
-    int removeMode_;        ///< The remove mode
-    int direction_;         ///< The remove direction
+    RemoveMode removeMode_;        ///< The remove mode
+    Direction direction_;         ///< The remove direction
 };
-
 
 } // edbee

--- a/edbee-lib/edbee/commands/selectioncommand.cpp
+++ b/edbee-lib/edbee/commands/selectioncommand.cpp
@@ -21,17 +21,16 @@ namespace edbee {
 /// @param unit the unit of this command
 /// @param amount the number of steps
 /// @param keepSelection when true the anchor stays put (and the selection is expanded)
-SelectionCommand::SelectionCommand(SelectionType unit, int amount, bool keepSelection , int rangeIndex)
+SelectionCommand::SelectionCommand(SelectionType unit, ptrdiff_t amount, bool keepSelection , size_t rangeIndex)
     : unit_(unit)
     , amount_(amount)
-    , anchor_(-1)
+    , anchor_(std::string::npos)
     , keepSelection_(keepSelection)
     , rangeIndex_(rangeIndex)
 {
 }
 
 
-/// The descructor of the command
 SelectionCommand::~SelectionCommand()
 {
 }
@@ -42,24 +41,24 @@ SelectionCommand::~SelectionCommand()
 int SelectionCommand::commandId()
 {
     int coalesceId = CoalesceId_Selection + unit_* 10;
-    if( amount_ > 0 ) { coalesceId +=1 ; }
+    if (amount_ > 0) { coalesceId +=1 ; }
     return coalesceId;
 }
 
 
 /// execute the given selection command
 /// @param controller the controller to execute the selection for
-void SelectionCommand::execute( TextEditorController* controller )
+void SelectionCommand::execute(TextEditorController* controller)
 {
     // save the selection state
     TextDocument* document = controller->textDocument();
-    TextRangeSet* currentSelection = dynamic_cast<TextRangeSet*>( controller->textSelection() );
+    TextRangeSet* currentSelection = dynamic_cast<TextRangeSet*>(controller->textSelection());
     TextRangeSet* sel = new TextRangeSet(*currentSelection);  // start with the current selection
 
     bool resetAnchors = !keepSelection_;
 
     // handle the select operation
-    switch( unit_ ) {
+    switch (unit_) {
         // character movement
         case MoveCaretByCharacter:
             sel->moveCarets(amount_);
@@ -68,7 +67,7 @@ void SelectionCommand::execute( TextEditorController* controller )
         // This results in clearing the selection if a selection is present or it results in a movement of the caret.
         // When clearing a selection the caret is placed next to the selection (which side depends on the direction)
         case MoveCaretsOrDeselect:
-            if( keepSelection_ ) {
+            if (keepSelection_) {
                 sel->moveCarets(amount_);
             } else {
                 sel->moveCaretsOrDeselect(amount_);
@@ -76,11 +75,11 @@ void SelectionCommand::execute( TextEditorController* controller )
             break;
 
         case MoveCaretByWord:
-            sel->moveCaretsByCharGroup(amount_, document->config()->whitespaceWithoutNewline(), document->config()->charGroups() );
+            sel->moveCaretsByCharGroup(amount_, document->config()->whitespaceWithoutNewline(), document->config()->charGroups());
             break;
 
         case MoveCaretByLine:
-            TextSelection::moveCaretsByLine( controller, sel, amount_ );
+            TextSelection::moveCaretsByLine(controller, sel, amount_);
             break;
 
         case MoveCaretToWordBoundary:
@@ -107,30 +106,31 @@ void SelectionCommand::execute( TextEditorController* controller )
             // make sure the first line of the window is scrolled
             TextRenderer* renderer   = controller->textRenderer();
             TextEditorWidget* widget = controller->widget();
-            int firstVisibleLine = renderer->firstVisibleLine();
-            int linesPerPage     = renderer->viewHeightInLines();
+            size_t firstVisibleLine = renderer->firstVisibleLine();
+            size_t linesPerPage     = renderer->viewHeightInLines();
 
             sel->beginChanges();
-            TextSelection::moveCaretsByPage( controller, sel, amount_ );
+            TextSelection::moveCaretsByPage(controller, sel, amount_);
             if( !keepSelection_ ) {
                 sel->resetAnchors();    // we must reset anchors here because de process-changes will merge carets
             }
             sel->endChanges();
 
             firstVisibleLine += linesPerPage * amount_;
-            widget->scrollTopToLine( firstVisibleLine );
+            widget->scrollTopToLine(firstVisibleLine);
 
             break;
         }
         case MoveCaretToExactOffset:
         {
-            if( rangeIndex_ < 0 ) {
+            Q_ASSERT(amount_ >= 0);
+            if (rangeIndex_ == std::string::npos) {
                 sel->toSingleRange();
-
+                rangeIndex_ = 0;
             }
-            TextRange & range = sel->range( rangeIndex_ >= 0 ? rangeIndex_ : 0);
-            range.setCaret(amount_);
-            if( anchor_ >= 0 ) range.setAnchor(anchor_);
+            TextRange & range = sel->range(rangeIndex_);
+            range.setCaret(static_cast<size_t>(amount_));
+            if (anchor_ != std::string::npos) range.setAnchor(anchor_);
             break;
         }
         case SelectAll:
@@ -145,12 +145,14 @@ void SelectionCommand::execute( TextEditorController* controller )
             break;
 
         case SelectWordAt:
-            sel->selectWordAt( amount_, document->config()->whitespaces(), document->config()->charGroups() );
+            Q_ASSERT(amount_ >= 0);
+            sel->selectWordAt(static_cast<size_t>(amount_), document->config()->whitespaces(), document->config()->charGroups());
             resetAnchors = false;
             break;
 
         case ToggleWordSelectionAt:
-            sel->toggleWordSelectionAt( amount_, document->config()->whitespaces(), document->config()->charGroups() );
+            Q_ASSERT(amount_ >= 0);
+            sel->toggleWordSelectionAt(static_cast<size_t>(amount_), document->config()->whitespaces(), document->config()->charGroups());
             resetAnchors = false;
             break;
 
@@ -160,12 +162,13 @@ void SelectionCommand::execute( TextEditorController* controller )
             break;
 
         case AddCaretAtOffset:
-            sel->addRange( amount_, amount_ );
+            Q_ASSERT(amount_ >= 0);
+            sel->addRange(static_cast<size_t>(amount_), static_cast<size_t>(amount_));
             resetAnchors = false;   // do not reset the anchors
             break;
 
         case AddCaretByLine:
-            TextSelection::addRangesByLine( controller, sel, amount_ );
+            TextSelection::addRangesByLine(controller, sel, amount_);
             break;
 
         case ResetSelection:
@@ -197,7 +200,7 @@ void SelectionCommand::execute( TextEditorController* controller )
 /// Converts the unit enumeration to a string
 /// @param unit the unit enumeration value
 /// @return the string representation of this unit
-static QString unitToString( int unit ) {
+static QString unitToString(int unit) {
     switch( unit ) {
       case SelectionCommand::MoveCaretByCharacter: return "MoveCaretByCharacter";
       case SelectionCommand::MoveCaretByWord: return "MoveCaretByWord";
@@ -222,7 +225,7 @@ static QString unitToString( int unit ) {
 /// Converts this command to a strings
 QString SelectionCommand::toString()
 {
-    return QStringLiteral("SelectionCommand(%1)").arg( unitToString(unit_) );
+    return QStringLiteral("SelectionCommand(%1)").arg(unitToString(unit_));
 }
 
 bool SelectionCommand::readonly()

--- a/edbee-lib/edbee/commands/selectioncommand.cpp
+++ b/edbee-lib/edbee/commands/selectioncommand.cpp
@@ -104,20 +104,21 @@ void SelectionCommand::execute(TextEditorController* controller)
         case MoveCaretByPage:
         {
             // make sure the first line of the window is scrolled
-            TextRenderer* renderer   = controller->textRenderer();
-            TextEditorWidget* widget = controller->widget();
-            size_t firstVisibleLine = renderer->firstVisibleLine();
-            size_t linesPerPage     = renderer->viewHeightInLines();
+            TextRenderer* renderer     = controller->textRenderer();
+            TextEditorWidget* widget   = controller->widget();
+            ptrdiff_t firstVisibleLine = static_cast<ptrdiff_t>(renderer->firstVisibleLine());
+            size_t linesPerPage        = renderer->viewHeightInLines();
 
             sel->beginChanges();
             TextSelection::moveCaretsByPage(controller, sel, amount_);
-            if( !keepSelection_ ) {
+            if (!keepSelection_) {
                 sel->resetAnchors();    // we must reset anchors here because de process-changes will merge carets
             }
             sel->endChanges();
 
-            firstVisibleLine += linesPerPage * amount_;
-            widget->scrollTopToLine(firstVisibleLine);
+            firstVisibleLine += static_cast<ptrdiff_t>(linesPerPage) * amount_;
+            if (firstVisibleLine < 0) firstVisibleLine = 0;
+            widget->scrollTopToLine(static_cast<size_t>(firstVisibleLine));
 
             break;
         }

--- a/edbee-lib/edbee/commands/selectioncommand.h
+++ b/edbee-lib/edbee/commands/selectioncommand.h
@@ -16,7 +16,7 @@ class EDBEE_EXPORT SelectionCommand : public TextEditorCommand
 public:
     enum SelectionType {
 
-      // movement and selection
+        // movement and selection
         MoveCaretByCharacter,           ///< Moves the caret(s) by the given amount of characters
         MoveCaretsOrDeselect,           ///< Moves the caret(s) by the given amount of characters or deselects the current selection
         // SubWord, // TODO, implement subword selecting
@@ -29,46 +29,44 @@ public:
         MoveCaretToDocumentEnd,         ///< moves the caret to the document end
         MoveCaretToExactOffset,         ///< moves the caret to the given offset (given in  amount). (This action also support the adjustment of the anchor)
 
-      // selection only
+        // selection only
         SelectAll,                      ///< selects the complete document
         SelectWord,                     ///< select a full word
         SelectFullLine,                 ///< select a full line
         SelectWordAt,                   ///< select 'toggles' a word. Double click on a word to select a word or deselect a word
         ToggleWordSelectionAt,          ///< Toggles the selection and caret at the given location
 
-      // add an extra caret
+        // add an extra caret
         AddCaretAtOffset,               ///< adds a extra caret at the given offset (amount is the caret offset)
         AddCaretByLine,                 ///< adds a caret at the given line amount is the amount of lines and the direction to add
         ResetSelection
     };
 
 public:
-    explicit SelectionCommand( SelectionType unit, int amount=0, bool keepSelection=false, int rangeIndex = -1 );
+    explicit SelectionCommand(SelectionType unit, ptrdiff_t amount = 0, bool keepSelection = false, size_t rangeIndex = std::string::npos);
     virtual ~SelectionCommand();
-
 
     virtual int commandId();
 
-
-    virtual void execute( TextEditorController* controller ) override;
+    virtual void execute(TextEditorController* controller) override;
     virtual QString toString() override;
     virtual bool readonly() override;
 
     SelectionType unit() { return unit_; }
-    int amount() { return amount_; }
+    ptrdiff_t amount() { return amount_; }
     bool keepSelection() { return keepSelection_; }
-    int rangeIndex() { return rangeIndex_; }
-    void setAnchor(int anchor) { anchor_ = anchor; }
-    int anchor() { return anchor_; }
+    size_t rangeIndex() { return rangeIndex_; }
+    void setAnchor(size_t anchor) { anchor_ = anchor; }
+    size_t anchor() { return anchor_; }
 
 
 private:
 
     SelectionType unit_;
-    int amount_;
-    int anchor_;              ///< currently only used for word-selection / line selection
+    ptrdiff_t amount_;		  ///< the selection amount depending on the type. This can be negative
+    size_t anchor_;           ///< currently only used for word-selection / line selection (is std::string::npos if not used)
     bool keepSelection_;
-    int rangeIndex_;
+    size_t rangeIndex_; 	  ///< the range index (is std::string::npos, when not selected)
 };
 
 

--- a/edbee-lib/edbee/commands/tabcommand.cpp
+++ b/edbee-lib/edbee/commands/tabcommand.cpp
@@ -18,15 +18,15 @@ namespace edbee {
 /// @param direction the direction of the tab (Forward or Backward)
 /// @param insertTab should we use a tab character?
 TabCommand::TabCommand(TabCommand::Direction direction, bool insertTab)
-    : dir_( direction )
-    , insertTab_( insertTab )
+    : dir_(direction)
+    , insertTab_(insertTab)
 {
 }
 
 
 /// indents or outdents in the given controller
 /// @parma controller the controller
-void TabCommand::indent( TextEditorController* controller )
+void TabCommand::indent(TextEditorController* controller)
 {
     TextDocument* doc  = controller->textDocument();
     TextSelection* sel = controller->textSelection();
@@ -34,69 +34,68 @@ void TabCommand::indent( TextEditorController* controller )
     bool useTab = false; //doc->config()->useTabChar();
     QString tab = useTab ? "\t" : QStringLiteral(" ").repeated(tabSize);
 
-    controller->beginUndoGroup( new MergableChangeGroup( controller ) );
+    controller->beginUndoGroup(new MergableChangeGroup(controller));
 
     sel->beginChanges();
 
-    int lastLine = -1;
-    for( int i=0, cnt = sel->rangeCount(); i<cnt; ++i ) {
+    ptrdiff_t lastLine = -1;
+    for (size_t i = 0, cnt = sel->rangeCount(); i < cnt; ++i) {
         TextRange& range = sel->range(i);
 
         // calculate the start and endline
-        int startLine = doc->lineFromOffset( range.min() );
-        int endLine   = doc->lineFromOffset( range.max() );
+        size_t startLine = doc->lineFromOffset(range.min());
+        size_t endLine   = doc->lineFromOffset(range.max());
 
         // when the last line is blank, we do NOT want to indent it (fixes #61)
-        if( startLine!=endLine && doc->columnFromOffsetAndLine(range.max(),endLine) == 0 ) {
+        if (startLine != endLine && doc->columnFromOffsetAndLine(range.max(), endLine) == 0) {
             --endLine;
         }
 
         // make sure we at least indent one line
-        if( startLine <= lastLine ) startLine = lastLine + 1;
+        if (static_cast<ptrdiff_t>(startLine) <= lastLine) startLine = static_cast<size_t>(lastLine + 1);
 
         // now indent all lines
-        for( int line=startLine; line<=endLine; ++line ) {
-            int offset = doc->offsetFromLine(line);
+        for (size_t line = startLine; line <= endLine; ++line) {
+            size_t offset = doc->offsetFromLine(line);
 
             // insert-tab
-            if( dir_ == Forward ) {
-                doc->replace(offset,0, tab );
-                sel->changeSpatial( offset, 0, tab.length(), true );
+            if (dir_ == Forward) {
+                doc->replace(offset, 0, tab);
+                sel->changeSpatial(offset, 0, static_cast<size_t>(tab.length()), true);
 
             // remove tab
             } else {
-                int offsetNextLine = doc->offsetFromLine(line+1)-1;
-                int endOffset = offset;
-                for( int j=0; j<tabSize; ++j ) {
-                    int off = offset + j;
-                    if(off >= doc->length()) break;
-                    QChar chr = doc->charAt(off);
+                size_t offsetNextLine = doc->offsetFromLine(line + 1) - 1;
+                size_t endOffset = offset;
+                for (size_t j = 0, cnt = static_cast<size_t>(tabSize); j < cnt; ++j ) {
+                    size_t off = offset + j;
+                    if (off >= doc->length()) break;
 
-                    if( chr != ' ' && chr != '\t' ) break;
-                    if( off >= offsetNextLine ) break;
+                    QChar chr = doc->charAt(off);
+                    if (chr != ' ' && chr != '\t' ) break;
+                    if (off >= offsetNextLine) break;
                     ++endOffset;
-                    if( chr == '\t' ) break;
+                    if (chr == '\t') break;
                 }
-                if( offset != (endOffset-offset)) {
-                    doc->replace( offset, endOffset-offset, "" );
-                    sel->changeSpatial( offset, endOffset-offset, 0, true );
+
+                if (offset < endOffset) {
+                    doc->replace(offset, endOffset - offset, "");
+                    sel->changeSpatial(offset, endOffset - offset, 0, true);
                 }
             }
-
         }
-        lastLine = endLine;
+        lastLine = static_cast<ptrdiff_t>(endLine);
     }
-
     sel->endChanges();
 
-    controller->endUndoGroup( CoalesceId_Indent + dir_, true );
+    controller->endUndoGroup(CoalesceId_Indent + dir_, true);
 }
 
 
 /// TODO: Refactor :)
 void TabCommand::execute(TextEditorController* controller)
 {
-    if( !insertTab_ ) {
+    if (!insertTab_) {
         indent(controller);
         return;
     }
@@ -111,21 +110,21 @@ void TabCommand::execute(TextEditorController* controller)
     // check if the changes are multi-line
     bool multiLine = false;
     bool atStartOfLine = true;
-    for( int i=0, cnt = sel->rangeCount(); i<cnt && !multiLine; ++i ) {
+    for (size_t i=0, cnt = sel->rangeCount(); i < cnt && !multiLine; ++i) {
         TextRange& range = sel->range(i);
         multiLine = multiLine || doc->lineFromOffset(range.anchor()) != doc->lineFromOffset(range.caret());
 
         // no selection? we need to check if we are at the start of the line
-        if( !range.hasSelection() && atStartOfLine ) {
-            int pos = range.caret();
-            int startPos = doc->offsetFromLine( doc->lineFromOffset( pos ) );
+        if (!range.hasSelection() && atStartOfLine) {
+            size_t pos = range.caret();
+            size_t startPos = doc->offsetFromLine( doc->lineFromOffset(pos));
             --pos;  // look hat the character before the pos
 
-            //Q_ASSERT(startPos <= pos);
-            if( pos >= startPos ) {
-                while(pos>startPos && atStartOfLine ) {
+            // Q_ASSERT(startPos <= pos);
+            if (pos >= startPos) {
+                while (pos>startPos && atStartOfLine) {
                     QChar chr = doc->charAt(pos);
-                    if( !ws.contains(chr) ) {
+                    if (!ws.contains(chr)) {
                         atStartOfLine = false;
                     }
                     --pos;
@@ -138,32 +137,31 @@ void TabCommand::execute(TextEditorController* controller)
     }
 
     // a Line-moving operation
-    if( multiLine || ( atStartOfLine && dir_ == Backward ) ) {
-        indent( controller );
+    if (multiLine || (atStartOfLine && dir_ == Backward)) {
+        indent(controller);
 
     // a character inserting operation
     } else {
-        if( dir_ == Forward) {
-            if( useTab ) {
-                controller->replaceSelection("\t", CoalesceId_Indent + SubCoalesceId_Indent_InsertTab );
+        if (dir_ == Forward) {
+            if (useTab) {
+                controller->replaceSelection("\t", CoalesceId_Indent + SubCoalesceId_Indent_InsertTab);
             } else {
 
                 // we need to 'calculate' the number of spaces to add (per caret)
                 QStringList texts;
-                for( int i=0, cnt = sel->rangeCount(); i<cnt; ++i ) {
+                for (size_t i = 0, cnt = sel->rangeCount(); i < cnt; ++i) {
                     TextRange& range = sel->range(i);
-                    int offset = range.min();
-                    int col = doc->columnFromOffsetAndLine(offset);
+                    size_t offset = range.min();
+                    size_t col = doc->columnFromOffsetAndLine(offset);
 
                     // calculate the number of spaces depending on the column
-                    int spaces = tabSize - col%tabSize;
-                    if( !spaces ) spaces = tabSize;
+                    int spaces = tabSize - static_cast<ptrdiff_t>(col) % tabSize;
+                    if (!spaces) spaces = tabSize;
 
                     // append the text
-                    texts.push_back( QStringLiteral(" ").repeated(spaces) );
+                    texts.push_back(QStringLiteral(" ").repeated(spaces));
                 }
-
-                controller->replaceSelection( texts, CoalesceId_Indent + SubCoalesceId_Indent_InsertSpaces  );
+                controller->replaceSelection(texts, CoalesceId_Indent + SubCoalesceId_Indent_InsertSpaces );
             }
         }
     }

--- a/edbee-lib/edbee/commands/tabcommand.h
+++ b/edbee-lib/edbee/commands/tabcommand.h
@@ -27,16 +27,15 @@ public:
         SubCoalesceId_Indent_InsertSpaces
     };
 
+    TabCommand(Direction direction, bool insertTab);
 
-    TabCommand( Direction direction, bool insertTab );
-
-    virtual void indent( TextEditorController* controller );
-    virtual void execute( TextEditorController* controller ) override;
+    virtual void indent(TextEditorController* controller);
+    virtual void execute(TextEditorController* controller) override;
     virtual QString toString() override;
 
 private:
-    Direction dir_;                 ///< The tab direction
-    bool insertTab_;                ///< Should we insert a tab
+    Direction dir_;   ///< The tab direction
+    bool insertTab_;  ///< Should we insert a tab
 };
 
 } // edbee

--- a/edbee-lib/edbee/exports.h
+++ b/edbee-lib/edbee/exports.h
@@ -3,6 +3,26 @@
 
 #pragma once
 
+// code for stricter compilation and testing of validation
+// A bit of a hack to place this in export.h.
+// This file is included by every header file in edbee.
+// Here it is possible to configure the correct validation to perform fixes that are required by every file
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+// include headers to prevent cast-errors in Qt Header
+#include <QDebug>
+#include <QtCore/qglobal.h>
+#include <QHash>
+#include <QList>
+#include <QString>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <qtmochelpers.h>
+#endif
+#pragma GCC diagnostic pop
+#endif
+
 #include <QtCore/qglobal.h>
 
 #ifdef EDBEE_SHARED

--- a/edbee-lib/edbee/io/baseplistparser.h
+++ b/edbee-lib/edbee/io/baseplistparser.h
@@ -23,29 +23,28 @@ public:
 
     QString lastErrorMessage() const;
 
-    void setLastErrorMessage( const QString& str );
+    void setLastErrorMessage(const QString& str);
 
-    bool beginParsing( QIODevice* device );
+    bool beginParsing(QIODevice* device);
     bool endParsing();
 
-    void raiseError( const QString& str );
+    void raiseError(const QString& str);
 
-  // general plist parsing
+      // general plist parsing
     QList<QVariant> readList();
     QHash<QString, QVariant> readDict();
-    QVariant readNextPlistType(int level=-1);
+    QVariant readNextPlistType(qsizetype level = -1);
 
-    bool readNextElement( const QString& name, int level=-1 );
+    bool readNextElement(const QString& name, qsizetype level = -1);
     QString readElementText();
 
-    int currentStackLevel();
+    qsizetype currentStackLevel();
 
 private:
 
     QString lastErrorMessage_;               ///< The last error message
     QStack<QString> elementStack_;           ///< The elements currently on the stack
     QXmlStreamReader* xml_;                  ///< The reference of the xml reader
-
 };
 
 } // edbee

--- a/edbee-lib/edbee/io/jsonparser.h
+++ b/edbee-lib/edbee/io/jsonparser.h
@@ -19,9 +19,9 @@ public:
     JsonParser();
     virtual ~JsonParser();
 
-    bool parse( const QString& fileName);
-    bool parse( QIODevice* device );
-    bool parse( const QByteArray& bytesIn );
+    bool parse(const QString& fileName);
+    bool parse(QIODevice* device );
+    bool parse(const QByteArray& bytesIn);
 
     QVariant result();
 
@@ -35,7 +35,7 @@ public:
 
 protected:
 
-    QByteArray stripCommentsFromJson( const QByteArray& bytesIn );
+    QByteArray stripCommentsFromJson(const QByteArray& bytesIn);
 
 private:
 
@@ -45,7 +45,6 @@ private:
     int errorColumn_;           ///< The column number of the error
 
     QVariant result_;           ///< variant is the easiest format to play around with in Qt. The result will be QVariantMap (no hash!) or QVariantArray
-
 };
 
 } //edbee

--- a/edbee-lib/edbee/io/textdocumentserializer.cpp
+++ b/edbee-lib/edbee/io/textdocumentserializer.cpp
@@ -47,7 +47,11 @@ bool TextDocumentSerializer::loadWithoutOpening(QIODevice* ioDevice)
     /// TODO: implement isStopRequested to stop loading if required
     while (/*ioDeviceRef_->atEnd() &&*/ true /*!isStopRequested()*/) {
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         qsizetype bytesRead = ioDevice->read( bytes.data(), blockSize_ - 1);
+#else
+        int bytesRead = ioDevice->read( bytes.data(), blockSize_ - 1);
+#endif
         if (bytesRead > 0) {
             bytes[bytesRead + 1] = 0; // 0 terminate the read bytes
 

--- a/edbee-lib/edbee/io/textdocumentserializer.h
+++ b/edbee-lib/edbee/io/textdocumentserializer.h
@@ -21,24 +21,24 @@ public:
     /// @param lineIdx the line index that needs to be saved
     /// @param line the line that's save
     /// @return true if the line needs to be selected. return false to skip the line
-    virtual bool saveLineSelector( TextDocumentSerializer* serializer, int lineIdx, QString& line ) = 0;
+    virtual bool saveLineSelector(TextDocumentSerializer* serializer, size_t lineIdx, QString& line) = 0;
 };
 
 
 /// A class used to load/save a text-file from and to an IODevice
 class EDBEE_EXPORT TextDocumentSerializer {
 public:
-    TextDocumentSerializer( TextDocument* textDocument );
+    TextDocumentSerializer(TextDocument* textDocument);
 
-    bool loadWithoutOpening( QIODevice* ioDevice );
+    bool loadWithoutOpening(QIODevice* ioDevice);
     bool load( QIODevice* ioDevice );
 
-    bool saveWithoutOpening( QIODevice* ioDevice );
-    bool save( QIODevice* ioDevice );
+    bool saveWithoutOpening(QIODevice* ioDevice);
+    bool save(QIODevice* ioDevice);
 
 
     QString errorString() { return errorString_; }
-    void setFilter( TextDocumentSerializerFilter* filter ) { filterRef_ = filter; }
+    void setFilter(TextDocumentSerializerFilter* filter) { filterRef_ = filter; }
     TextDocumentSerializerFilter* filter() { return filterRef_; }
 
 private:

--- a/edbee-lib/edbee/lexers/grammartextlexer.cpp
+++ b/edbee-lib/edbee/lexers/grammartextlexer.cpp
@@ -5,6 +5,7 @@
 
 #include <limits>
 #include <QStack>
+#include <QThread>
 
 #include "edbee/models/textgrammar.h"
 #include "edbee/models/textdocument.h"
@@ -19,46 +20,47 @@ namespace edbee {
 /// Constructs the grammar textlexer
 /// @param scopes a reference to the scopes model
 GrammarTextLexer::GrammarTextLexer(TextDocumentScopes* scopes)
-    : TextLexer( scopes )
-    , lineRangeList_( 0 )
+    : TextLexer(scopes)
+    , lineRangeList_(nullptr)
 {
-    setGrammar( Edbee::instance()->grammarManager()->defaultGrammar() );
+    setGrammar(Edbee::instance()->grammarManager()->defaultGrammar());
 }
 
 
-/// The destructor
 GrammarTextLexer::~GrammarTextLexer()
 {
     delete lineRangeList_;  // just in case
 }
 
 
-/// This method builds the end-regexp for the given multi-line-regexp
+/// Builds the end-regexp for the given multi-line-regexp
 /// @param startRegExp the start regexp
 /// @param endRegExStringIn the end regexp string
-RegExp* GrammarTextLexer::createEndRegExp( RegExp* startRegExp, const QString& endRegExpStringIn)
+RegExp* GrammarTextLexer::createEndRegExp(RegExp* startRegExp, const QString& endRegExpStringIn)
 {
+    QStringView endRegExpStringInView(endRegExpStringIn);
+
     // build the end-regexp string
     QString endRegExpString;
     RegExp matcher("\\\\(\\d+)");  // \(d+)
-    int lastPos = 0;
-    while( matcher.indexIn(endRegExpStringIn,lastPos) >= 0 ) {
-        int len = matcher.len();
-        int pos = matcher.pos();
+    size_t lastPos = 0;
+    while (matcher.indexIn(endRegExpStringIn, lastPos) != std::string::npos) {
+        size_t len = matcher.len();
+        size_t pos = matcher.pos();
 
         // append the previous string
-        if( pos-lastPos > 0 ) {
-            endRegExpString.append( endRegExpStringIn.mid(lastPos,pos-lastPos) );
+        if (pos > lastPos) {
+            endRegExpString.append(endRegExpStringInView.mid(static_cast<qsizetype>(lastPos), static_cast<qsizetype>(pos - lastPos)));
         }
 
         // append the 'match'
         int nr = matcher.cap(1).toInt();
-        if( nr >= 0 ) {
-            endRegExpString.append( startRegExp->cap(nr) );
+        if (nr >= 0) {
+            endRegExpString.append(startRegExp->cap(static_cast<size_t>(nr)));
         }
         lastPos = pos + len + 1;
     }
-    endRegExpString.append( endRegExpStringIn.mid(lastPos));
+    endRegExpString.append(endRegExpStringInView.mid(static_cast<qsizetype>(lastPos)));
     return new RegExp(endRegExpString);
 }
 
@@ -67,32 +69,30 @@ RegExp* GrammarTextLexer::createEndRegExp( RegExp* startRegExp, const QString& e
 /// @param (out) foundRegExp the found regexp
 /// @param (out) foundPosition the found position
 /// @return the grammarRule found
-void GrammarTextLexer::findNextGrammarRule( const QString& line, int offsetInLine, TextGrammarRule* activeRule, TextGrammarRule*& foundRule, RegExp*& foundRegExp, int& foundPosition )
+void GrammarTextLexer::findNextGrammarRule(const QString& line, size_t offsetInLine, TextGrammarRule* activeRule, TextGrammarRule*& foundRule, RegExp*& foundRegExp, size_t& foundPosition)
 {
-
     // next iterate over all rules and find the rule with the lowest offset
     QStack<TextGrammarRule::Iterator*> ruleIterators;
-    ruleIterators.push( activeRule->createIterator() );
-    while( !ruleIterators.isEmpty() ) {
+    ruleIterators.push( activeRule->createIterator());
+    while (!ruleIterators.isEmpty()) {
 
-        while( ruleIterators.top()->hasNext() ) {
-            TextGrammarRule* rule = ruleIterators.top()->next(); //activeRule->rule(i);
+        while (ruleIterators.top()->hasNext()) {
+            TextGrammarRule* rule = ruleIterators.top()->next(); // activeRule->rule(i);
 
             bool processNewRule = false;
             do {
                 processNewRule = false;
-//qlog_info() << "     -   " << ":" << rule->toString(false);
-                switch( rule->instruction() ) {
+                switch (rule->instruction()) {
                     case TextGrammarRule::SingleLineRegExp:
                     case TextGrammarRule::MultiLineRegExp:
                     {
                         // only use this match if the offset < foundPosition
-                        int pos = rule->matchRegExp()->indexIn( line, offsetInLine );
-                        if( pos >= 0 ) {
-                            if( pos < foundPosition ) {
-                                foundRule      = rule;
-                                foundRegExp    = rule->matchRegExp();
-                                foundPosition   = pos;
+                        size_t pos = rule->matchRegExp()->indexIn(line, offsetInLine);
+                        if (pos != std::string::npos) {
+                            if (pos < foundPosition) {
+                                foundRule     = rule;
+                                foundRegExp   = rule->matchRegExp();
+                                foundPosition = pos;
                             }
                         }
                         break;
@@ -101,11 +101,11 @@ void GrammarTextLexer::findNextGrammarRule( const QString& line, int offsetInLin
                     // and include rule
                     case TextGrammarRule::IncludeCall:
                     {
-                        TextGrammarRule* includedRule= findIncludeGrammarRule( rule);
-                        if( includedRule ) {
+                        TextGrammarRule* includedRule = findIncludeGrammarRule(rule);
+                        if (includedRule) {
                             // a rule list, append the iterator
-                            if( includedRule->isRuleList() || includedRule->isMainRule() ) {
-                                ruleIterators.push_back( includedRule->createIterator() );
+                            if (includedRule->isRuleList() || includedRule->isMainRule()) {
+                                ruleIterators.push_back( includedRule->createIterator());
 
                             // a normal rule? We need to process this one again
                             } else {
@@ -127,37 +127,35 @@ void GrammarTextLexer::findNextGrammarRule( const QString& line, int offsetInLin
                         Q_ASSERT(false && "unkown rule");
                 }
             }
-            while( processNewRule );
+            while (processNewRule);
         } // while hasNext
 
         delete ruleIterators.pop();
 
-    }// while ruleIterators
+    } // while ruleIterators
 }
 
 
 /// This method processes the captures and adds them to the active line
 /// @param foundRegExp the found regexp
 /// @param foundCaptures the found captures
-void GrammarTextLexer::processCaptures( RegExp* foundRegExp, const QMap<int, QString>* foundCaptures )
+void GrammarTextLexer::processCaptures(RegExp* foundRegExp, const QMap<size_t, QString>* foundCaptures)
 {
-    if( !foundCaptures->isEmpty() ) {
+    if (!foundCaptures->isEmpty()) {
 //qlog_info() << "found: captures:";
-        QMapIterator<int,QString> itr(*foundCaptures);
-        while( itr.hasNext() ) {
+        QMapIterator<size_t, QString> itr(*foundCaptures);
+        while (itr.hasNext()) {
             itr.next();
-            int captureIndex = itr.key();
+            size_t captureIndex = itr.key();
             const QString scope = itr.value();
 
-            int capturePos = foundRegExp->pos(captureIndex);
-            if( capturePos >=0 ) {
-                int capLen = foundRegExp->len(captureIndex);
-                int start  = capturePos;
-                int end    = capturePos+capLen;
+            size_t capturePos = foundRegExp->pos(captureIndex);
+            if (capturePos != std::string::npos) {
+                size_t capLen = foundRegExp->len(captureIndex);
+                size_t start  = capturePos;
+                size_t end    = capturePos + capLen;
 
-//                textScopes()->addScopedRange( currentDocOffset+capturePos, currentDocOffset+capturePos+capLen, scope, foundRule );
-                lineRangeList_->giveRange( new ScopedTextRange( start, end, Edbee::instance()->scopeManager()->refTextScope(scope) ));
-
+                lineRangeList_->giveRange(new ScopedTextRange(start, end, Edbee::instance()->scopeManager()->refTextScope(scope)));
             }
         }
     }
@@ -168,52 +166,50 @@ void GrammarTextLexer::processCaptures( RegExp* foundRegExp, const QMap<int, QSt
 /// @param currentDocOffset the current document offset
 /// @param line the line that's being matches
 /// @param offsetInLine (in/out) the current offset in the line
-TextGrammarRule* GrammarTextLexer::findAndApplyNextGrammarRule( int currentDocOffset, const QString& line, int& offsetInLine  )
+TextGrammarRule* GrammarTextLexer::findAndApplyNextGrammarRule(size_t currentDocOffset, const QString& line, size_t& offsetInLine)
 {
     Q_ASSERT(lineRangeList_);
 
-//    qlog_info() << "--- matchNextGrammarRule: " << currentDocOffset << ", line:" << line << ":"<<offsetInLine << "--";
     MultiLineScopedTextRange* activeMultiRange = this->activeMultiLineRange();
-    TextGrammarRule* activeRule      = activeMultiRange->grammarRule();
-//qlog_info() << "--- matchNextGrammarRule ---------------------";
-//qlog_info() << " - activeRule : " << activeRule->toString();
-//qlog_info() << " - activeRange: " << activeRange->toString();
+    TextGrammarRule* activeRule = activeMultiRange->grammarRule();
+    //qlog_info() << "--- matchNextGrammarRule ---------------------";
+    //qlog_info() << " - activeRule : " << activeRule->toString();
+    //qlog_info() << " - activeRange: " << activeRange->toString();
 
-    TextGrammarRule* foundRule = 0;
-    RegExp* foundRegExp    = 0;
-    int foundPosition      = std::numeric_limits<int>::max();
-
+    TextGrammarRule* foundRule = nullptr;
+    RegExp* foundRegExp = nullptr;
+    size_t foundPosition = std::numeric_limits<size_t>::max();
 
     // first try to close the active rule
-    if( activeMultiRange->endRegExp() ) {
-        if( activeMultiRange->endRegExp()->indexIn( line, offsetInLine ) >= 0 ) {
+    if (activeMultiRange->endRegExp()) {
+        if (activeMultiRange->endRegExp()->indexIn(line, offsetInLine) != std::string::npos) {
             foundRule      = activeRule;
             foundRegExp    = activeMultiRange->endRegExp();
             foundPosition  = foundRegExp->pos();
         }
     }
 
+
     // find the grammar rule
-    findNextGrammarRule( line, offsetInLine, activeRule, foundRule, foundRegExp, foundPosition );
+    findNextGrammarRule(line, offsetInLine, activeRule, foundRule, foundRegExp, foundPosition);
 
     // next we have found the rule that matched a certain scope
-    if( foundRule ) {
-        int matchedLength = foundRegExp->matchedLength();
-//        if( !matchedLength ) { matchedLength=1; }   // always match at least 1 character! (else we're in big trouble )
+    if (foundRule) {
+        size_t matchedLength = foundRegExp->matchedLength();
 
-        int startPos = foundPosition;
-        int endPos   = startPos + matchedLength;
-//qlog_info() << " foundRule: " << foundRule->toString(false) << ", foundPosition:" << foundPosition <<" : " << startPos << "t/m" << endPos;
-//qlog_info() << " foundRegExp: " << foundRegExp->pattern();
+        size_t startPos = foundPosition;
+        size_t endPos   = startPos + matchedLength;
+        //qlog_info() << " foundRule: " << foundRule->toString(false) << ", foundPosition:" << foundPosition <<" : " << startPos << "t/m" << endPos;
+        //qlog_info() << " foundRegExp: " << foundRegExp->pattern();
 
         // the found captures
 
         // Did we found the endrule? Then  we need to 'close' the current activeRule
-        if( activeMultiRange->endRegExp() == foundRegExp ) {
+        if (activeMultiRange->endRegExp() == foundRegExp) {
             activeMultiRange->maxVar() = currentDocOffset + endPos;         // mark the end (DOC)
             activeScopedTextRange()->maxVar() = endPos;                     // mark the end (TextScope)
 
-            processCaptures( foundRegExp, &activeRule->endCaptures() );
+            processCaptures(foundRegExp, &activeRule->endCaptures());
 
             popActiveRange();
 
@@ -223,45 +219,41 @@ TextGrammarRule* GrammarTextLexer::findAndApplyNextGrammarRule( int currentDocOf
 
             // did we find a multiline regexp. add the start of this scope
             if( foundRule->isMultiLineRegExp() ) {
+                ScopedTextRange* range = new ScopedTextRange(startPos, static_cast<size_t>(line.length()), scopeRef);
+                lineRangeList_->giveRange(range);
 
-                ScopedTextRange* range = new ScopedTextRange(startPos, line.length(), scopeRef );
-                lineRangeList_->giveRange( range );
+                MultiLineScopedTextRange* multiRange = new MultiLineScopedTextRange(currentDocOffset+startPos, textScopes()->textDocument()->length(), scopeRef);
+                multiRange->setGrammarRule(foundRule);
+                multiRange->giveEndRegExp(createEndRegExp( foundRegExp, foundRule->endRegExpString()));
 
-                MultiLineScopedTextRange* multiRange = new MultiLineScopedTextRange( currentDocOffset+startPos, textScopes()->textDocument()->length(), scopeRef );
-                multiRange->setGrammarRule( foundRule );
-                multiRange->giveEndRegExp( createEndRegExp( foundRegExp, foundRule->endRegExpString() ) );
-
-                pushActiveRange( range, multiRange );
+                pushActiveRange(range, multiRange);
 
             // a single rule
             } else {
                 // add the found regexp
-                lineRangeList_->giveRange( new ScopedTextRange(startPos, endPos, scopeRef ));
-                //textScopes()->addScopedRange( startPos, endPos, foundRule->scopeName(), foundRule );
+                lineRangeList_->giveRange(new ScopedTextRange(startPos, endPos, scopeRef));
             }
 
             // next we need to add the 'captures'
-            processCaptures( foundRegExp, &foundRule->matchCaptures() );
+            processCaptures(foundRegExp, &foundRule->matchCaptures());
         }
 
 
         // increase the offset for the next search
-//qlog_info() << " ++ " << matchedLength;
         offsetInLine = foundPosition + matchedLength;
 
         return foundRule;
     }
-//qlog_info() << "-- not found ??";
-    return 0;   // no rule found
+    return nullptr;   // no rule found
 }
 
 
 /// internal method that returns the active grammar rule
 MultiLineScopedTextRange* GrammarTextLexer::activeMultiLineRange()
 {
-    Q_ASSERT( !activeMultiLineRangesRefList_.isEmpty() );
+    Q_ASSERT(!activeMultiLineRangesRefList_.isEmpty());
     MultiLineScopedTextRange* result = activeMultiLineRangesRefList_.last();
-    Q_ASSERT( result->grammarRule() );
+    Q_ASSERT(result->grammarRule());
     return result;
 }
 
@@ -269,7 +261,7 @@ MultiLineScopedTextRange* GrammarTextLexer::activeMultiLineRange()
 /// Returns the active scoped text range
 ScopedTextRange* GrammarTextLexer::activeScopedTextRange()
 {
-    Q_ASSERT( !activeScopedRangesRefList_.isEmpty() );
+    Q_ASSERT(!activeScopedRangesRefList_.isEmpty());
     return activeScopedRangesRefList_.last();
 }
 
@@ -279,12 +271,12 @@ ScopedTextRange* GrammarTextLexer::activeScopedTextRange()
 /// If the range was started at a previous line, the item is added to the closedActiveRangeRefList
 void GrammarTextLexer::popActiveRange()
 {
-    Q_ASSERT( activeMultiLineRangesRefList_.size() > 1 ); // there should be at least 2 items. The first one is the grammar rule!
-    Q_ASSERT( activeScopedRangesRefList_.size() == activeMultiLineRangesRefList_.size() );
+    Q_ASSERT(activeMultiLineRangesRefList_.size() > 1); // there should be at least 2 items. The first one is the grammar rule!
+    Q_ASSERT(activeScopedRangesRefList_.size() == activeMultiLineRangesRefList_.size());
     //
-    if( currentMultiLineRangeList_.isEmpty() ) {
-        closedMultiRangesRangesRefList_.append( activeMultiLineRangesRefList_.last() );
-//        closedActiveRangesRefList_.append(range);
+    if(currentMultiLineRangeList_.isEmpty()) {
+        closedMultiRangesRangesRefList_.append( activeMultiLineRangesRefList_.last());
+        // closedActiveRangesRefList_.append(range);
     // pushed and popped on this line, no document-scope
     } else {
         delete currentMultiLineRangeList_.last();
@@ -299,14 +291,11 @@ void GrammarTextLexer::popActiveRange()
 /// Adds the given range to the multiscoped textranges
 /// And to the list of current line ranges
 /// @param range the range top push
-void GrammarTextLexer::pushActiveRange(ScopedTextRange* range, MultiLineScopedTextRange* multiRange )
+void GrammarTextLexer::pushActiveRange(ScopedTextRange* range, MultiLineScopedTextRange* multiRange)
 {
-    activeMultiLineRangesRefList_.push_back( multiRange );
-    currentMultiLineRangeList_.push_back( multiRange );
-    activeScopedRangesRefList_.push_back( range );
-//qlog_info() << "[push]";
-//    activeRangesRefList_.push_back( range );
-//    currentLineRangesList_.push_back(range);
+    activeMultiLineRangesRefList_.push_back(multiRange);
+    currentMultiLineRangeList_.push_back(multiRange);
+    activeScopedRangesRefList_.push_back(range);
 }
 
 
@@ -317,31 +306,31 @@ TextGrammarRule* GrammarTextLexer::findIncludeGrammarRule(TextGrammarRule* base)
     QString name = base->includeName();
 
     // repos call
-    if( name.startsWith("#")) {
-        return base->grammar()->findFromRepos( name.mid(1) );
+    if (name.startsWith("#")) {
+        return base->grammar()->findFromRepos(name.mid(1));
 
     }
     // another language call
     // The difference between $base and $self is very subtle.. The exact difference is unkown to me..
-    if( name=="$base" || name == "$self" ) {
+    if (name=="$base" || name == "$self") {
         return grammar()->mainRule();
     }
 
-    TextGrammar* grammar = Edbee::instance()->grammarManager()->get( name );
-    if( grammar ) { return grammar->mainRule(); }
-    return 0;
+    TextGrammar* grammar = Edbee::instance()->grammarManager()->get(name);
+    if (grammar) { return grammar->mainRule(); }
+    return nullptr;
 }
 
 
 
 /// This method is called to notify the lexer some data has been changed
 //void GrammarTextLexer::textReplaced( int offset, int length, int newLength )
-void GrammarTextLexer::textChanged( const TextBufferChange& change )
+void GrammarTextLexer::textChanged(const TextBufferChange& change)
 {
     TextDocument* doc = textDocument();
     TextDocumentScopes* docScopes = textScopes();
 
-    int offsetStart = doc->offsetFromLine(change.line());
+    size_t offsetStart = doc->offsetFromLine(change.line());
     docScopes->removeScopesAfterOffset(offsetStart);
 
     /// TODO: rebuild an optimized scope-rebuilding algorithm
@@ -351,50 +340,46 @@ void GrammarTextLexer::textChanged( const TextBufferChange& change )
 /// This method lexes a single line
 /// @return the last indexed offset
 /// WARNING lexline CANNOT be called indepdently of lexLines (beacuse lex-lines set the activeScopes!
-bool GrammarTextLexer::lexLine( int lineIdx, int& currentDocOffset )
+bool GrammarTextLexer::lexLine(size_t lineIdx, size_t& currentDocOffset)
 {
     TextDocument* doc = textDocument();
     TextDocumentScopes* docScopes = textScopes();
 
-    QString line        = doc->line(lineIdx); //+ "\n";
+    QString line        = doc->line(lineIdx);
 
-    //    int lineStartOffset = doc->offsetFromLine(lineIdx);
-
-    Q_ASSERT( currentMultiLineRangeList_.isEmpty() );
-    Q_ASSERT( closedMultiRangesRangesRefList_.isEmpty() );
-    Q_ASSERT( activeScopedRangesRefList_.isEmpty() );
+    Q_ASSERT(currentMultiLineRangeList_.isEmpty());
+    Q_ASSERT(closedMultiRangesRangesRefList_.isEmpty());
+    Q_ASSERT(activeScopedRangesRefList_.isEmpty());
 
     lineRangeList_ = new ScopedTextRangeList();
 
     // append the active ranges
-    for( int i=0,cnt=activeMultiLineRangesRefList_.size(); i<cnt; ++i ) {
-        MultiLineScopedTextRangeReference* range = new MultiLineScopedTextRangeReference( *activeMultiLineRangesRefList_.at(i) );
+    for (qsizetype i=0, cnt=activeMultiLineRangesRefList_.size(); i < cnt; ++i) {
+        MultiLineScopedTextRangeReference* range = new MultiLineScopedTextRangeReference(*activeMultiLineRangesRefList_.at(i));
         range->setAnchor(0);
-        range->setCaret(line.length());
-        lineRangeList_->giveRange( range );
+        range->setCaret(static_cast<size_t>(line.length()));
+        lineRangeList_->giveRange(range);
         activeScopedRangesRefList_.append(range);
     }
 
-// qlog_info() << "";
-// qlog_info() << "////////////////////////////////////////////////////////////////";
-// qlog_info() << " * " << lineIdx << ":" << line;
+    // qlog_info() << "";
+    // qlog_info() << "////////////////////////////////////////////////////////////////";
+    // qlog_info() << " * " << lineIdx << ":" << line;
 
     // find the first 'matching' rule
-    int offsetInLine = 0;
-    int lastOffsetInLine = 0;
-    TextGrammarRule* lastFoundRule = 0;
-    while( true ) {
-//QString debug;
-//debug.append( QStringLiteral((" =[%1,%2,%3]= ").arg(lineIdx).arg(offsetInLine).arg(currentDocOffset) );
-        TextGrammarRule* foundRule = findAndApplyNextGrammarRule( currentDocOffset, line, offsetInLine  );
-//debug.append( QStringLiteral((" %1  (%2)").arg(foundRule?foundRule->scopeName():"<<null>").arg(offsetInLine) );
-//qlog_info() << debug;
-        if( !foundRule ) break;
+    size_t offsetInLine = 0;
+    size_t lastOffsetInLine = 0;
+    TextGrammarRule* lastFoundRule = nullptr;
+    while (true) {
+        //QString debug;
+        //debug.append( QStringLiteral((" =[%1,%2,%3]= ").arg(lineIdx).arg(offsetInLine).arg(currentDocOffset) );
+
+        TextGrammarRule* foundRule = findAndApplyNextGrammarRule(currentDocOffset, line, offsetInLine); //debug.append( QStringLiteral((" %1  (%2)").arg(foundRule?foundRule->scopeName():"<<null>").arg(offsetInLine) ); //qlog_info() << debug; if (!foundRule) break;
+        if (!foundRule) break;
 
         /// check the next offset
-        if( offsetInLine == lastOffsetInLine ) {
-
-            if( lastFoundRule == foundRule ) {
+        if (offsetInLine == lastOffsetInLine) {
+            if (lastFoundRule == foundRule) {
 
                 // I'm very much in doubt how to solve this. What should happend here?
                 // when the same ruleis found, we need to stop else we will keep on
@@ -423,20 +408,19 @@ bool GrammarTextLexer::lexLine( int lineIdx, int& currentDocOffset )
             }
         }
         lastFoundRule = foundRule;
-
         lastOffsetInLine = offsetInLine;
     }
 
     // when there are no-multi-line spanning rules, set the independent flag
-    lineRangeList_->setIndependent( currentMultiLineRangeList_.isEmpty() && closedMultiRangesRangesRefList_.isEmpty());
+    lineRangeList_->setIndependent(currentMultiLineRangeList_.isEmpty() && closedMultiRangesRangesRefList_.isEmpty());
     lineRangeList_->squeeze();  // free unused memory
     bool result = lineRangeList_->isIndependent();
 
     // give the line to the document scopes
-    docScopes->giveLineScopedRangeList( lineIdx, lineRangeList_ );
+    docScopes->giveLineScopedRangeList(lineIdx, lineRangeList_);
     lineRangeList_ = 0;
 
-    foreach( MultiLineScopedTextRange* scopedRange, currentMultiLineRangeList_ ) {
+    foreach (MultiLineScopedTextRange* scopedRange, currentMultiLineRangeList_) {
         docScopes->giveMultiLineScopedTextRange(scopedRange);
     }
     activeScopedRangesRefList_.clear();
@@ -444,16 +428,15 @@ bool GrammarTextLexer::lexLine( int lineIdx, int& currentDocOffset )
     closedMultiRangesRangesRefList_.clear();
 
     // increase the current document offset
-    currentDocOffset += line.size(); // + 1;    // +1 because we didn't retrieve the newline
+    currentDocOffset += static_cast<size_t>(line.size()); // + 1;    // +1 because we didn't retrieve the newline
     return result;
 }
 
 
 /// This method lexes a range of line
 /// @return the last indexed offset
-void GrammarTextLexer::lexLines(int lineStart,int lineCount)
+void GrammarTextLexer::lexLines(size_t lineStart, size_t lineCount)
 {
-
     // (INIT) ALGORITHM BELOW:
     //
     // - first find the current active scopes.
@@ -471,26 +454,26 @@ void GrammarTextLexer::lexLines(int lineStart,int lineCount)
     TextDocument* doc = textDocument();
     TextDocumentScopes* docScopes = textScopes();
 
-//qlog_info() << "===== lexText(" << offset << "," << length << ") ["<<lineStart <<","<<lineEnd<<"] ======";
+    //qlog_info() << "===== lexText(" << offset << "," << length << ") ["<<lineStart <<","<<lineEnd<<"] ======";
 
     // next find all 'active' scoped ranges
-    int offsetStart = doc->offsetFromLine(lineStart);
-    activeMultiLineRangesRefList_ = docScopes->multiLineScopedRangesBetweenOffsets( offsetStart, offsetStart);
+    size_t offsetStart = doc->offsetFromLine(lineStart);
+    activeMultiLineRangesRefList_ = docScopes->multiLineScopedRangesBetweenOffsets(offsetStart, offsetStart);
 
-//    GrammarRule* activeRule = grammarRef_->mainRule();
-//    if( !activeScopedRanges.isEmpty() ) { activeRule = activeScopedRanges.last()->grammarRule(); }
-//    Q_ASSERT( activeRule );
+    //    GrammarRule* activeRule = grammarRef_->mainRule();
+    //    if( !activeScopedRanges.isEmpty() ) { activeRule = activeScopedRanges.last()->grammarRule(); }
+    //    Q_ASSERT( activeRule );
 
     // next find the rule
-    int currentDocOffset = offsetStart;
+    size_t currentDocOffset = offsetStart;
     bool independent = true;
-    for( int idx=0; idx<lineCount; ++idx) {
-        independent = lexLine( lineStart+idx, currentDocOffset  ) && independent;
+    for (size_t idx = 0; idx < lineCount; ++idx) {
+        independent = lexLine(lineStart + idx, currentDocOffset) && independent;
     }
 
     // only set the scoped offset if less and not indepdent
-    if( currentDocOffset < docScopes->lastScopedOffset() ) {
-        if( !independent ) {
+    if (currentDocOffset < docScopes->lastScopedOffset()) {
+        if (!independent) {
             docScopes->setLastScopedOffset(currentDocOffset);
             docScopes->removeScopesAfterOffset(currentDocOffset);
         }
@@ -509,7 +492,7 @@ void GrammarTextLexer::lexLines(int lineStart,int lineCount)
 ///
 /// @param beginOffset the first offset
 /// @param endOffset the last offset to
-void GrammarTextLexer::lexRange( int beginOffset, int endOffset )
+void GrammarTextLexer::lexRange(size_t beginOffset, size_t endOffset)
 {
     Q_UNUSED(beginOffset);
 
@@ -523,12 +506,12 @@ void GrammarTextLexer::lexRange( int beginOffset, int endOffset )
     }
 
     // first we need to find the correct location to start from
-    int offset = docScopes->lastScopedOffset(); //qMin( docScopes->scopedToOffset(), offset );
+    size_t offset = docScopes->lastScopedOffset(); //qMin( docScopes->scopedToOffset(), offset );
 
-    int lineStart   = doc->lineFromOffset(offset);
-    int lineEnd     = doc->lineFromOffset(endOffset) + 1;
+    size_t lineStart   = doc->lineFromOffset(offset);
+    size_t lineEnd     = doc->lineFromOffset(endOffset) + 1;
 
-    lexLines(lineStart, lineEnd-lineStart);
+    lexLines(lineStart, lineEnd - lineStart);
 }
 
 

--- a/edbee-lib/edbee/lexers/grammartextlexer.h
+++ b/edbee-lib/edbee/lexers/grammartextlexer.h
@@ -25,26 +25,26 @@ class TextGrammarRule;
 class EDBEE_EXPORT GrammarTextLexer : public TextLexer
 {
 public:
-    GrammarTextLexer( TextDocumentScopes* scopes );
+    GrammarTextLexer(TextDocumentScopes* scopes);
     virtual ~GrammarTextLexer();
 
-    virtual void textChanged( const TextBufferChange& change );
+    virtual void textChanged(const TextBufferChange& change);
 
 private:
-    virtual bool lexLine(int line, int& currentDocOffset );
+    virtual bool lexLine(size_t line, size_t& currentDocOffset );
 
 public:
-    virtual void lexLines( int line, int lineCount );
-    virtual void lexRange( int beginOffset, int endOffset );
+    virtual void lexLines(size_t line, size_t lineCount);
+    virtual void lexRange(size_t beginOffset, size_t endOffset);
 
 private:
 
     RegExp* createEndRegExp( RegExp* startRegExp, const QString &endRegExpStringIn);
 
-    void findNextGrammarRule(const QString &line, int offsetInLine, TextGrammarRule *activeRule, TextGrammarRule *&foundRule, RegExp*& foundRegExp, int& foundPosition );
-    void processCaptures( RegExp *foundRegExp, const QMap<int,QString>* foundCaptures );
+    void findNextGrammarRule(const QString &line, size_t offsetInLine, TextGrammarRule *activeRule, TextGrammarRule *&foundRule, RegExp*& foundRegExp, size_t& foundPosition);
+    void processCaptures(RegExp *foundRegExp, const QMap<size_t, QString>* foundCaptures);
 
-    TextGrammarRule* findAndApplyNextGrammarRule(int currentDocOffset, const QString& line, int& offsetInLine  );
+    TextGrammarRule* findAndApplyNextGrammarRule(size_t currentDocOffset, const QString& line, size_t& offsetInLine);
 
     MultiLineScopedTextRange* activeMultiLineRange();
     ScopedTextRange* activeScopedTextRange();

--- a/edbee-lib/edbee/models/change.cpp
+++ b/edbee-lib/edbee/models/change.cpp
@@ -252,9 +252,9 @@ Change *ChangeGroup::take(int idx)
     return change;
 }
 
-int ChangeGroup::size()
+size_t ChangeGroup::size()
 {
-    return changeList_.size();
+    return static_cast<size_t>(changeList_.size());
 }
 
 void ChangeGroup::clear(bool performDelete)
@@ -284,12 +284,12 @@ Change* ChangeGroup::takeLast()
 
 /// The total number of items in the list (excluding the group items)
 /// @return the number of items recussive (iterating) all groups
-int ChangeGroup::recursiveSize()
+size_t ChangeGroup::recursiveSize()
 {
-    int itemCount = 0;
-    for( int i=0,cnt=changeList_.size(); i<cnt; ++i ) {
+    size_t itemCount = 0;
+    for (size_t i=0, cnt=size(); i < cnt; ++i) {
         ChangeGroup* group = dynamic_cast<ChangeGroup*>(changeList_[i]);
-        if( group ) {
+        if (group) {
             itemCount += group->size();
         } else {
             ++itemCount;

--- a/edbee-lib/edbee/models/change.cpp
+++ b/edbee-lib/edbee/models/change.cpp
@@ -243,7 +243,6 @@ void ChangeGroup::giveChange(TextDocument* doc, Change* change)
 Change* ChangeGroup::at(size_t idx)
 {
     Q_ASSERT(idx < size());
-qDebug() << " idx = " << idx << ", size = " << size();
     return changeList_.at(static_cast<qsizetype>(idx));
 }
 

--- a/edbee-lib/edbee/models/change.h
+++ b/edbee-lib/edbee/models/change.h
@@ -97,8 +97,8 @@ public:
     virtual void flatten();
 
     virtual void giveChange(TextDocument* doc, Change* change);
-    virtual Change* at(int idx);
-    virtual Change* take(int idx);
+    virtual Change* at(size_t idx);
+    virtual Change* take(size_t idx);
     virtual size_t size();
     virtual void clear(bool performDelete=true);
     Change* last();

--- a/edbee-lib/edbee/models/change.h
+++ b/edbee-lib/edbee/models/change.h
@@ -100,11 +100,11 @@ public:
     virtual void giveChange( TextDocument* doc, Change* change );
     virtual Change* at( int idx );
     virtual Change* take( int idx );
-    virtual int size();
+    virtual size_t size();
     virtual void clear(bool performDelete=true);
     Change* last();
     Change* takeLast();
-    int recursiveSize();
+    size_t recursiveSize();
 
     virtual TextEditorController* controllerContext();
 

--- a/edbee-lib/edbee/models/change.h
+++ b/edbee-lib/edbee/models/change.h
@@ -17,14 +17,13 @@ class TextEditorController;
 /// A basic change
 class EDBEE_EXPORT Change {
 public:
-
     virtual ~Change();
 
     /// This method should execute the command
-    virtual void execute( TextDocument* document ) = 0;
-    virtual void revert( TextDocument* );
+    virtual void execute(TextDocument* document) = 0;
+    virtual void revert(TextDocument*);
 
-    virtual bool giveAndMerge( TextDocument* document, Change* textChange );
+    virtual bool giveAndMerge(TextDocument* document, Change* textChange);
     virtual bool canUndo();
 
     virtual bool isPersistenceRequired();
@@ -54,8 +53,8 @@ class EDBEE_EXPORT EmptyDocumentChange : public Change
 {
 public:
     virtual bool isPersistenceRequired();
-    virtual void execute( TextDocument* );
-    virtual void revert( TextDocument*);
+    virtual void execute(TextDocument*);
+    virtual void revert(TextDocument*);
     virtual QString toString();
 };
 
@@ -67,7 +66,7 @@ public:
 class EDBEE_EXPORT ControllerChange : public Change
 {
 public:
-    ControllerChange( TextEditorController* controller );
+    ControllerChange(TextEditorController* controller);
     virtual TextEditorController* controllerContext();
     virtual TextEditorController* controller();
 
@@ -83,7 +82,7 @@ private:
 class EDBEE_EXPORT ChangeGroup : public ControllerChange
 {
 public:
-    ChangeGroup( TextEditorController* controller );
+    ChangeGroup(TextEditorController* controller);
     virtual ~ChangeGroup();
 
     virtual bool isGroup();
@@ -91,15 +90,15 @@ public:
     virtual bool isDiscardable();
     virtual void groupClosed();
 
-    virtual void execute( TextDocument* document);
-    virtual void revert( TextDocument* document);
+    virtual void execute(TextDocument* document);
+    virtual void revert(TextDocument* document);
 
-    virtual bool giveAndMerge( TextDocument* document, Change* textChange );
+    virtual bool giveAndMerge(TextDocument* document, Change* textChange);
     virtual void flatten();
 
-    virtual void giveChange( TextDocument* doc, Change* change );
-    virtual Change* at( int idx );
-    virtual Change* take( int idx );
+    virtual void giveChange(TextDocument* doc, Change* change);
+    virtual Change* at(int idx);
+    virtual Change* take(int idx);
     virtual size_t size();
     virtual void clear(bool performDelete=true);
     Change* last();
@@ -113,8 +112,6 @@ public:
 private:
     QList<Change*> changeList_;     ///< A list of all actions
 };
-
-
 
 
 } // edbee

--- a/edbee-lib/edbee/models/changes/abstractrangedchange.cpp
+++ b/edbee-lib/edbee/models/changes/abstractrangedchange.cpp
@@ -15,9 +15,11 @@ AbstractRangedChange::~AbstractRangedChange()
 
 /// Adds the given amount to the offset
 /// @param amount the offset to add
-void AbstractRangedChange::addOffset(size_t amount)
+void AbstractRangedChange::addOffset(ptrdiff_t amount)
 {
-    setOffset(offset() + amount);
+    ptrdiff_t newOffset = static_cast<ptrdiff_t>(offset()) + amount;
+    Q_ASSERT(newOffset >= 0);
+    setOffset(static_cast<size_t>(newOffset));
 }
 
 

--- a/edbee-lib/edbee/models/changes/abstractrangedchange.cpp
+++ b/edbee-lib/edbee/models/changes/abstractrangedchange.cpp
@@ -15,27 +15,27 @@ AbstractRangedChange::~AbstractRangedChange()
 
 /// Adds the given amount to the offset
 /// @param amount the offset to add
-void AbstractRangedChange::addOffset(int amount)
+void AbstractRangedChange::addOffset(size_t amount)
 {
-    setOffset( offset() + amount );
+    setOffset(offset() + amount);
 }
 
 
 /// Calculates the merged length
 /// @param change the change that't being merged
-int AbstractRangedChange::getMergedDocLength(AbstractRangedChange* change)
+size_t AbstractRangedChange::getMergedDocLength(AbstractRangedChange* change)
 {
-    int result = change->docLength();
+    size_t result = change->docLength();
 
     // add the prefix of the a length
-    if( offset() < change->offset() ) {
-        result += ( change->offset()-offset() );
+    if (offset() < change->offset()) {
+        result += (change->offset()-offset());
     }
 
     // add the postfix of the length
-    int aEnd = offset() + docLength();
-    int bEnd = change->offset() + change->storedLength();
-    if( bEnd < aEnd ) {
+    size_t aEnd = offset() + docLength();
+    size_t bEnd = change->offset() + change->storedLength();
+    if (bEnd < aEnd) {
         result += aEnd - bEnd;
     }
     return result;
@@ -45,9 +45,9 @@ int AbstractRangedChange::getMergedDocLength(AbstractRangedChange* change)
 /// Calculates the merge data size, that's required for merging the given change
 /// @param change the change to merge with this change
 /// @return the size of this change
-int AbstractRangedChange::getMergedStoredLength(AbstractRangedChange* change)
+size_t AbstractRangedChange::getMergedStoredLength(AbstractRangedChange* change)
 {
-    int result = 0;
+    size_t result = 0;
 
     // we first need to 'take' the leading part of the new change
     if( change->offset() < offset() ) {
@@ -58,8 +58,16 @@ int AbstractRangedChange::getMergedStoredLength(AbstractRangedChange* change)
     result += storedLength();
 
     // then we need to append the remainer
-    int delta = offset()-change->offset();
-    int remainerOffset = docLength() + delta;
+
+    // int delta = offset() - change->offset();
+    // int remainerOffset = docLength() + delta;
+    size_t remainerOffset = docLength();
+    if (offset() > change->offset()) {
+        remainerOffset += offset() - change->offset();
+    } else {
+        remainerOffset -= change->offset() - offset();
+    }
+
     if( 0 <= remainerOffset && remainerOffset < change->storedLength()  ) {
         result += change->storedLength() - remainerOffset;
     }
@@ -68,12 +76,12 @@ int AbstractRangedChange::getMergedStoredLength(AbstractRangedChange* change)
 
 
 /// Per forms a memcopy or zero fills the given area
-static void memcopy_or_zerofill( void* target, void* source, size_t size)
+static void memcopy_or_zerofill(void* target, void* source, size_t size)
 {
-    if( source ) {
-        memcpy( target, source, size);
+    if (source) {
+        memcpy(target, source, size);
     } else {
-        memset( target, 0, size);
+        memset(target, 0, size);
     }
 }
 
@@ -86,48 +94,56 @@ static void memcopy_or_zerofill( void* target, void* source, size_t size)
 /// @param changeData pointer to the of the other change data (this can be a 0 pointer!, which results in 0-filling the target)
 /// @param change the other change of the data to merge
 /// @param itemSize the size of single item
-void AbstractRangedChange::mergeStoredDataViaMemcopy(void* targetData, void* data, void* changeData, AbstractRangedChange* change, int itemSize )
+void AbstractRangedChange::mergeStoredDataViaMemcopy(void* targetData, void* data, void* changeData, AbstractRangedChange* change, size_t itemSize )
 {
     char* target = (char*)targetData;
 
     // we first need to 'take' the leading part of the new change
-    if( change->offset() < offset() ) {
-        int size = itemSize * (offset() - change->offset() );
+    if (change->offset() < offset()) {
+        size_t size = itemSize * (offset() - change->offset());
         memcopy_or_zerofill( target, changeData, size );
         target += size;
     }
 
     // copy the other text
-    memcopy_or_zerofill( target, data, itemSize * storedLength() );
+    memcopy_or_zerofill(target, data, itemSize * storedLength());
     target += itemSize * storedLength() ;
 
     // then we need to append the remainer
-    int delta = offset()-change->offset();
-    int remainerOffset = docLength() + delta;
-    if( 0 <= remainerOffset && remainerOffset < change->storedLength()  ) {
-        memcopy_or_zerofill( target, changeData ? ((char*)changeData) + (remainerOffset*itemSize) : 0, (change->storedLength()-remainerOffset) * itemSize  );
+
+    // int delta = offset() - change->offset();
+    // int remainerOffset = docLength() + delta;
+    size_t remainerOffset = docLength();
+    if (offset() > change->offset()) {
+        remainerOffset += offset() - change->offset();
+    } else {
+        remainerOffset -= change->offset() - offset();
+    }
+
+    if (0 <= remainerOffset && remainerOffset < change->storedLength()) {
+        memcopy_or_zerofill(target, changeData ? ((char*)changeData) + (remainerOffset * itemSize) : 0, (change->storedLength() - remainerOffset) * itemSize);
     }
 }
 
 
-/// This method merges the change
+/// merges a changes
 /// @param document the document to merges
 /// @param change the change change to merge
-bool AbstractRangedChange::merge( AbstractRangedChange* change )
+bool AbstractRangedChange::merge(AbstractRangedChange* change)
 {
     // overlap is a bit harder
-    if( isOverlappedBy(change) || isTouchedBy(change) ) {
+    if (isOverlappedBy(change) || isTouchedBy(change)) {
 
         // build the new sizes and offsets
-        int newOffset = qMin( offset(), change->offset() );
-        int newLength = getMergedDocLength(change);
+        size_t newOffset = qMin(offset(), change->offset());
+        size_t newLength = getMergedDocLength(change);
 
         // merge the data
-        mergeStoredData( change );
+        mergeStoredData(change);
 
         // when the data is meged assign the new dimensions
-        setDocLength( newLength );
-        setOffset( newOffset );
+        setDocLength(newLength);
+        setOffset(newOffset);
         delete change;
         return true;
     }
@@ -135,7 +151,7 @@ bool AbstractRangedChange::merge( AbstractRangedChange* change )
 }
 
 
-/// This method checks if this textchange is overlapped by the second textchange
+/// Checks if this textchange is overlapped by the second textchange
 /// overlapping is an exclusive overlap, which means the changes are really on top of eachother
 /// to test if the changes are touching use isTouchedBy
 /// @param secondChange the other change to compare it to
@@ -143,8 +159,8 @@ bool AbstractRangedChange::merge( AbstractRangedChange* change )
 bool AbstractRangedChange::isOverlappedBy(AbstractRangedChange* secondChange)
 {
     return
-    ( offset() < ( secondChange->offset() + secondChange->docLength() ) &&  secondChange->offset() < (offset() + docLength()) )
-    || (  offset() < ( secondChange->offset() + secondChange->storedLength() ) && secondChange->offset() < (offset() + docLength())  )
+    (offset() < (secondChange->offset() + secondChange->docLength()) && secondChange->offset() < (offset() + docLength()))
+      || (offset() < (secondChange->offset() + secondChange->storedLength()) && secondChange->offset() < (offset() + docLength()))
     ;
 }
 
@@ -155,10 +171,10 @@ bool AbstractRangedChange::isOverlappedBy(AbstractRangedChange* secondChange)
 /// @return true if the changes overlap
 bool AbstractRangedChange::isTouchedBy(AbstractRangedChange* secondChange)
 {
-    return offset() == (secondChange->offset() + secondChange->docLength() )
+    return offset() == (secondChange->offset() + secondChange->docLength())
         || (offset() + docLength()) == secondChange->offset()
         // Delete operation should be supported
-        || ( secondChange->docLength() < secondChange->storedLength() &&  offset() == (secondChange->offset() + secondChange->storedLength() ) )
+        || (secondChange->docLength() < secondChange->storedLength() &&  offset() == (secondChange->offset() + secondChange->storedLength()))
         // delete touch (Should we add those length < newlength condition!??)
         //|| ( ( length() < newLength() ) && (offset() + newLength()) == secondChange->offset() )
             ;

--- a/edbee-lib/edbee/models/changes/abstractrangedchange.h
+++ b/edbee-lib/edbee/models/changes/abstractrangedchange.h
@@ -17,22 +17,21 @@ class EDBEE_EXPORT AbstractRangedChange : public Change
 public:
     virtual ~AbstractRangedChange();
 
-    /// this method should return the offset of the change
-    virtual int offset() const = 0;
+    /// Returns the offset of the change
+    virtual size_t offset() const = 0;
 
-    /// this method should set the offset
-    virtual void setOffset( int value ) = 0;
-    void addOffset( int amount );
+    /// Set the offset
+    virtual void setOffset(size_t value) = 0;
+    void addOffset(size_t amount);
 
-    /// this method should set the old length
-    virtual void setDocLength( int value ) = 0;
+    /// Set the old length
+    virtual void setDocLength(size_t value) = 0;
 
-    /// this method should return the length in the document
-    virtual int docLength() const = 0;
+    /// Return the length in the document
+    virtual size_t docLength() const = 0;
 
-    /// this method should return the length of this item in memory
-    virtual int storedLength() const = 0;
-
+    /// Returns the length of this item in memory
+    virtual size_t storedLength() const = 0;
 
 protected:
 
@@ -42,18 +41,16 @@ protected:
     /// QString newText;
     /// newText.resize( calculateMergeDataSize( change) );
     /// mergeData( newText.data(), text_.data(), singleTextChange->text_.data(), change, sizeof(QChar) );
-    virtual void mergeStoredData( AbstractRangedChange* change ) = 0;
+    virtual void mergeStoredData(AbstractRangedChange* change) = 0;
 
-
-    int getMergedDocLength(AbstractRangedChange* change);
-    int getMergedStoredLength(AbstractRangedChange* change);
-    void mergeStoredDataViaMemcopy(void* targetData, void* data, void* changeData, AbstractRangedChange* change, int itemSize );
-    bool merge( AbstractRangedChange* change );
+    size_t getMergedDocLength(AbstractRangedChange* change);
+    size_t getMergedStoredLength(AbstractRangedChange* change);
+    void mergeStoredDataViaMemcopy(void* targetData, void* data, void* changeData, AbstractRangedChange* change, size_t itemSize);
+    bool merge(AbstractRangedChange* change);
 
 public:
     bool isOverlappedBy( AbstractRangedChange* secondChange );
     bool isTouchedBy( AbstractRangedChange* secondChange );
-
 };
 
 

--- a/edbee-lib/edbee/models/changes/abstractrangedchange.h
+++ b/edbee-lib/edbee/models/changes/abstractrangedchange.h
@@ -22,7 +22,7 @@ public:
 
     /// Set the offset
     virtual void setOffset(size_t value) = 0;
-    void addOffset(size_t amount);
+    void addOffset(ptrdiff_t amount);
 
     /// Set the old length
     virtual void setDocLength(size_t value) = 0;

--- a/edbee-lib/edbee/models/changes/linedatachange.cpp
+++ b/edbee-lib/edbee/models/changes/linedatachange.cpp
@@ -10,41 +10,46 @@
 
 namespace edbee {
 
-LineDataChange::LineDataChange( int line, int field )
+LineDataChange::LineDataChange(size_t line, size_t field)
     : line_(line)
     , field_(field)
-    , lineData_( 0 )
+    , lineData_(nullptr)
 {
 }
+
 
 LineDataChange::~LineDataChange()
 {
     delete lineData_;
 }
 
-void LineDataChange::giveLineData(TextLineData *lineData)
+
+void LineDataChange::giveLineData(TextLineData* lineData)
 {
     lineData_ = lineData;
 }
 
+
 void LineDataChange::execute(TextDocument* doc)
 {
-    changeLineData( doc );
+    changeLineData(doc);
 }
+
 
 void LineDataChange::revert(TextDocument* doc)
 {
-    changeLineData( doc );
+    changeLineData(doc);
 }
+
 
 /// merge is never a problem, simply
 bool LineDataChange::giveAndMerge(TextDocument* document, Change* textChange)
 {
-    Q_UNUSED( document );
-    Q_UNUSED( textChange );
-    LineDataChange* change =  dynamic_cast<LineDataChange*>(lineData_);
-    if( change ) {
-        if( line_ == change->line_ && field_ == change->field_ ) {
+    Q_UNUSED(document);
+    Q_UNUSED(textChange);
+    LineDataChange* change = dynamic_cast<LineDataChange*>(lineData_);
+    if (change) {
+        if (line_ == change->line_ && field_ == change->field_) {
             delete textChange;
             return true;
         }
@@ -52,11 +57,16 @@ bool LineDataChange::giveAndMerge(TextDocument* document, Change* textChange)
     return false;
 }
 
+
 /// line is moved with the given delta
-void LineDataChange::applyLineDelta(int line, int length, int newLength)
+void LineDataChange::applyLineDelta(size_t line, size_t length, size_t newLength)
 {
-    if( line <= line_ ) {
-        line_ += newLength - length;
+    if (line <= line_) {
+        if (newLength > length) {
+            line_ += newLength - length;
+        } else {
+            line_ -= length - newLength;
+        }
     }
 }
 
@@ -71,38 +81,37 @@ QString LineDataChange::toString()
 /// The change line data
 void LineDataChange::changeLineData(TextDocument* doc)
 {
-    TextLineData* oldLineData = doc->lineDataManager()->take( line_, field_ );
-    doc->lineDataManager()->give( line_, field_, lineData_ );
+    TextLineData* oldLineData = doc->lineDataManager()->take(line_, field_);
+    doc->lineDataManager()->give(line_, field_, lineData_);
     lineData_ = oldLineData;
 }
 
 
 /// Returns the line index
-int LineDataChange::line() const
+size_t LineDataChange::line() const
 {
     return line_;
 }
 
 
 /// Sets the line of this change
-void LineDataChange::setLine(int line)
+void LineDataChange::setLine(size_t line)
 {
     line_ = line;
 }
 
 
 /// retursn the field index of this line-data item
-int LineDataChange::field() const
+size_t LineDataChange::field() const
 {
     return field_;
 }
 
 
 /// sets the field position
-void LineDataChange::setField(int field)
+void LineDataChange::setField(size_t field)
 {
     field_ = field;
 }
-
 
 } // edbee

--- a/edbee-lib/edbee/models/changes/linedatachange.h
+++ b/edbee-lib/edbee/models/changes/linedatachange.h
@@ -16,35 +16,35 @@ class TextLineData;
 class EDBEE_EXPORT LineDataChange : public Change
 {
 public:
-    LineDataChange(int line, int field);
+    LineDataChange(size_t line, size_t field);
     virtual ~LineDataChange();
 
-    void giveLineData( TextLineData* lineData );
+    void giveLineData(TextLineData* lineData);
 
     virtual void execute(TextDocument* document);
     virtual void revert(TextDocument* doc);
 
     virtual bool giveAndMerge(TextDocument* document, Change* textChange );
 
-    virtual void applyLineDelta( int line, int length, int newLength );
+    virtual void applyLineDelta(size_t line, size_t length, size_t newLength);
 
     virtual QString toString();
 
-    int line() const;
-    void setLine( int line );
+    size_t line() const;
+    void setLine(size_t line);
 
-    int field() const;
-    void setField( int field );
-
-private:
-    void changeLineData( TextDocument* doc );
+    size_t field() const;
+    void setField(size_t field);
 
 private:
 
-    int line_;                      ///< The line number
-    int field_;                     ///< The field index
+    void changeLineData(TextDocument* doc);
+
+private:
+
+    size_t line_;                   ///< The line number
+    size_t field_;                  ///< The field index
     TextLineData* lineData_;        ///< The text-line data
-
 };
 
 } // edbee

--- a/edbee-lib/edbee/models/changes/linedatalistchange.cpp
+++ b/edbee-lib/edbee/models/changes/linedatalistchange.cpp
@@ -30,8 +30,8 @@ LineDataListChange::LineDataListChange(TextLineDataManager* manager, size_t line
 /// Destructs the linedata textchange
 LineDataListChange::~LineDataListChange()
 {
-    if( oldListList_ ) {
-        for (size_t i=0; i < contentLength_; ++i) {
+    if (oldListList_) {
+        for (size_t i = 0; i < contentLength_; ++i) {
             TextLineDataList* list = oldListList_[i];
             if (list) {
                 list->destroy(managerRef_);
@@ -131,12 +131,12 @@ void LineDataListChange::mergeStoredData(AbstractRangedChange* change)
             TextLineDataList* list = lineTextChange->oldListList_[i];
 
             // find it in this change
-            for( int j=0; j<newOldListSize && !found; ++j ) {
-                found = ( list == newOldListList_[j] );
+            for (size_t j = 0; j < newOldListSize && !found; ++j) {
+                found = (list == newOldListList_[j]);
             }
 
             // delete the old list if not found
-            if( !found ) {
+            if (!found) {
                 delete list;
             }
         }
@@ -173,7 +173,7 @@ QString LineDataListChange::toString()
 
 
 /// Returns the line
-size_t LineDataListChange::offset () const
+size_t LineDataListChange::offset() const
 {
     return offset_;
 }

--- a/edbee-lib/edbee/models/changes/linedatalistchange.cpp
+++ b/edbee-lib/edbee/models/changes/linedatalistchange.cpp
@@ -12,13 +12,12 @@ namespace edbee {
 
 class TextLineDataManager;
 
-
 /// The line data text change constructor
 /// @param manager the line data manager
 /// @param line the starting line of the change
 /// @param length the number of lines affected
 /// @param newLength the new number of lines
-LineDataListChange::LineDataListChange( TextLineDataManager* manager, int line, int length, int newLength )
+LineDataListChange::LineDataListChange(TextLineDataManager* manager, size_t line, size_t length, size_t newLength)
     : managerRef_(manager)
     , offset_(line)
     , docLength_(newLength)
@@ -32,15 +31,15 @@ LineDataListChange::LineDataListChange( TextLineDataManager* manager, int line, 
 LineDataListChange::~LineDataListChange()
 {
     if( oldListList_ ) {
-        for( int i=0; i < contentLength_; ++i ) {
+        for (size_t i=0; i < contentLength_; ++i) {
             TextLineDataList* list = oldListList_[i];
-            if( list ) {
+            if (list) {
                 list->destroy(managerRef_);
                 delete list;
             }
         }
         delete[] oldListList_;
-        oldListList_ = 0;
+        oldListList_ = nullptr;
     }
 }
 
@@ -51,11 +50,11 @@ void LineDataListChange::execute(TextDocument* document)
 {
     Q_UNUSED(document);
     // backup the old items
-    for( int i=0; i<contentLength_; ++i ){
-        TextLineDataList* list = managerRef_->takeList(offset_+i);  // take the ownership of the list
-        if( list ) {
+    for (size_t i=0; i<contentLength_; ++i) {
+        TextLineDataList* list = managerRef_->takeList(offset_ + i);  // take the ownership of the list
+        if (list) {
             // jit allocation of the list!
-            if( !oldListList_ ) {
+            if (!oldListList_) {
                 oldListList_= new TextLineDataList*[contentLength_](); /// new X[]() => fills it with zero's
             }
             oldListList_[i] = list;
@@ -63,7 +62,7 @@ void LineDataListChange::execute(TextDocument* document)
     }
 
     // replace all old items with 0 values
-    managerRef_->fillWithEmpty( offset_, contentLength_, docLength_ );
+    managerRef_->fillWithEmpty(offset_, contentLength_, docLength_);
 }
 
 
@@ -72,12 +71,12 @@ void LineDataListChange::execute(TextDocument* document)
 void LineDataListChange::revert(TextDocument* doc)
 {
     Q_UNUSED(doc);
-    if( oldListList_ ) {
-        managerRef_->replace( offset_, docLength_, oldListList_, contentLength_ );
+    if (oldListList_) {
+        managerRef_->replace(offset_, docLength_, oldListList_, contentLength_);
         delete oldListList_;
-        oldListList_ = 0;
+        oldListList_ = nullptr;
     } else {
-        managerRef_->fillWithEmpty( offset_, docLength_, contentLength_ );
+        managerRef_->fillWithEmpty(offset_, docLength_, contentLength_);
     }
 }
 
@@ -87,14 +86,14 @@ void LineDataListChange::revert(TextDocument* doc)
 void LineDataListChange::mergeStoredData(AbstractRangedChange* change)
 {
     LineDataListChange* lineTextChange = dynamic_cast<LineDataListChange*>(change);
-    Q_ASSERT(lineTextChange );  // this shouldn't happen
-    if( !lineTextChange ) return;
+    Q_ASSERT(lineTextChange);  // this shouldn't happen
+    if (!lineTextChange) return;
 
     // calculate the new size
-    int newOldListSize = getMergedStoredLength( change);// qlog_info() << "CALCULATED: " << newOldListSize ;
+    size_t newOldListSize = getMergedStoredLength(change);
 
     // no old data, we don't need to store anthing
-    if( this->oldListList_ == 0 && lineTextChange->oldListList_ == 0 ) {
+    if (this->oldListList_ == nullptr && lineTextChange->oldListList_ == nullptr) {
         contentLength_ = newOldListSize;    // also store the content list
         return;
     }
@@ -103,32 +102,31 @@ void LineDataListChange::mergeStoredData(AbstractRangedChange* change)
     TextLineDataList**  newOldListList_ = new TextLineDataList*[newOldListSize];
 
     // merge the stuff
-    mergeStoredDataViaMemcopy( newOldListList_, oldListList_, lineTextChange->oldListList_, change, sizeof(TextLineDataList*) );
+    mergeStoredDataViaMemcopy(newOldListList_, oldListList_, lineTextChange->oldListList_, change, sizeof(TextLineDataList*));
 
     // we need to delete all items that aren't used anymore
-    if( oldListList_ ) {
-        for( int i=0; i<contentLength_; ++i ) {
+    if (oldListList_) {
+        for (size_t i = 0; i < contentLength_; ++i) {
             bool found=false;
             TextLineDataList* list = oldListList_[i];
 
             // find it in this change
-            for( int j=0; j<newOldListSize && !found; ++j ) {
-                found = ( list == newOldListList_[j] );
+            for (size_t j = 0; j < newOldListSize && !found; ++j ) {
+                found = (list == newOldListList_[j]);
             }
 
             // delete the old list if not found
-            if( !found ) {
-//                list->destroy( // manager WTF !);
+            if (!found) {
                 delete list;
             }
         }
         delete[] oldListList_;
-        oldListList_ = 0;
+        oldListList_ = nullptr;
     }
 
     // same for other change
-    if( lineTextChange->oldListList_ ) {
-        for( int i=0; i<lineTextChange->contentLength_; ++i ) {
+    if (lineTextChange->oldListList_) {
+        for (size_t i = 0; i < lineTextChange->contentLength_; ++i) {
             bool found=false;
             TextLineDataList* list = lineTextChange->oldListList_[i];
 
@@ -139,15 +137,13 @@ void LineDataListChange::mergeStoredData(AbstractRangedChange* change)
 
             // delete the old list if not found
             if( !found ) {
-//                list->destroy( // manager WTF !);
                 delete list;
             }
         }
         delete[] lineTextChange->oldListList_;
-        lineTextChange->oldListList_ = 0;
+        lineTextChange->oldListList_ = nullptr;
     }
 
-/// TODO: Know how and what to delete
     oldListList_ = newOldListList_;
     contentLength_ = newOldListSize;    // also store the content list
 }
@@ -161,9 +157,9 @@ bool LineDataListChange::giveAndMerge(TextDocument* document, Change* textChange
 {
     Q_UNUSED(document);
     Q_UNUSED(textChange);
-    LineDataListChange* change = dynamic_cast<LineDataListChange*>( textChange );
-    if( change ) {
-        return merge( change );
+    LineDataListChange* change = dynamic_cast<LineDataListChange*>(textChange);
+    if (change) {
+        return merge(change);
     }
     return false;
 }
@@ -177,37 +173,36 @@ QString LineDataListChange::toString()
 
 
 /// Returns the line
-int LineDataListChange::offset () const
+size_t LineDataListChange::offset () const
 {
     return offset_;
 }
 
 
 /// Sets the new offset
-void LineDataListChange::setOffset(int value)
+void LineDataListChange::setOffset(size_t value)
 {
     offset_ = value;
 }
 
 
 /// Retursn the length in the document/data
-int LineDataListChange::docLength() const
+size_t LineDataListChange::docLength() const
 {
     return docLength_;
 }
 
 
-/// This method sets the old length
+/// Sets the old length
 /// @param value the new old-length value
-void LineDataListChange::setDocLength(int value)
+void LineDataListChange::setDocLength(size_t value)
 {
     docLength_ = value;
 }
 
 
-
 /// The lengt of the content in this object
-int LineDataListChange::storedLength() const
+size_t LineDataListChange::storedLength() const
 {
     return contentLength_;
 }
@@ -221,13 +216,12 @@ TextLineDataList**LineDataListChange::oldListList()
 
 
 /// retursn the length of th eold list list
-int LineDataListChange::oldListListLength()
+size_t LineDataListChange::oldListListLength()
 {
     if( oldListList_ ) {
         return contentLength_;
     }
     return 0;
 }
-
 
 } // edbee

--- a/edbee-lib/edbee/models/changes/linedatalistchange.h
+++ b/edbee-lib/edbee/models/changes/linedatalistchange.h
@@ -26,7 +26,7 @@ public:
     virtual void revert(TextDocument* doc);
 
     virtual void mergeStoredData(AbstractRangedChange* change);
-    virtual bool giveAndMerge(TextDocument* document, Change* textChange );
+    virtual bool giveAndMerge(TextDocument* document, Change* textChange);
 
     virtual QString toString();
 

--- a/edbee-lib/edbee/models/changes/linedatalistchange.h
+++ b/edbee-lib/edbee/models/changes/linedatalistchange.h
@@ -19,7 +19,7 @@ class TextLineDataList;
 class EDBEE_EXPORT LineDataListChange : public AbstractRangedChange
 {
 public:
-    LineDataListChange( TextLineDataManager* manager, int offset , int lenght, int newLength );
+    LineDataListChange(TextLineDataManager* manager, size_t offset, size_t lenght, size_t newLength);
     virtual ~LineDataListChange();
 
     virtual void execute(TextDocument* document);
@@ -30,25 +30,25 @@ public:
 
     virtual QString toString();
 
-    int offset() const;
-    void setOffset( int value );
+    size_t offset() const;
+    void setOffset(size_t value);
 
-    virtual int docLength() const;
-    void setDocLength( int value );
+    virtual size_t docLength() const;
+    void setDocLength(size_t value);
 
-    virtual int storedLength() const;
+    virtual size_t storedLength() const;
 
     TextLineDataList** oldListList();
-    int oldListListLength();
+    size_t oldListListLength();
 
 private:
 
     TextLineDataManager* managerRef_;         ///< A reference to the manager
-    int offset_;                              ///< The line number start
-    int docLength_;                           ///< The number of new items (they all will be 0)
+    size_t offset_;                           ///< The line number start
+    size_t docLength_;                        ///< The number of new items (they all will be 0)
 
     TextLineDataList** oldListList_;          /// The lists of items (old items)
-    int contentLength_;                       ///< The number of elements in the oldListList
+    size_t contentLength_;                    ///< The number of elements in the oldListList
 };
 
 } // edbee

--- a/edbee-lib/edbee/models/changes/mergablechangegroup.cpp
+++ b/edbee-lib/edbee/models/changes/mergablechangegroup.cpp
@@ -307,40 +307,44 @@ void MergableChangeGroup::giveChange(TextDocument* doc, Change* change)
 
 
 ///returns the textchange at the given index
-Change* MergableChangeGroup::at(int idx)
+Change* MergableChangeGroup::at(size_t idx)
 {
+    qsizetype qidx = static_cast<qsizetype>(idx);
+
     // plain text changes
-    if( idx < textChangeList_.size() ) {
-        return textChangeList_.at(idx);
+    if (qidx < textChangeList_.size()) {
+        return textChangeList_.at(qidx);
     }
     // line-data changes
-    idx -= textChangeList_.size();
-    if( idx < lineDataTextChangeList_.size() ) {
-        return lineDataTextChangeList_.at(idx);
+    qidx -= textChangeList_.size();
+    if (qidx < lineDataTextChangeList_.size()) {
+        return lineDataTextChangeList_.at(qidx);
     }
     // other changes
-    idx -= lineDataTextChangeList_.size();
-    Q_ASSERT(idx < miscChangeList_.size() );
-    return miscChangeList_.at(idx);
+    qidx -= lineDataTextChangeList_.size();
+    Q_ASSERT(qidx < miscChangeList_.size() );
+    return miscChangeList_.at(qidx);
 }
 
 
 /// Takes the given item
-Change*MergableChangeGroup::take(int idx)
+Change*MergableChangeGroup::take(size_t idx)
 {
+    qsizetype qidx = static_cast<qsizetype>(idx);
+
     // plain text changes
-    if( idx < textChangeList_.size() ) {
-        return textChangeList_.takeAt(idx);
+    if (qidx < textChangeList_.size()) {
+        return textChangeList_.takeAt(qidx);
     }
     // line-data changes
-    idx -= textChangeList_.size();
-    if( idx < lineDataTextChangeList_.size() ) {
-        return lineDataTextChangeList_.takeAt(idx);
+    qidx -= textChangeList_.size();
+    if (qidx < lineDataTextChangeList_.size()) {
+        return lineDataTextChangeList_.takeAt(qidx);
     }
     // other changes
-    idx -= lineDataTextChangeList_.size();
-    Q_ASSERT(idx < miscChangeList_.size() );
-    return miscChangeList_.takeAt(idx);
+    qidx -= lineDataTextChangeList_.size();
+    Q_ASSERT(qidx < miscChangeList_.size());
+    return miscChangeList_.takeAt(qidx);
 }
 
 

--- a/edbee-lib/edbee/models/changes/mergablechangegroup.cpp
+++ b/edbee-lib/edbee/models/changes/mergablechangegroup.cpp
@@ -20,11 +20,11 @@ namespace edbee {
 /// The default complex textchange constructor
 MergableChangeGroup::MergableChangeGroup(TextEditorController* controller)
     : ChangeGroup(controller)
-    , previousSelection_(0)
-    , newSelection_(0)
+    , previousSelection_(nullptr)
+    , newSelection_(nullptr)
 {
-    if( controller ) {
-       previousSelection_ = new TextRangeSet( *( controller->textSelection() ) );
+    if (controller) {
+       previousSelection_ = new TextRangeSet(*(controller->textSelection()));
     }
 }
 
@@ -48,7 +48,7 @@ bool MergableChangeGroup::isDiscardable()
 /// the group is closed, we must 'store' the selection
 void MergableChangeGroup::groupClosed()
 {
-    if( controller() ) {
+    if (controller()) {
         delete newSelection_;
         newSelection_ = new TextRangeSet( *(controller()->textSelection() ) ) ;
     }
@@ -345,9 +345,9 @@ Change*MergableChangeGroup::take(int idx)
 
 
 /// returns the number of elements
-int MergableChangeGroup::size()
+size_t MergableChangeGroup::size()
 {
-    return textChangeList_.size() + lineDataTextChangeList_.size() + miscChangeList_.size();
+    return static_cast<size_t>(textChangeList_.size() + lineDataTextChangeList_.size() + miscChangeList_.size());
 }
 
 

--- a/edbee-lib/edbee/models/changes/mergablechangegroup.h
+++ b/edbee-lib/edbee/models/changes/mergablechangegroup.h
@@ -51,7 +51,7 @@ public:
     virtual void giveChange( TextDocument* doc, Change* change );
     virtual Change* at( int idx );
     virtual Change* take( int idx );
-    virtual int size();
+    virtual size_t size();
     virtual void clear(bool performDelete=true);
 
     /// This method tries to merge the given change with the other change

--- a/edbee-lib/edbee/models/changes/mergablechangegroup.h
+++ b/edbee-lib/edbee/models/changes/mergablechangegroup.h
@@ -23,7 +23,7 @@ class TextRangeSet;
 class EDBEE_EXPORT MergableChangeGroup : public ChangeGroup
 {
 public:
-    MergableChangeGroup( TextEditorController* controller );
+    MergableChangeGroup(TextEditorController* controller);
     virtual ~MergableChangeGroup();
 
     // this change cannot be optimized away
@@ -34,21 +34,19 @@ public:
     virtual void revert(TextDocument* document);
 
 private:
-    void addOffsetDeltaToChanges( QList<AbstractRangedChange*>& changes, int fromIndex, int delta );
-    int findInsertIndexForOffset( QList<AbstractRangedChange*>& changes, int offset );
-    int mergeChange( QList<AbstractRangedChange*>& changes, TextDocument* doc, AbstractRangedChange* newChange, int& delta );
-    void inverseMergeRemainingOverlappingChanges( QList<AbstractRangedChange*>& changes, TextDocument* doc, int mergedAtIndex, int orgStartOffset, int orgEndOffset , int delta);
+    void addOffsetDeltaToChanges(QList<AbstractRangedChange*>& changes, size_t fromIndex, ptrdiff_t delta);
+    qsizetype findInsertIndexForOffset(QList<AbstractRangedChange*>& changes, size_t offset);
+    qsizetype mergeChange(QList<AbstractRangedChange*>& changes, TextDocument* doc, AbstractRangedChange* newChange, ptrdiff_t& delta);
+    void inverseMergeRemainingOverlappingChanges(QList<AbstractRangedChange*>& changes, TextDocument* doc, qsizetype mergedAtIndex, size_t orgStartOffset, size_t orgEndOffset, ptrdiff_t delta);
 
-    void giveChangeToList(  QList<AbstractRangedChange*>& changes, TextDocument* doc, AbstractRangedChange* change );
-    void giveAndMergeChangeToList(  QList<AbstractRangedChange*>& changes, TextDocument* doc, AbstractRangedChange* change );
-
-//TODO:     void giveAbstractRangedTextChange( TextDocument* doc, QList<AbstractRangedTextChange* changeList>& changes, AbstractRangedTextChange* change );
+    void giveChangeToList(QList<AbstractRangedChange*>& changes, TextDocument* doc, AbstractRangedChange* change);
+    void giveAndMergeChangeToList(QList<AbstractRangedChange*>& changes, TextDocument* doc, AbstractRangedChange* change);
 
 public:
-    void giveSingleTextChange( TextDocument* doc, TextChange* change);
-    void giveLineDataListTextChange( TextDocument* doc, LineDataListChange* change );
+    void giveSingleTextChange(TextDocument* doc, TextChange* change);
+    void giveLineDataListTextChange(TextDocument* doc, LineDataListChange* change);
 
-    virtual void giveChange( TextDocument* doc, Change* change );
+    virtual void giveChange(TextDocument* doc, Change* change);
     virtual Change* at(size_t idx);
     virtual Change* take(size_t idx);
     virtual size_t size();
@@ -59,20 +57,20 @@ public:
     /// It's the choice of this merge operation if the execution is required
     /// @param textChange the textchange to merge
     /// @return true if the merge has been successfull. False if nothing has been merged and executed
-    virtual bool giveAndMerge( TextDocument* document, Change* textChange );
+    virtual bool giveAndMerge(TextDocument* document, Change* textChange);
 
     virtual QString toString();
     QString toSingleTextChangeTestString();
 
-    void moveChangesFromGroup( TextDocument* doc, ChangeGroup* group);
+    void moveChangesFromGroup(TextDocument* doc, ChangeGroup* group);
 
 protected:
 
-    bool mergeAsGroup( TextDocument* document, Change* textChange );
-    bool mergeAsSelection( TextDocument* document, Change* textChange );
+    bool mergeAsGroup(TextDocument* document, Change* textChange);
+    bool mergeAsSelection(TextDocument* document, Change* textChange);
 
-    void compressTextChanges( TextDocument* document );
-    void compressChanges( TextDocument* document );
+    void compressTextChanges(TextDocument* document);
+    void compressChanges(TextDocument* document);
 
 private:
 
@@ -80,10 +78,8 @@ private:
     QList<LineDataListChange*> lineDataTextChangeList_;     ///<The list with liendata text changes
     QList<Change*> miscChangeList_;                         ///< Other textchanges
 
-
     TextRangeSet* previousSelection_;
     TextRangeSet* newSelection_;
-
 };
 
 } // edbee

--- a/edbee-lib/edbee/models/changes/mergablechangegroup.h
+++ b/edbee-lib/edbee/models/changes/mergablechangegroup.h
@@ -49,8 +49,8 @@ public:
     void giveLineDataListTextChange( TextDocument* doc, LineDataListChange* change );
 
     virtual void giveChange( TextDocument* doc, Change* change );
-    virtual Change* at( int idx );
-    virtual Change* take( int idx );
+    virtual Change* at(size_t idx);
+    virtual Change* take(size_t idx);
     virtual size_t size();
     virtual void clear(bool performDelete=true);
 

--- a/edbee-lib/edbee/models/changes/textchange.cpp
+++ b/edbee-lib/edbee/models/changes/textchange.cpp
@@ -16,7 +16,7 @@ namespace edbee {
 /// @param length, the length of the change
 /// @param text , the new text
 /// @param executed, a boolean (mainly used for testing) to mark this change as exected
-TextChange::TextChange(int offset, int length, const QString& text)
+TextChange::TextChange(size_t offset, size_t length, const QString& text)
     : offset_(offset)
     , length_(length)
     , text_(text)
@@ -46,35 +46,15 @@ void TextChange::revert(TextDocument* document)
 }
 
 
-/// This method merges the old data with the new data
+/// Merges the old data with the new data
 /// @apram change the data to merge with
 void TextChange::mergeStoredData(AbstractRangedChange* change)
 {
     TextChange* singleTextChange = dynamic_cast<TextChange*>(change);
 
     QString newText;
-    newText.resize( getMergedStoredLength( change) );
-    mergeStoredDataViaMemcopy( newText.data(), text_.data(), singleTextChange->text_.data(), change, sizeof(QChar) );
-    /*
-      QString newText;
-      // we first need to 'take' the leading part of the new change
-      if( change->offset() < offset() ) {
-          newText.append( change->oldText(document).mid(0, offset() - change->offset() ) );
-      }
-
-      newText.append(oldText(document));
-
-      // then we need to append the remainer
-      int delta = offset()-change->offset();
-      int remainerOffset = newLength() + delta;
-      if( remainerOffset >= 0 ) {
-          if( remainerOffset < change->oldLength() ) {
-              //Q_ASSERT(false);    // need to figure out if this works
-              newText.append( change->oldText( document  ).mid(remainerOffset ) );
-          }
-      }
-
-    */
+    newText.resize( getMergedStoredLength(change));
+    mergeStoredDataViaMemcopy(newText.data(), text_.data(), singleTextChange->text_.data(), change, sizeof(QChar));
     text_ = newText;
 }
 
@@ -87,10 +67,10 @@ void TextChange::mergeStoredData(AbstractRangedChange* change)
 /// @return true on success else false
 bool TextChange::giveAndMerge( TextDocument* document, Change* textChange)
 {
-    Q_UNUSED( document );
-    TextChange* change = dynamic_cast<TextChange*>( textChange );
-    if( change ) {
-        return merge( change );
+    Q_UNUSED(document);
+    TextChange* change = dynamic_cast<TextChange*>(textChange);
+    if (change) {
+        return merge(change);
     }
     return false;
 }
@@ -106,7 +86,7 @@ QString TextChange::toString()
 
 /// Return the offset
 /// @return the offset of the change
-int TextChange::offset() const
+size_t TextChange::offset() const
 {
     return offset_;
 }
@@ -114,29 +94,29 @@ int TextChange::offset() const
 
 /// set the new offset
 /// @param offset the new offset
-void TextChange::setOffset(int offset)
+void TextChange::setOffset(size_t offset)
 {
     offset_ = offset;
 }
 
 
 /// This is the length in the document
-int TextChange::docLength() const
+size_t TextChange::docLength() const
 {
     return length_;
 }
 
 
 /// The content length is the length that's currently stored in memory.
-int TextChange::storedLength() const
+size_t TextChange::storedLength() const
 {
-    return text_.size();
+    return static_cast<size_t>(text_.size());
 }
 
 
 /// Set the length of the change
 /// @param len sets the length of the change
-void TextChange::setDocLength(int len)
+void TextChange::setDocLength(size_t len)
 {
     length_ = len;
 }
@@ -182,14 +162,12 @@ QString TextChange::testString()
 void TextChange::replaceText(TextDocument* document)
 {
     TextBuffer* buffer = document->buffer();
-    QString old = buffer->textPart( offset_, length_ );
+    QString old = buffer->textPart(offset_, length_);
 
-    buffer->replaceText( offset_, length_, text_ );
+    buffer->replaceText(offset_, length_, text_);
     length_ = text_.length();
     text_ = old;
 }
-
-
 
 
 } // edbee

--- a/edbee-lib/edbee/models/changes/textchange.cpp
+++ b/edbee-lib/edbee/models/changes/textchange.cpp
@@ -53,7 +53,7 @@ void TextChange::mergeStoredData(AbstractRangedChange* change)
     TextChange* singleTextChange = dynamic_cast<TextChange*>(change);
 
     QString newText;
-    newText.resize( getMergedStoredLength(change));
+    newText.resize(static_cast<qsizetype>(getMergedStoredLength(change)));
     mergeStoredDataViaMemcopy(newText.data(), text_.data(), singleTextChange->text_.data(), change, sizeof(QChar));
     text_ = newText;
 }
@@ -143,14 +143,14 @@ void TextChange::appendStoredText(const QString& text)
 }
 
 
-/// This method returns the text currently in the document
+/// Rketurns the text currently in the document
 const QString TextChange::docText(TextDocument* doc) const
 {
     return doc->textPart( offset_, length_ );
 }
 
 
-/// This method returns a string used for testing
+/// Returns a string used for testing
 QString TextChange::testString()
 {
     return QStringLiteral("%1:%2:%3").arg(offset_).arg(length_).arg(QString(text_).replace("\n","§"));
@@ -165,7 +165,7 @@ void TextChange::replaceText(TextDocument* document)
     QString old = buffer->textPart(offset_, length_);
 
     buffer->replaceText(offset_, length_, text_);
-    length_ = text_.length();
+    length_ = static_cast<size_t>(text_.length());
     text_ = old;
 }
 

--- a/edbee-lib/edbee/models/changes/textchange.h
+++ b/edbee-lib/edbee/models/changes/textchange.h
@@ -18,31 +18,31 @@ namespace edbee {
 class EDBEE_EXPORT TextChange : public AbstractRangedChange
 {
 public:
-    TextChange(int offset, int length, const QString& text );
+    TextChange(size_t offset, size_t length, const QString& text );
     virtual ~TextChange();
 
     virtual void execute(TextDocument* document);
     virtual void revert(TextDocument* document);
 
 protected:
-    virtual void mergeStoredData( AbstractRangedChange* change );
+    virtual void mergeStoredData(AbstractRangedChange* change);
 
 public:
-    virtual bool giveAndMerge(TextDocument *document, Change* textChange );
+    virtual bool giveAndMerge(TextDocument *document, Change* textChange);
 
     virtual QString toString();
 
-    int offset() const;
-    void setOffset( int offset );
-    virtual int docLength() const;
-    virtual int storedLength() const;
+    size_t offset() const;
+    void setOffset(size_t offset);
+    virtual size_t docLength() const;
+    virtual size_t storedLength() const;
 
-    void setDocLength( int len );
+    void setDocLength(size_t len);
 
     QString storedText() const;
-    void setStoredText( const QString& text );
-    void appendStoredText( const QString& text );
-    const QString docText( TextDocument* doc ) const;
+    void setStoredText(const QString& text);
+    void appendStoredText(const QString& text);
+    const QString docText(TextDocument* doc) const;
 
     QString testString();
 
@@ -50,8 +50,8 @@ protected:
     void replaceText( TextDocument* document );
 
 private:
-    int offset_;            ///< The offset of the text
-    int length_;            ///< the length of the change in the document
+    size_t offset_;         ///< The offset of the text
+    size_t length_;         ///< the length of the change in the document
     QString text_;          ///< The text data
 };
 

--- a/edbee-lib/edbee/models/changes/textchangewithcaret.cpp
+++ b/edbee-lib/edbee/models/changes/textchangewithcaret.cpp
@@ -7,15 +7,15 @@
 
 namespace edbee {
 
-TextChangeWithCaret::TextChangeWithCaret(int offset, int length, const QString& text, int caret )
-    : TextChange( offset, length, text )
-    , caret_( caret )
+TextChangeWithCaret::TextChangeWithCaret(size_t offset, size_t length, const QString& text, size_t caret)
+    : TextChange(offset, length, text)
+    , caret_(caret)
 {
 }
 
 
 /// returns the caret position
-int TextChangeWithCaret::caret() const
+size_t TextChangeWithCaret::caret() const
 {
     return caret_;
 }
@@ -23,7 +23,7 @@ int TextChangeWithCaret::caret() const
 
 /// Sets the caret position
 /// @param caret the caret to set
-void TextChangeWithCaret::setCaret(int caret)
+void TextChangeWithCaret::setCaret(size_t caret)
 {
     caret_ = caret;
 }

--- a/edbee-lib/edbee/models/changes/textchangewithcaret.cpp
+++ b/edbee-lib/edbee/models/changes/textchangewithcaret.cpp
@@ -15,6 +15,7 @@ TextChangeWithCaret::TextChangeWithCaret(size_t offset, size_t length, const QSt
 
 
 /// returns the caret position
+/// when std::string::npos (no caret is available)
 size_t TextChangeWithCaret::caret() const
 {
     return caret_;
@@ -23,6 +24,7 @@ size_t TextChangeWithCaret::caret() const
 
 /// Sets the caret position
 /// @param caret the caret to set
+/// when std::string::npos (no caret is available)
 void TextChangeWithCaret::setCaret(size_t caret)
 {
     caret_ = caret;

--- a/edbee-lib/edbee/models/changes/textchangewithcaret.h
+++ b/edbee-lib/edbee/models/changes/textchangewithcaret.h
@@ -15,13 +15,13 @@ namespace edbee {
 class EDBEE_EXPORT TextChangeWithCaret : public TextChange
 {
 public:
-    TextChangeWithCaret( int offset, int length, const QString& text, int caret );
+    TextChangeWithCaret(size_t offset, size_t length, const QString& text, size_t caret);
 
-    int caret() const ;
-    void setCaret( int caret );
+    size_t caret() const ;
+    void setCaret(size_t caret);
 
 private:
-    int caret_;         ///< The new cret
+    size_t caret_;         ///< The new cret
 };
 
 } // edbee

--- a/edbee-lib/edbee/models/chardocument/chartextbuffer.cpp
+++ b/edbee-lib/edbee/models/chardocument/chartextbuffer.cpp
@@ -91,7 +91,7 @@ void CharTextBuffer::replaceText(size_t offset, size_t length, const QChar* buff
 /// @return the line from the given offset
 size_t CharTextBuffer::lineFromOffset(size_t offset)
 {
-//    int result = lineFromOffsetSearch(offset);
+    //  int result = lineFromOffsetSearch(offset);
     size_t result = lineOffsetList_.findLineFromOffset(offset);
     return result;
 }
@@ -102,8 +102,6 @@ size_t CharTextBuffer::lineFromOffset(size_t offset)
 /// @return the offset of the given line
 size_t CharTextBuffer::offsetFromLine(size_t line)
 {
-    if( line < 0 ) return 0;    // at the start
-
     if( line >= lineOffsetList_.length()) {
         return length();
     }

--- a/edbee-lib/edbee/models/chardocument/chartextbuffer.cpp
+++ b/edbee-lib/edbee/models/chardocument/chartextbuffer.cpp
@@ -10,20 +10,19 @@
 
 namespace edbee {
 
-
 /// The constructor of the textbuffer
 /// @param a reference to the parent
 CharTextBuffer::CharTextBuffer(QObject *parent)
     : TextBuffer( parent )
-    , rawAppendStart_(-1)
-    , rawAppendLineStart_(-1)
+    , rawAppendStart_(std::string::npos)
+    , rawAppendLineStart_(std::string::npos)
 {
 }
 
 
 /// Returns the length of the buffer
 /// @return the length of the given text
-int CharTextBuffer::length() const
+size_t CharTextBuffer::length() const
 {
     return buf_.length();
 }
@@ -32,9 +31,8 @@ int CharTextBuffer::length() const
 /// Returns the character at the given character
 /// @param offset the offset of the given character
 /// @return the character at the given offset
-QChar CharTextBuffer::charAt(int offset) const
+QChar CharTextBuffer::charAt(size_t offset) const
 {
-    Q_ASSERT(offset >= 0);
     Q_ASSERT(offset < buf_.length() );
     return buf_.at(offset);
 }
@@ -44,14 +42,14 @@ QChar CharTextBuffer::charAt(int offset) const
 /// @param pos the position of the given text
 /// @param length the length of the text to get
 /// @return returns a part of the text
-QString CharTextBuffer::textPart(int pos, int length) const
+QString CharTextBuffer::textPart(size_t pos, size_t length) const
 {
     // do NOT use data here. Data moves the gap!
     // QString str( buf_.data() + pos, length );
     // return str;
     ///buf_.data()
 
-    QString result = buf_.mid( pos, length );
+    QString result = buf_.mid(pos, length);
     return result;
 }
 
@@ -61,40 +59,40 @@ QString CharTextBuffer::textPart(int pos, int length) const
 /// @param length the length of the text to replace
 /// @param buffer a pointer to a buffer with data
 /// @param bufferLenth the length of the buffer
-void CharTextBuffer::replaceText(int offset, int length, const QChar* buffer, int bufferLength )
+void CharTextBuffer::replaceText(size_t offset, size_t length, const QChar* buffer, size_t bufferLength )
 {
     // make sure the length matches
-    length = qMin( this->length()-offset, length );
+    length = qMin(this->length()-offset, length);
 
     // make sure the position is correct
-    if( offset > buf_.length() ) {
+    if(offset > buf_.length()) {
         offset = buf_.length();  // Qt doesn't append if the position > length
         length = 0;
     }
 
-    TextBufferChange change( this, offset, length, buffer, bufferLength );
+    TextBufferChange change(this, offset, length, buffer, bufferLength);
 
-    emit textAboutToBeChanged( change );
+    emit textAboutToBeChanged(change);
 
     // replace the text
     QString oldText = buf_.mid(offset, length);
 
-    buf_.replace( offset, length, buffer, bufferLength );
+    buf_.replace(offset, length, buffer, bufferLength);
 
     // replace the line data and offsets
-    lineOffsetList_.applyChange( change );
+    lineOffsetList_.applyChange(change);
 
-    emit textChanged( change, oldText );
+    emit textChanged(change, oldText);
 }
 
 
 /// Returns the line position at the given offset
 /// @param offset the offset to retreive the line from
 /// @return the line from the given offset
-int CharTextBuffer::lineFromOffset(int offset )
+size_t CharTextBuffer::lineFromOffset(size_t offset)
 {
 //    int result = lineFromOffsetSearch(offset);
-    int result = lineOffsetList_.findLineFromOffset(offset);
+    size_t result = lineOffsetList_.findLineFromOffset(offset);
     return result;
 }
 
@@ -102,7 +100,7 @@ int CharTextBuffer::lineFromOffset(int offset )
 /// This method returns the offset of the given line
 /// @param lin the line to retrieve the offset from
 /// @return the offset of the given line
-int CharTextBuffer::offsetFromLine(int line)
+size_t CharTextBuffer::offsetFromLine(size_t line)
 {
     if( line < 0 ) return 0;    // at the start
 
@@ -117,8 +115,8 @@ int CharTextBuffer::offsetFromLine(int line)
 /// Starts raw data appending to the buffer
 void CharTextBuffer::rawAppendBegin()
 {
-    Q_ASSERT(rawAppendStart_ == -1 );
-    Q_ASSERT(rawAppendLineStart_ == -1 );
+    Q_ASSERT(rawAppendStart_ == std::string::npos );
+    Q_ASSERT(rawAppendLineStart_ == std::string::npos );
     rawAppendStart_ = length();
     rawAppendLineStart_ = lineCount();
 }
@@ -127,9 +125,9 @@ void CharTextBuffer::rawAppendBegin()
 /// Appends a buffer of text to the document
 /// @param data the data to append
 /// @param dataLength the number of bytes availble by the data pointer
-void CharTextBuffer::rawAppend(const QChar* data, int dataLength)
+void CharTextBuffer::rawAppend(const QChar* data, size_t dataLength)
 {
-    buf_.append( data, dataLength );
+    buf_.append(data, dataLength);
 }
 
 
@@ -144,27 +142,18 @@ void CharTextBuffer::rawAppend(QChar c)
 /// Ends the 'raw' appending of data
 void CharTextBuffer::rawAppendEnd()
 {
-    Q_ASSERT(rawAppendStart_ >= 0 );
-    Q_ASSERT(rawAppendLineStart_ >= 0 );
+    Q_ASSERT(rawAppendStart_ != std::string::npos);
+    Q_ASSERT(rawAppendLineStart_ != std::string::npos);
 
-    // append all the newlines to the vector
-    /*
-    int oldLength = lineOffsetList_.length();
-    for( int i=rawAppendStart_,len=length(); i<len; ++i ){
-        if( charAt(i) == '\n' ) { lineOffsetList_.appendOffset( i+1 ); }
-    }
-    int linesAdded = lineOffsetList_.length() - oldLength;
-    */
-
-    //emit the about signal
-    TextBufferChange change( this, rawAppendStart_, 0, buf_.data() + rawAppendStart_, buf_.length() - rawAppendStart_ );
+    // emit the about signal
+    TextBufferChange change(this, rawAppendStart_, 0, buf_.data() + rawAppendStart_, buf_.length() - rawAppendStart_);
 
     emit textAboutToBeChanged( change );
     lineOffsetList_.applyChange( change );
     emit textChanged( change, QString() );
 
-    rawAppendLineStart_ = -1;
-    rawAppendStart_     = -1;
+    rawAppendLineStart_ = std::string::npos;
+    rawAppendStart_     = std::string::npos;
 }
 
 
@@ -174,6 +163,5 @@ QChar* CharTextBuffer::rawDataPointer()
 {
     return buf_.data();
 }
-
 
 } // edbee

--- a/edbee-lib/edbee/models/chardocument/chartextbuffer.h
+++ b/edbee-lib/edbee/models/chardocument/chartextbuffer.h
@@ -16,7 +16,7 @@ namespace edbee {
 class EDBEE_EXPORT CharTextBuffer : public TextBuffer
 {
 public:
-    CharTextBuffer(QObject* parent=0);
+    CharTextBuffer(QObject* parent=nullptr);
 
     virtual size_t length() const;
     virtual QChar charAt(size_t offset) const;

--- a/edbee-lib/edbee/models/chardocument/chartextbuffer.h
+++ b/edbee-lib/edbee/models/chardocument/chartextbuffer.h
@@ -16,22 +16,22 @@ namespace edbee {
 class EDBEE_EXPORT CharTextBuffer : public TextBuffer
 {
 public:
-    CharTextBuffer( QObject* parent=0);
+    CharTextBuffer(QObject* parent=0);
 
-    virtual int length() const;
-    virtual QChar charAt(  int offset ) const;
-    virtual QString textPart( int offset, int length ) const;
+    virtual size_t length() const;
+    virtual QChar charAt(size_t offset) const;
+    virtual QString textPart(size_t offset, size_t length) const;
 
-    virtual void replaceText( int offset, int length, const QChar* buffer, int bufferLength );
+    virtual void replaceText(size_t offset, size_t length, const QChar* buffer, size_t bufferLength);
 
-    virtual int lineCount() { return lineOffsetList_.length(); }
+    virtual size_t lineCount() { return lineOffsetList_.length(); }
 
-    virtual int lineFromOffset( int offset );
-    virtual int offsetFromLine( int line );
+    virtual size_t lineFromOffset(size_t offset);
+    virtual size_t offsetFromLine(size_t line);
 
     virtual void rawAppendBegin();
-    virtual void rawAppend( QChar c );
-    virtual void rawAppend( const QChar* data, int dataLength );
+    virtual void rawAppend(QChar c);
+    virtual void rawAppend(const QChar* data, size_t dataLength);
     virtual void rawAppendEnd();
 
     virtual QChar* rawDataPointer();
@@ -47,9 +47,8 @@ private:
     QCharGapVector buf_;                     ///< The textbuffer
     LineOffsetVector lineOffsetList_;        ///< The line offset vector
 
-    int rawAppendStart_;                     ///< The start offset of raw appending. -1 means no appending is happening
-    int rawAppendLineStart_;                 ///< The line start
-
+    size_t rawAppendStart_;                     ///< The start offset of raw appending. std::string::npos means no appending is happening
+    size_t rawAppendLineStart_;                 ///< The line start. std::string::npos no appending is happening
 };
 
 } // edbee

--- a/edbee-lib/edbee/models/chardocument/chartextdocument.cpp
+++ b/edbee-lib/edbee/models/chardocument/chartextdocument.cpp
@@ -69,7 +69,7 @@ CharTextDocument::CharTextDocument(TextEditorConfig* config, QObject* object)
     // forward the persisted state changes
     connect(textUndoStack_, SIGNAL(persistedChanged(bool)), this,  SIGNAL(persistedChanged(bool)));
 
-    connect(textScopes_, SIGNAL(lastScopedOffsetChanged(int,int)), this, SIGNAL(lastScopedOffsetChanged(int,int)));
+    connect(textScopes_, SIGNAL(lastScopedOffsetChanged(size_t,size_t)), this, SIGNAL(lastScopedOffsetChanged(size_t,size_t)));
 }
 
 

--- a/edbee-lib/edbee/models/chardocument/chartextdocument.cpp
+++ b/edbee-lib/edbee/models/chardocument/chartextdocument.cpp
@@ -25,21 +25,21 @@
 namespace edbee {
 
 /// The main contstructor of the chartext document
-CharTextDocument::CharTextDocument(QObject *object)
+CharTextDocument::CharTextDocument(QObject* object)
     : edbee::CharTextDocument(new TextEditorConfig(), object)
 {
 }
 
-CharTextDocument::CharTextDocument(TextEditorConfig *config, QObject *object)
+CharTextDocument::CharTextDocument(TextEditorConfig* config, QObject* object)
     : TextDocument(object)
     , config_(config)
-    , textBuffer_(0)
-    , textScopes_(0)
-    , textLexer_(0)
-    , textCodecRef_(0)
-    , lineEndingRef_(0)
-    , textUndoStack_(0)
-    , autoCompleteProviderList_(0)
+    , textBuffer_(nullptr)
+    , textScopes_(nullptr)
+    , textLexer_(nullptr)
+    , textCodecRef_(nullptr)
+    , lineEndingRef_(nullptr)
+    , textUndoStack_(nullptr)
+    , autoCompleteProviderList_(nullptr)
 {
     Q_ASSERT_GUI_THREAD;
 
@@ -48,28 +48,28 @@ CharTextDocument::CharTextDocument(TextEditorConfig *config, QObject *object)
 
     textBuffer_ = new CharTextBuffer();
 
-    textScopes_ = new TextDocumentScopes( this );
+    textScopes_ = new TextDocumentScopes(this);
 
     textCodecRef_ = Edbee::instance()->codecManager()->codecForName("UTF-8");
     lineEndingRef_ = LineEnding::unixType();
 
     // create the text scopes and lexer
-    textLexer_ = new GrammarTextLexer( textScopes_ );
+    textLexer_ = new GrammarTextLexer(textScopes_);
 
     // create the undo stack
     textUndoStack_ = new TextUndoStack(this);
 
     // create the autocomplete provider (with the global parent provider)
-    autoCompleteProviderList_ = new TextAutoCompleteProviderList( Edbee::instance()->autoCompleteProviderList());
+    autoCompleteProviderList_ = new TextAutoCompleteProviderList(Edbee::instance()->autoCompleteProviderList());
 
     // simply forward the about to change signal
-    connect( textBuffer_, SIGNAL(textAboutToBeChanged(edbee::TextBufferChange)), SIGNAL(textAboutToBeChanged(edbee::TextBufferChange)), Qt::DirectConnection );
-    connect( textBuffer_, SIGNAL(textChanged(edbee::TextBufferChange, QString)), SLOT(textBufferChanged(edbee::TextBufferChange, QString)), Qt::DirectConnection );
+    connect(textBuffer_, SIGNAL(textAboutToBeChanged(edbee::TextBufferChange)), SIGNAL(textAboutToBeChanged(edbee::TextBufferChange)), Qt::DirectConnection);
+    connect(textBuffer_, SIGNAL(textChanged(edbee::TextBufferChange,QString)), SLOT(textBufferChanged(edbee::TextBufferChange,QString)), Qt::DirectConnection);
 
     // forward the persisted state changes
-    connect( textUndoStack_, SIGNAL(persistedChanged(bool)), this,  SIGNAL(persistedChanged(bool)) );
+    connect(textUndoStack_, SIGNAL(persistedChanged(bool)), this,  SIGNAL(persistedChanged(bool)));
 
-    connect( textScopes_, SIGNAL(lastScopedOffsetChanged(int,int)), this, SIGNAL(lastScopedOffsetChanged(int,int)) );
+    connect(textScopes_, SIGNAL(lastScopedOffsetChanged(int,int)), this, SIGNAL(lastScopedOffsetChanged(int,int)));
 }
 
 
@@ -86,14 +86,14 @@ CharTextDocument::~CharTextDocument()
 
 
 /// Returns the active textbuffer
-TextBuffer*CharTextDocument::buffer() const
+TextBuffer* CharTextDocument::buffer() const
 {
     return textBuffer_;
 }
 
 
 /// returns the language grammar
-TextGrammar *CharTextDocument::languageGrammar()
+TextGrammar* CharTextDocument::languageGrammar()
 {
     return textLexer_->grammar();
 }
@@ -118,7 +118,7 @@ TextAutoCompleteProviderList* CharTextDocument::autoCompleteProviderList()
 
 
 /// This method returns the configuration
-TextEditorConfig*CharTextDocument::config() const
+TextEditorConfig* CharTextDocument::config() const
 {
     return config_;
 }
@@ -134,10 +134,11 @@ TextEditorConfig*CharTextDocument::config() const
 /// Gives a change to the undo stack without invoking the filter
 /// @param change the change to execute
 /// @param coalesceId the coalescing identifier
-Change *CharTextDocument::giveChangeWithoutFilter(Change *change, int coalesceId )
+Change* CharTextDocument::giveChangeWithoutFilter(Change *change, int coalesceId)
 {
-    return textUndoStack()->giveChange( change, coalesceId);
+    return textUndoStack()->giveChange(change, coalesceId);
 }
+
 
 /// This method replaces the given text via the undo-button
 //void CharTextDocument::replaceTextWithoutFilter( int offset, int length, const QString& text )
@@ -150,15 +151,15 @@ Change *CharTextDocument::giveChangeWithoutFilter(Change *change, int coalesceId
 // the text is changed
 void CharTextDocument::textBufferChanged(const TextBufferChange& change, QString oldText)
 {
-    if( textLexer_ ) {
-        textLexer_->textChanged( change );
+    if (textLexer_) {
+        textLexer_->textChanged(change);
     }
 
     // execute the line change
-    if( !isUndoOrRedoRunning() ) {
-        Change* lineDataChange = lineDataManager()->createLinesReplacedChange( change.line()+1, change.lineCount(), change.newLineCount() );
-        if( lineDataChange ) {
-            executeAndGiveChange( lineDataChange, 0 );
+    if (!isUndoOrRedoRunning()) {
+        Change* lineDataChange = lineDataManager()->createLinesReplacedChange(change.line() + 1, change.lineCount(), change.newLineCount());
+        if (lineDataChange) {
+            executeAndGiveChange(lineDataChange, 0);
         }
     }
 

--- a/edbee-lib/edbee/models/chardocument/chartextdocument.h
+++ b/edbee-lib/edbee/models/chardocument/chartextdocument.h
@@ -26,8 +26,8 @@ class EDBEE_EXPORT CharTextDocument : public TextDocument
 Q_OBJECT
 
 public:
-    CharTextDocument( QObject* object );
-    CharTextDocument( TextEditorConfig *config = new TextEditorConfig(), QObject* object = nullptr );
+    CharTextDocument(QObject* object);
+    CharTextDocument(TextEditorConfig *config = new TextEditorConfig(), QObject* object = nullptr);
     virtual ~CharTextDocument();
 
 
@@ -42,7 +42,7 @@ public:
     virtual TextCodec* encoding() { return textCodecRef_; }
 
     /// Sets the encoding
-    virtual void setEncoding( TextCodec* codec ) {
+    virtual void setEncoding(TextCodec* codec) {
         Q_ASSERT(codec);
         textCodecRef_ = codec;
     }
@@ -51,7 +51,7 @@ public:
     virtual const edbee::LineEnding* lineEnding() { return lineEndingRef_; }
 
     /// Set the used line ending
-    virtual void setLineEnding( const edbee::LineEnding* lineEnding ) {
+    virtual void setLineEnding(const edbee::LineEnding* lineEnding) {
         Q_ASSERT(lineEnding);
         lineEndingRef_ = lineEnding;
     }
@@ -76,9 +76,9 @@ public:
 
 
 protected slots:
-//    virtual void textReplaced( int offset, int length, const QChar* data, int dataLength );
-//    virtual void linesReplaced( int line, int lineCount, int newLineCount );
-    virtual void textBufferChanged( const edbee::TextBufferChange& change, QString oldText = QString() );
+    //    virtual void textReplaced( int offset, int length, const QChar* data, int dataLength );
+    //    virtual void linesReplaced( int line, int lineCount, int newLineCount );
+    virtual void textBufferChanged(const edbee::TextBufferChange& change, QString oldText = QString());
 
 private:
     TextEditorConfig* config_;                               ///< The text editor configuration

--- a/edbee-lib/edbee/models/dynamicvariables.cpp
+++ b/edbee-lib/edbee/models/dynamicvariables.cpp
@@ -4,7 +4,6 @@
 #include "dynamicvariables.h"
 
 #include "edbee/models/textdocumentscopes.h"
-#include "edbee/models/textdocument.h"
 #include "edbee/models/textdocumentscopes.h"
 #include "edbee/texteditorcontroller.h"
 
@@ -23,7 +22,7 @@ DynamicVariable::~DynamicVariable()
 
 
 /// Constructs a basic dynamic (read static :P ) variable
-BasicDynamicVariable::BasicDynamicVariable( const QVariant& value )
+BasicDynamicVariable::BasicDynamicVariable(const QVariant& value)
     : value_(value)
 {
 }
@@ -42,7 +41,7 @@ QVariant BasicDynamicVariable::value() const
 /// constructs a dynamic variable
 /// @param value the value of the variable
 /// @param selector (default=0) the selector to use. This class takes ownership of the selector!!
-ScopedDynamicVariable::ScopedDynamicVariable( const QVariant& value, TextScopeSelector* selector  )
+ScopedDynamicVariable::ScopedDynamicVariable(const QVariant& value, TextScopeSelector* selector)
     : BasicDynamicVariable(value)
     , selector_(selector)
 {
@@ -57,9 +56,9 @@ ScopedDynamicVariable::~ScopedDynamicVariable()
 
 
 /// returns the score for the location
-double ScopedDynamicVariable::score( TextScopeList* scopes ) const
+double ScopedDynamicVariable::score(TextScopeList* scopes) const
 {
-    return selector()->calculateMatchScore( scopes );
+    return selector()->calculateMatchScore(scopes);
 }
 
 
@@ -71,6 +70,7 @@ TextScopeSelector* ScopedDynamicVariable::selector() const
 
 
 //--------------------------------
+
 
 /// default constructor
 DynamicVariables::DynamicVariables()
@@ -94,7 +94,7 @@ void DynamicVariables::setAndGiveScopedSelector(const QString& name, const QVari
 {
     /// Todo, perhaps we should detect identical scope selectors and replace the original
     variableNames_.insert(name);
-    scopedVariableMap_.insert( name, new ScopedDynamicVariable(value, new TextScopeSelector(selector) ) );
+    scopedVariableMap_.insert(name, new ScopedDynamicVariable(value, new TextScopeSelector(selector)));
 }
 
 
@@ -104,13 +104,13 @@ void DynamicVariables::set(const QString& name, const QVariant& value)
 {
     delete variableMap_.value(name);     // delete the old one
     variableNames_.insert(name);
-    variableMap_.insert( name, new BasicDynamicVariable(value) );
+    variableMap_.insert(name, new BasicDynamicVariable(value));
 }
 
 
 /// Returns the number of variables available
 /// @return the number of variable names. (there can be more values as variables)
-int DynamicVariables::size() const
+qsizetype DynamicVariables::size() const
 {
     return variableNames_.size();
 }
@@ -119,7 +119,7 @@ int DynamicVariables::size() const
 /// returns the number of variable-rules/entries available with the given name
 /// @param name the name of the variable to retrieve the size for
 /// @return the number of variables entires with the given name
-int DynamicVariables::valueCount(const QString& name) const
+qsizetype DynamicVariables::valueCount(const QString& name) const
 {
     return scopedVariableMap_.count(name) + variableMap_.count(name);
 }
@@ -130,17 +130,15 @@ int DynamicVariables::valueCount(const QString& name) const
 /// @param scopeList the scope list to find the variable for
 DynamicVariable* DynamicVariables::find(const QString& name, TextScopeList* scopelist)
 {
-//qlog_info() << "name: " << name << "," << scopelist->toString();
     // the initial result is no variable found
     DynamicVariable* result = variableMap_.value(name);
     double resultScore = -0.01;
-    if( scopelist ) {
-        foreach( ScopedDynamicVariable* var, scopedVariableMap_.values(name) ) {
+    if (scopelist) {
+        foreach(ScopedDynamicVariable* var, scopedVariableMap_.values(name)) {
             double score = var->score( scopelist );
-//qlog_info() << "-  " << var->value() << ": score: " << score << " > " << resultScore;
 
             // the variable is only found if the score is better
-            if( score > resultScore ) {
+            if (score > resultScore) {
                 resultScore = score;
                 result = var;
             }
@@ -153,15 +151,14 @@ DynamicVariable* DynamicVariables::find(const QString& name, TextScopeList* scop
 /// Returns the value at the given position
 /// @param name the name of the variable
 /// @param scopeList the scope list to find the variable for
-QVariant DynamicVariables::value(const QString& name, TextScopeList* scopelist )
+QVariant DynamicVariables::value(const QString& name, TextScopeList* scopelist)
 {
-    DynamicVariable* var = find( name, scopelist );
-    if( var ) {
+    DynamicVariable* var = find( name, scopelist);
+    if (var) {
         return var->value();
     }
     return QVariant();
 }
-
 
 
 } // edbee

--- a/edbee-lib/edbee/models/dynamicvariables.h
+++ b/edbee-lib/edbee/models/dynamicvariables.h
@@ -67,13 +67,13 @@ public:
     virtual ~DynamicVariables();
 
     void setAndGiveScopedSelector(const QString& name, const QVariant& value, const QString& selector);
-    void set( const QString& name, const QVariant& value );
+    void set(const QString& name, const QVariant& value);
 
-    int size() const;
-    int valueCount( const QString& name ) const;
+    qsizetype size() const;
+    qsizetype valueCount(const QString& name) const;
 
-    DynamicVariable* find( const QString& name, TextScopeList* scopelist );
-    QVariant value( const QString& name, TextScopeList* scopeList=0 );
+    DynamicVariable* find(const QString& name, TextScopeList* scopelist);
+    QVariant value(const QString& name, TextScopeList* scopeList = nullptr);
 
 private:
     QSet<QString> variableNames_;                                             ///< A set with all unique variable names

--- a/edbee-lib/edbee/models/textbuffer.cpp
+++ b/edbee-lib/edbee/models/textbuffer.cpp
@@ -70,6 +70,7 @@ TextBufferChange::TextBufferChange()
     d_ = new TextBufferChangeData((TextBuffer*)nullptr, 0, 0, 0, 0);
 }
 
+
 TextBufferChange::TextBufferChange(TextBuffer* buffer, size_t off, size_t len, const QChar* text, size_t textlen)
 {
     d_ = new TextBufferChangeData(buffer, off, len, text, textlen);
@@ -80,10 +81,27 @@ TextBufferChange::TextBufferChange(LineOffsetVector* lineOffsets, size_t off, si
     d_ = new TextBufferChangeData(lineOffsets, off, len, text, textlen);
 }
 
+
 TextBufferChange::TextBufferChange(const TextBufferChange& other) : d_(other.d_)
 {
 }
 
+
+const QString TextBufferChange::toDebugString() const
+{
+    QString s;
+    s.append("TextBufferChange: ");
+    s.append(QStringLiteral(" | (offset: %1, line: %2").arg(offset()).arg(line()));
+    s.append(QStringLiteral(" | length: %1 => %2").arg(length()).arg(newTextLength()));
+    s.append(QStringLiteral(" | lines: %1 => %2").arg(lineCount()).arg(newLineCount()));
+    s.append(" | offsets: ");
+    for (qsizetype i = 0, cnt = newLineOffsets().length(); i < cnt; ++i) {
+        if (i) s.append(", ");
+        s.append(QStringLiteral("%1").arg(newLineOffsets().at(i)));
+    }
+    s.append(QStringLiteral(" | text: %1").arg(newText()));
+    return s;
+}
 
 
 //=====================================================

--- a/edbee-lib/edbee/models/textbuffer.cpp
+++ b/edbee-lib/edbee/models/textbuffer.cpp
@@ -23,18 +23,20 @@ TextBufferChangeData::TextBufferChangeData(TextBuffer* buffer, size_t off, size_
     Q_ASSERT(buffer);
 
     // decide which lines
-    line_         = buffer->lineFromOffset( offset_ );
-    int endLine   = buffer->lineFromOffset( offset_ + length_ );
+    line_         = buffer->lineFromOffset(offset_);
+    size_t endLine   = buffer->lineFromOffset(offset_ + length_);
+    Q_ASSERT(endLine >= line_);
+
     lineCount_    = endLine - line_;
-    Q_ASSERT(lineCount_>=0);
 
     // find the newlines in the text
-    for( int i=0; i< newTextLength_; ++i ) {
-        if( newText_[i] == '\n' ) {
-            newLineOffsets_.append( offset_ + i + 1 );    // +1 because it points to the start of the next line
+    for (size_t i = 0; i < newTextLength_; ++i) {
+        if (newText_[i] == '\n') {
+            newLineOffsets_.append(offset_ + i + 1);    // +1 because it points to the start of the next line
         }
     }
 }
+
 
 /// Initializes the textbuffer change
 /// @param buffer when buffer is 0 NO line calculation is done
@@ -65,7 +67,7 @@ TextBufferChangeData::TextBufferChangeData(LineOffsetVector* lineOffsets, size_t
 
 TextBufferChange::TextBufferChange()
 {
-    d_ = new TextBufferChangeData((TextBuffer*)nullptr, 0, 0, 0, 0 );
+    d_ = new TextBufferChangeData((TextBuffer*)nullptr, 0, 0, 0, 0);
 }
 
 TextBufferChange::TextBufferChange(TextBuffer* buffer, size_t off, size_t len, const QChar* text, size_t textlen)
@@ -100,21 +102,21 @@ TextBuffer::TextBuffer(QObject *parent)
 /// @param text the new text to insert
 void TextBuffer::replaceText(size_t offset, size_t length, const QString& text)
 {
-    replaceText( offset, length, text.data(), text.length());
+    replaceText(offset, length, text.data(), static_cast<size_t>(text.length()));
 }
 
 
 /// Returns the full text as a QString
 QString TextBuffer::text()
 {
-     return textPart(0, length());
+    return textPart(0, length());
 }
 
 
 /// A convenient method for directly filling the textbuffer with the given content
 void TextBuffer::setText(const QString& text)
 {
-    replaceText( 0, length(), text.data(), text.length() );
+    replaceText(0, length(), text.data(), static_cast<size_t>(text.length()));
 }
 
 
@@ -122,15 +124,19 @@ void TextBuffer::setText(const QString& text)
 /// @param offset the character offset
 /// @param line the line index this position is on. (Use this argument for optimization if you already know this)
 /// 			(default std::string::npos, use the current line index)
-int TextBuffer::columnFromOffsetAndLine(size_t offset, size_t line)
+size_t TextBuffer::columnFromOffsetAndLine(size_t offset, size_t line)
 {
-    if( line == std::string::npos ) line = lineFromOffset(offset);
+    if (line == std::string::npos) {
+        line = lineFromOffset(offset);
+    }
 
     // const QList<int>& lofs = lineOffsets();
-    if( line < lineCount() ) {
-        std::ptrdiff_t col = offset - offsetFromLine(line);
-        if( col < 0 ) return 0;
-        return qMin( lineLength(line), col );
+    if (line < lineCount()) {
+        size_t lineOffset = offsetFromLine(line);
+        if (lineOffset >= offset) {
+            return 0;
+        }
+        return qMin(lineLength(line), offset - lineOffset);
     } else {
         return 0;
     }
@@ -141,69 +147,69 @@ int TextBuffer::columnFromOffsetAndLine(size_t offset, size_t line)
 /// @param text the text to appendf
 void TextBuffer::appendText(const QString& text)
 {
-    replaceText(length(),0,text.data(), text.length() );
+    replaceText(length(),0,text.data(), static_cast<size_t>(text.length()));
 }
 
 
-/// This method returns the offset from the give line and column
+/// Returns the offset from the give line and column
 /// If the column exceed the number of column the caret is placed just before the newline
-int TextBuffer::offsetFromLineAndColumn(int line, int col)
+size_t TextBuffer::offsetFromLineAndColumn(size_t line, size_t col)
 {
-    int offsetLine = offsetFromLine(line);
-    int offsetNextLine = offsetFromLine(line+1);
-    int offset = offsetLine + col;
-    if( offset >= offsetNextLine && offset < length() ) { --offset; }
+    size_t offsetLine = offsetFromLine(line);
+    size_t offsetNextLine = offsetFromLine(line + 1);
+    size_t offset = offsetLine + col;
+    if (offset >= offsetNextLine && offset < length()) { --offset; }
     return offset;
 }
 
 
 /// Returns the line at the given line position. This line INCLUDES the newline character (if it's there)
 /// @param line the line to return
-QString TextBuffer::line(int line)
+QString TextBuffer::line(size_t line)
 {
-    int off = offsetFromLine(line);
-    int endOff = offsetFromLine(line+1);
-    return textPart( off, endOff - off  ); // skip the return
+    size_t off = offsetFromLine(line);
+    size_t endOff = offsetFromLine(line + 1);
+    return textPart(off, endOff - off); // skip the return
 }
 
 
 /// Returns the line without the newline character
-QString TextBuffer::lineWithoutNewline(int line)
+QString TextBuffer::lineWithoutNewline(size_t line)
 {
-    int off = offsetFromLine(line);
-    int removeNewlineCount = 1;
-    if( line == lineCount()-1 ) { removeNewlineCount = 0; }
-    return textPart( off , offsetFromLine(line+1) - off - removeNewlineCount  ); // skip the return
+    size_t off = offsetFromLine(line);
+    size_t removeNewlineCount = 1;
+    if (line == lineCount() - 1) { removeNewlineCount = 0; }
+    return textPart(off , offsetFromLine(line + 1) - off - removeNewlineCount); // skip the return
 }
 
 
 /// Returns the length of the given line. Also counting the trailing newline character if present
 /// @param line the line to retrieve the length for
 /// @return the length of the given line
-int TextBuffer::lineLength(int line)
+size_t TextBuffer::lineLength(size_t line)
 {
-    return offsetFromLine(line+1) - offsetFromLine(line);
+    return offsetFromLine(line + 1) - offsetFromLine(line);
 }
 
 
 /// Returns the length of the given line. Without counting a trailing newline character
 /// @param line the line to retrieve the length for
 /// @return the length of the given line
-int TextBuffer::lineLengthWithoutNewline(int line)
+size_t TextBuffer::lineLengthWithoutNewline(size_t line)
 {
-    int removeNewlineCount = 1;
-    if( line == lineCount()-1 ) { removeNewlineCount = 0; }
-    int lastOffset = offsetFromLine(line+1) - removeNewlineCount;
-    return  lastOffset - offsetFromLine(line);
+    size_t removeNewlineCount = 1;
+    if (line == lineCount() - 1) { removeNewlineCount = 0; }
+    size_t lastOffset = offsetFromLine(line + 1) - removeNewlineCount;
+    return lastOffset - offsetFromLine(line);
 }
 
 
 /// replace the texts
 /// @param range the range to replace
 /// @param text the text to insert at the given location
-void TextBuffer::replaceText( const TextRange& range, const QString& text )
+void TextBuffer::replaceText(const TextRange& range, const QString& text)
 {
-    return replaceText( range.min(), range.length(), text.data(), text.length() );
+    return replaceText(range.min(), range.length(), text.data(), static_cast<size_t>(text.length()));
 }
 
 
@@ -212,14 +218,14 @@ void TextBuffer::replaceText( const TextRange& range, const QString& text )
 /// @parm direction the direction (left < 0, or right > 0 )
 /// @param chars the chars to search
 /// @param equals when setting to true if will search for the first given char. When false it will stop when another char is found
-int TextBuffer::findCharPos(int offset, int direction, const QString& chars, bool equals)
+/// @returns the character position or std::string:npos if not found
+size_t TextBuffer::findCharPos(size_t offset, int direction, const QString& chars, bool equals)
 {
-    return findCharPosWithinRange(offset, direction, chars, equals, 0, length() );
-
+    return findCharPosWithinRange(offset, direction, chars, equals, 0, length());
 }
 
 
-/// This method finds the find the first character position that equals the given char
+/// Finds the find the first character position that equals the given char
 ///
 /// @param offset the offset to search from. A negative offset means the CURRENT character isn't used
 /// @param direction the direction to search. If the direction is multiple. the nth item is returned
@@ -227,38 +233,44 @@ int TextBuffer::findCharPos(int offset, int direction, const QString& chars, boo
 /// @param equals when setting to true if will search for the first given char. When false it will stop when another char is found
 /// @param beginRange the start of the range to search in
 /// @param endRange the end of the range to search in (exclusive)
-/// @return the offset of the first character
-int TextBuffer::findCharPosWithinRange(int offset, int direction, const QString& chars, bool equals, int beginRange, int endRange)
+/// @return the offset of the first character (Or std::string::npos if not found)
+size_t TextBuffer::findCharPosWithinRange(size_t offset, int direction, const QString& chars, bool equals, size_t beginRange, size_t endRange)
 {
-    int charStep      = direction < 0 ? -1 : 1;
-    int charNumber    = qAbs(direction);
+    if (offset == std::string::npos) { return std::string::npos; }
 
-    while( beginRange <= offset && offset < endRange ) {
-        if( chars.contains( charAt(offset) ) == equals ) {
-            if( --charNumber <= 0 ) { return offset; }
+    size_t charNumber = static_cast<size_t>(qAbs(direction));
+    if (charNumber == 0) return std::string::npos;
+
+    while (beginRange <= offset && offset < endRange) {
+        if (chars.contains( charAt(offset) ) == equals) {
+            if (--charNumber == 0) { return offset; }
         }
-        offset += charStep;
+        if (direction < 0) {
+            --offset;
+        } else {
+            ++offset;
+        }
     }
-    return -1;
+    return std::string::npos;
 }
 
 
 /// See documentation at findCharPosWithinRange.
 /// This method searches a char position within the given rang (from the given ofset)
-int TextBuffer::findCharPosOrClamp(int offset, int direction, const QString& chars, bool equals)
+size_t TextBuffer::findCharPosOrClamp(size_t offset, int direction, const QString& chars, bool equals)
 {
-    return findCharPosWithinRangeOrClamp( offset, direction, chars, equals, 0, length() );
+    return findCharPosWithinRangeOrClamp(offset, direction, chars, equals, 0u, length());
 }
 
 
 /// See documentation at findCharPosWithinRange.
 /// This method searches a char position within the given rang (from the given ofset)
-int TextBuffer::findCharPosWithinRangeOrClamp(int offset, int direction, const QString& chars, bool equals, int beginRange, int endRange)
+size_t TextBuffer::findCharPosWithinRangeOrClamp(size_t offset, int direction, const QString& chars, bool equals, size_t beginRange, size_t endRange)
 {
-    int pos = findCharPosWithinRange(offset, direction, chars, equals, beginRange, endRange);
-    if( pos < 0 ) {
-        if( direction < 0 ) return beginRange;
-        if( direction > 0 ) return endRange;
+    size_t pos = findCharPosWithinRange(offset, direction, chars, equals, beginRange, endRange);
+    if (pos == std::string::npos) {
+        if (direction < 0) return beginRange;
+        if (direction > 0) return endRange;
     }
     return pos;
 }
@@ -269,10 +281,10 @@ int TextBuffer::findCharPosWithinRangeOrClamp(int offset, int direction, const Q
 QString TextBuffer::lineOffsetsAsString()
 {
     QString str;
-    for( int idx=0,cnt=lineCount(); idx<cnt; ++idx  ) {
-        int offset = offsetFromLine(idx);
-        if( !str.isEmpty() ) str.append(',');
-        str.append( QStringLiteral("%1").arg(offset) );
+    for (size_t idx = 0, cnt=lineCount(); idx < cnt; ++idx) {
+        size_t offset = offsetFromLine(idx);
+        if (!str.isEmpty()) str.append(',');
+        str.append(QStringLiteral("%1").arg(offset));
     }
     return str;
 }

--- a/edbee-lib/edbee/models/textbuffer.cpp
+++ b/edbee-lib/edbee/models/textbuffer.cpp
@@ -283,6 +283,7 @@ size_t TextBuffer::findCharPosOrClamp(size_t offset, int direction, const QStrin
 
 /// See documentation at findCharPosWithinRange.
 /// This method searches a char position within the given rang (from the given ofset)
+/// @returns the given position or clamps at the begin/endrange (depending on the direction)
 size_t TextBuffer::findCharPosWithinRangeOrClamp(size_t offset, int direction, const QString& chars, bool equals, size_t beginRange, size_t endRange)
 {
     size_t pos = findCharPosWithinRange(offset, direction, chars, equals, beginRange, endRange);

--- a/edbee-lib/edbee/models/textbuffer.h
+++ b/edbee-lib/edbee/models/textbuffer.h
@@ -22,8 +22,8 @@ class LineOffsetVector;
 class EDBEE_EXPORT TextBufferChangeData : public QSharedData
 {
 public:
-    TextBufferChangeData( TextBuffer* buffer, size_t off, size_t len, const QChar* text, size_t textlen );
-    TextBufferChangeData( LineOffsetVector* lineOffsets, size_t off, size_t len, const QChar* text, size_t textlen );
+    TextBufferChangeData(TextBuffer* buffer, size_t off, size_t len, const QChar* text, size_t textlen);
+    TextBufferChangeData(LineOffsetVector* lineOffsets, size_t off, size_t len, const QChar* text, size_t textlen);
 
     // text information
     size_t offset_;             ///< The offset in the buffer
@@ -44,9 +44,9 @@ public:
 class EDBEE_EXPORT TextBufferChange {
 public:
     TextBufferChange();
-    TextBufferChange( TextBuffer* buffer, size_t off, size_t len, const QChar* text, size_t textlen );
-    TextBufferChange( LineOffsetVector* lineOffsets, size_t off, size_t len, const QChar* text, size_t textlen );
-    TextBufferChange( const TextBufferChange& other );
+    TextBufferChange(TextBuffer* buffer, size_t off, size_t len, const QChar* text, size_t textlen);
+    TextBufferChange(LineOffsetVector* lineOffsets, size_t off, size_t len, const QChar* text, size_t textlen);
+    TextBufferChange(const TextBufferChange& other);
 
     size_t offset() const { return d_->offset_; }
     size_t length() const { return d_->length_; }
@@ -54,7 +54,7 @@ public:
     size_t newTextLength() const { return d_->newTextLength_; }
     size_t line() const { return d_->line_; }
     size_t lineCount() const { return d_->lineCount_; }
-    inline size_t newLineCount() const { return d_->newLineOffsets_.size(); }
+    inline size_t newLineCount() const { return static_cast<size_t>(d_->newLineOffsets_.size()); }
     const QVector<size_t>& newLineOffsets() const { return d_->newLineOffsets_; }
 
 
@@ -121,20 +121,20 @@ public:
 
     QString text();
     void setText(const QString& text);
-    virtual int columnFromOffsetAndLine(size_t offset, size_t line = std::string::npos);
+    virtual size_t columnFromOffsetAndLine(size_t offset, size_t line = std::string::npos);
     virtual void appendText(const QString& text);
-    virtual int offsetFromLineAndColumn(int line, int col);
-    virtual QString line(int line);
-    virtual QString lineWithoutNewline(int line);
-
-    virtual int lineLength(int line);
-    virtual int lineLengthWithoutNewline(int line);
+    virtual size_t offsetFromLineAndColumn(size_t line, size_t col);
+    virtual QString line(size_t line);
+    virtual QString lineWithoutNewline(size_t line);
+    
+    virtual size_t lineLength(size_t line);
+    virtual size_t lineLengthWithoutNewline(size_t line);
     virtual void replaceText(const TextRange& range, const QString& text);
 
-    virtual int findCharPos(int offset, int direction, const QString& chars, bool equals);
-    virtual int findCharPosWithinRange(int offset, int direction, const QString& chars, bool equals, int beginRange, int endRange);
-    virtual int findCharPosOrClamp(int offset, int direction, const QString& chars, bool equals);
-    virtual int findCharPosWithinRangeOrClamp(int offset, int direction, const QString& chars, bool equals, int beginRange, int endRange);
+    virtual size_t findCharPos(size_t offset, int direction, const QString& chars, bool equals);
+    virtual size_t findCharPosWithinRange(size_t offset, int direction, const QString& chars, bool equals, size_t beginRange, size_t endRange);
+    virtual size_t findCharPosOrClamp(size_t offset, int direction, const QString& chars, bool equals);
+    virtual size_t findCharPosWithinRangeOrClamp(size_t offset, int direction, const QString& chars, bool equals, size_t beginRange, size_t endRange);
 
     virtual QString lineOffsetsAsString();
 

--- a/edbee-lib/edbee/models/textbuffer.h
+++ b/edbee-lib/edbee/models/textbuffer.h
@@ -34,7 +34,7 @@ public:
     // line informationm
     size_t line_;                    ///< The line number were the change occured
     size_t lineCount_;               ///< the number of lines that are involved.
-    QVector<size_t> newLineOffsets_; ///< A list of new line offset
+    QVector<int> newLineOffsets_; ///< A list of new line offset
 };
 
 
@@ -55,7 +55,7 @@ public:
     size_t line() const { return d_->line_; }
     size_t lineCount() const { return d_->lineCount_; }
     inline size_t newLineCount() const { return static_cast<size_t>(d_->newLineOffsets_.size()); }
-    const QVector<size_t>& newLineOffsets() const { return d_->newLineOffsets_; }
+    const QVector<int>& newLineOffsets() const { return d_->newLineOffsets_; }
 
 
 private:

--- a/edbee-lib/edbee/models/textbuffer.h
+++ b/edbee-lib/edbee/models/textbuffer.h
@@ -34,7 +34,7 @@ public:
     // line informationm
     size_t line_;                    ///< The line number were the change occured
     size_t lineCount_;               ///< the number of lines that are involved.
-    QVector<int> newLineOffsets_; ///< A list of new line offset
+    QVector<size_t> newLineOffsets_; ///< A list of new line offset (offsets within the document!!)
 };
 
 
@@ -55,7 +55,9 @@ public:
     size_t line() const { return d_->line_; }
     size_t lineCount() const { return d_->lineCount_; }
     inline size_t newLineCount() const { return static_cast<size_t>(d_->newLineOffsets_.size()); }
-    const QVector<int>& newLineOffsets() const { return d_->newLineOffsets_; }
+    const QVector<size_t>& newLineOffsets() const { return d_->newLineOffsets_; }
+
+    const QString toDebugString() const;
 
 
 private:

--- a/edbee-lib/edbee/models/textbuffer.h
+++ b/edbee-lib/edbee/models/textbuffer.h
@@ -22,20 +22,19 @@ class LineOffsetVector;
 class EDBEE_EXPORT TextBufferChangeData : public QSharedData
 {
 public:
-    TextBufferChangeData( TextBuffer* buffer, int off, int len, const QChar* text, int textlen );
-    TextBufferChangeData( LineOffsetVector* lineOffsets, int off, int len, const QChar* text, int textlen );
+    TextBufferChangeData( TextBuffer* buffer, size_t off, size_t len, const QChar* text, size_t textlen );
+    TextBufferChangeData( LineOffsetVector* lineOffsets, size_t off, size_t len, const QChar* text, size_t textlen );
 
     // text information
-    int offset_;             ///< The offset in the buffer
-    int length_;             ///< The number of chars to replaced
-    const QChar* newText_;   ///< The reference to a new text
-    int newTextLength_;      ///< The length of this text
+    size_t offset_;             ///< The offset in the buffer
+    size_t length_;             ///< The number of chars to replaced
+    const QChar* newText_;      ///< The reference to a new text
+    size_t newTextLength_;      ///< The length of this text
 
     // line informationm
-    int line_;                    ///< The line number were the change occured
-    int lineCount_;               ///< the number of lines that are involved.
-    QVector<int> newLineOffsets_; ///< A list of new line offset
-
+    size_t line_;                    ///< The line number were the change occured
+    size_t lineCount_;               ///< the number of lines that are involved.
+    QVector<size_t> newLineOffsets_; ///< A list of new line offset
 };
 
 
@@ -45,18 +44,18 @@ public:
 class EDBEE_EXPORT TextBufferChange {
 public:
     TextBufferChange();
-    TextBufferChange( TextBuffer* buffer, int off, int len, const QChar* text, int textlen );
-    TextBufferChange( LineOffsetVector* lineOffsets, int off, int len, const QChar* text, int textlen );
+    TextBufferChange( TextBuffer* buffer, size_t off, size_t len, const QChar* text, size_t textlen );
+    TextBufferChange( LineOffsetVector* lineOffsets, size_t off, size_t len, const QChar* text, size_t textlen );
     TextBufferChange( const TextBufferChange& other );
 
-    int offset() const { return d_->offset_; }
-    int length() const { return d_->length_; }
+    size_t offset() const { return d_->offset_; }
+    size_t length() const { return d_->length_; }
     const QChar* newText() const  { return d_->newText_; }
-    int newTextLength() const { return d_->newTextLength_; }
-    int line() const { return d_->line_; }
-    int lineCount() const { return d_->lineCount_; }
-    inline int newLineCount() const { return d_->newLineOffsets_.size(); }
-    const QVector<int>& newLineOffsets() const { return d_->newLineOffsets_; }
+    size_t newTextLength() const { return d_->newTextLength_; }
+    size_t line() const { return d_->line_; }
+    size_t lineCount() const { return d_->lineCount_; }
+    inline size_t newLineCount() const { return d_->newLineOffsets_.size(); }
+    const QVector<size_t>& newLineOffsets() const { return d_->newLineOffsets_; }
 
 
 private:
@@ -69,39 +68,38 @@ class EDBEE_EXPORT TextBuffer : public QObject
 Q_OBJECT
 
 public:
-    TextBuffer( QObject* parent = 0);
+    TextBuffer(QObject* parent = 0);
 
 // Minimal abstract interface to implement
 
-    /// should return the number of 'characters'.
-    virtual int length() const = 0;
+    ///  returns the number of 'characters'.
+    virtual size_t length() const = 0;
 
-    /// A method for returning a single char
-    virtual QChar charAt( int offset ) const = 0;
+    /// returns a single char
+    virtual QChar charAt(size_t offset) const = 0;
 
     /// return the given text.
-    virtual QString textPart( int offset, int length ) const = 0;
+    virtual QString textPart(size_t offset, size_t length) const = 0;
 
-    /// this method should replace the given text
-    /// And fire a 'text-replaced' signal
-    virtual void replaceText( int offset, int length, const QChar* buffer, int bufferLength ) = 0;
+    /// replaces the given text and fire a 'text-replaced' signal
+    virtual void replaceText(size_t offset, size_t length, const QChar* buffer, size_t bufferLength) = 0;
 
     /// this method should return an array with all line offsets. A line offset pointsto the START of a line
     /// So it does NOT point to a newline character, but it points to the first character AFTER the newline character
-    virtual int lineCount() = 0; // { return lineOffsets().length(); }
-    virtual int lineFromOffset(int offset ) = 0;
-    virtual int offsetFromLine( int line ) = 0;
+    virtual size_t lineCount() = 0; // { return lineOffsets().length(); }
+    virtual size_t lineFromOffset(size_t offset) = 0;
+    virtual size_t offsetFromLine(size_t line) = 0;
 
 // raw loading methods
 
-    /// This method starts raw appending
+    /// starts raw appending
     virtual void rawAppendBegin() = 0;
 
-    /// this method should append the given character to the buffer
-    virtual void rawAppend( QChar c ) = 0;
+    /// append the given character to the buffer
+    virtual void rawAppend(QChar c) = 0;
 
-    /// This method should raw append the given character string
-    virtual void rawAppend( const QChar* data, int dataLength ) = 0;
+    /// raw append the given character string
+    virtual void rawAppend(const QChar* data, size_t dataLength) = 0;
 
     /// the end raw append method should bring the document in a consistent state and
     /// emit the correct "replaceText" signals
@@ -110,7 +108,7 @@ public:
     /// And the newlines are already added to the newline list!
     virtual void rawAppendEnd() = 0;
 
-    /// This method returns the raw data buffer.
+    /// returns the raw data buffer.
     /// WARNING this method CAN be slow because when using a gapvector the gap is moved to the end to make a full buffer
     /// Modifying the content of the data will mess up the line-offset-vector and other dependent classes. For reading it's ok :-)
     virtual QChar* rawDataPointer() = 0;
@@ -119,31 +117,31 @@ public:
 // easy functions
 
     /// Replace the given text.
-    virtual void replaceText( int offset, int length, const QString& text );
+    virtual void replaceText(size_t offset, size_t length, const QString& text);
 
     QString text();
-    void setText( const QString& text );
-    virtual int columnFromOffsetAndLine( int offset, int line=-1 );
-    virtual void appendText( const QString& text );
-    virtual int offsetFromLineAndColumn( int line, int col );
-    virtual QString line( int line);
-    virtual QString lineWithoutNewline( int line );
+    void setText(const QString& text);
+    virtual int columnFromOffsetAndLine(size_t offset, size_t line = std::string::npos);
+    virtual void appendText(const QString& text);
+    virtual int offsetFromLineAndColumn(int line, int col);
+    virtual QString line(int line);
+    virtual QString lineWithoutNewline(int line);
 
     virtual int lineLength(int line);
     virtual int lineLengthWithoutNewline(int line);
-    virtual void replaceText( const TextRange& range, const QString& text  );
+    virtual void replaceText(const TextRange& range, const QString& text);
 
-    virtual int findCharPos( int offset, int direction, const QString& chars, bool equals );
-    virtual int findCharPosWithinRange( int offset, int direction, const QString& chars, bool equals, int beginRange, int endRange );
-    virtual int findCharPosOrClamp( int offset, int direction, const QString& chars, bool equals );
-    virtual int findCharPosWithinRangeOrClamp( int offset, int direction, const QString& chars, bool equals, int beginRange, int endRange );
+    virtual int findCharPos(int offset, int direction, const QString& chars, bool equals);
+    virtual int findCharPosWithinRange(int offset, int direction, const QString& chars, bool equals, int beginRange, int endRange);
+    virtual int findCharPosOrClamp(int offset, int direction, const QString& chars, bool equals);
+    virtual int findCharPosWithinRangeOrClamp(int offset, int direction, const QString& chars, bool equals, int beginRange, int endRange);
 
     virtual QString lineOffsetsAsString();
 
  signals:
 
-    void textAboutToBeChanged( edbee::TextBufferChange change );
-    void textChanged( edbee::TextBufferChange change, QString oldText = QString() );
+    void textAboutToBeChanged(edbee::TextBufferChange change);
+    void textChanged(edbee::TextBufferChange change, QString oldText = QString());
 
 };
 

--- a/edbee-lib/edbee/models/textdocument.cpp
+++ b/edbee-lib/edbee/models/textdocument.cpp
@@ -316,16 +316,16 @@ Change *TextDocument::executeAndGiveChange(Change* change, int coalesceId )
 /// @param coalesceId (default 0) the coalesceId to use. Whe using the same number changes could be merged to one change. CoalesceId of 0 means no merging
 void TextDocument::append(const QString& text, int coalesceId )
 {
-    replace( this->length(), 0, text, coalesceId );
+    replace(this->length(), 0, text, coalesceId);
 }
 
 
 /// Appends the given text
 /// @param text the text to append
 /// @param coalesceId (default 0) the coalesceId to use. Whe using the same number changes could be merged to one change. CoalesceId of 0 means no merging
-void TextDocument::replace( int offset, int length, const QString& text, int coalesceId )
+void TextDocument::replace(size_t offset, size_t length, const QString& text, int coalesceId)
 {
-    executeAndGiveChange( new TextChange( offset, length, text ), coalesceId);
+    executeAndGiveChange(new TextChange(offset, length, text), coalesceId);
 }
 
 
@@ -333,7 +333,7 @@ void TextDocument::replace( int offset, int length, const QString& text, int coa
 /// @param text the new document text
 void TextDocument::setText(const QString& text)
 {
-    replace( 0, length(), text, 0 );
+    replace(0, length(), text, 0);
 }
 
 
@@ -363,9 +363,9 @@ void TextDocument::rawAppend(QChar c)
 
 
 /// Appends an array of characters
-void TextDocument::rawAppend(const QChar* chars, int length)
+void TextDocument::rawAppend(const QChar* chars, size_t length)
 {
-    buffer()->rawAppend(chars,length);
+    buffer()->rawAppend(chars, length);
 }
 
 

--- a/edbee-lib/edbee/models/textdocument.cpp
+++ b/edbee-lib/edbee/models/textdocument.cpp
@@ -45,10 +45,10 @@ TextDocument::~TextDocument()
 /// Decreasting the fieldcount  reults in the lost of the 'old' fields
 /// At least the 'PredefinedFieldCount' amont of fields are required
 /// This method EMPTIES the undo-stack. So after this call all undo history is gone!
-void TextDocument::setLineDataFieldsPerLine(int count)
+void TextDocument::setLineDataFieldsPerLine(size_t count)
 {
     Q_ASSERT( count >= PredefinedFieldCount );
-    lineDataManager()->setFieldsPerLine( count );
+    lineDataManager()->setFieldsPerLine(count);
     textUndoStack()->clear();
 }
 
@@ -60,13 +60,13 @@ void TextDocument::giveLineDataManager(TextLineDataManager* manager)
 }
 
 
-/// This method gives a given data item to a text line
-void TextDocument::giveLineData(int line, int field, TextLineData* dataItem)
+/// Gives a given data item to a text line
+void TextDocument::giveLineData(size_t line, size_t field, TextLineData* dataItem)
 {
-    Q_ASSERT(line < lineCount() );
-    LineDataChange* change = new LineDataChange( line, field );
-    change->giveLineData( dataItem );
-    executeAndGiveChange( change, true );
+    Q_ASSERT(line < lineCount());
+    LineDataChange* change = new LineDataChange(line, field);
+    change->giveLineData(dataItem);
+    executeAndGiveChange(change, true);
 }
 
 
@@ -74,12 +74,12 @@ void TextDocument::giveLineData(int line, int field, TextLineData* dataItem)
 /// @param line the line number to retrieve the line data for
 /// @param field the field to retrieve the data for
 /// @return TextLineData the associated line data
-TextLineData* TextDocument::getLineData(int line, int field)
+TextLineData* TextDocument::getLineData(size_t line, size_t field)
 {
-    int len = lineDataManager()->length();
+    size_t len = lineDataManager()->length();
     // Q_ASSERT( len == lineCount() );  FIXME: disabled, issue with renderer retreiving linedata
-    Q_ASSERT( line < len );
-    return lineDataManager()->get( line, field );
+    Q_ASSERT(line < len);
+    return lineDataManager()->get(line, field);
 }
 
 
@@ -87,7 +87,7 @@ TextLineData* TextDocument::getLineData(int line, int field)
 /// @param group the textchange group that groups the undo operations
 void TextDocument::beginUndoGroup(ChangeGroup* group)
 {
-    if( !group ) {
+    if (!group) {
         group = new ChangeGroup(nullptr);
     }
 //    if( documentFilter() ) {
@@ -100,7 +100,7 @@ void TextDocument::beginUndoGroup(ChangeGroup* group)
 /// Ends the current undo group
 /// @param coalesceId the coalesceId
 /// @param flatten should the operation be flatten (flattens undo-group trees)
-void TextDocument::endUndoGroup( int coalesceId, bool flatten)
+void TextDocument::endUndoGroup(int coalesceId, bool flatten)
 {
 //    if( documentFilter() ) {
 //        TextChangeGroup* group = textUndoStack()->currentGroup();
@@ -222,20 +222,20 @@ void TextDocument::replaceRangeSet(TextRangeSet& rangeSet, const QStringList& te
         TextRange& range = rangeSet.range(idx);
         QString text = texts.at(static_cast<qsizetype>(idx) % textsIn.size());  // rotating text-fetching
 
-        range.setCaret(range.caret() + delta);
-        range.setAnchor(range.anchor() + delta);
+        range.setCaretBounded(this, static_cast<ptrdiff_t>(range.caret()) + delta);
+        range.setAnchorBounded(this, static_cast<ptrdiff_t>(range.anchor()) + delta);
 
         delta += (text.length() - static_cast<ptrdiff_t>(range.length()));
 
         TextChangeWithCaret* change = new TextChangeWithCaret(range.min(), range.length(), text, -1);
 
-        Change* effectiveChange = executeAndGiveChange( change, false );
+        Change* effectiveChange = executeAndGiveChange(change, false);
         TextChangeWithCaret* effectiveChangeWithCaret = dynamic_cast<TextChangeWithCaret*>(effectiveChange);
 
         // when a new caret position is supplied (can only happen via a TextDocumentFilter)
         // access it and change the caret to the given position
-        int caret = 0;
-        if( effectiveChangeWithCaret && effectiveChangeWithCaret->caret() >= 0 ) {
+        size_t caret = 0;
+        if (effectiveChangeWithCaret && effectiveChangeWithCaret->caret() >= 0) {
           caret = effectiveChangeWithCaret->caret();
         // Default caret location is change-independent: old location + length new text
         } else {
@@ -243,7 +243,7 @@ void TextDocument::replaceRangeSet(TextRangeSet& rangeSet, const QStringList& te
         }
 
         // sticky selection, keeps the selection around the text
-        if(stickySelection) {
+        if (stickySelection) {
           range.set(range.min(), caret);
         } else {
           range.setCaret(caret);
@@ -251,7 +251,7 @@ void TextDocument::replaceRangeSet(TextRangeSet& rangeSet, const QStringList& te
         }
 
         // next range
-        if( rangeSet.rangeCount() < oldRangeCount ) {
+        if (rangeSet.rangeCount() < oldRangeCount) {
             qDebug() <<  "TEST TO SEE IF THIS REALLY HAPPENS!! I think it cannot happen. (but I'm not sure)";
             Q_ASSERT(false);
 

--- a/edbee-lib/edbee/models/textdocument.cpp
+++ b/edbee-lib/edbee/models/textdocument.cpp
@@ -227,7 +227,7 @@ void TextDocument::replaceRangeSet(TextRangeSet& rangeSet, const QStringList& te
 
         delta += (text.length() - static_cast<ptrdiff_t>(range.length()));
 
-        TextChangeWithCaret* change = new TextChangeWithCaret(range.min(), range.length(), text, -1);
+        TextChangeWithCaret* change = new TextChangeWithCaret(range.min(), range.length(), text, std::string::npos);
 
         Change* effectiveChange = executeAndGiveChange(change, false);
         TextChangeWithCaret* effectiveChangeWithCaret = dynamic_cast<TextChangeWithCaret*>(effectiveChange);
@@ -235,14 +235,14 @@ void TextDocument::replaceRangeSet(TextRangeSet& rangeSet, const QStringList& te
         // when a new caret position is supplied (can only happen via a TextDocumentFilter)
         // access it and change the caret to the given position
         size_t caret = 0;
-        if (effectiveChangeWithCaret && effectiveChangeWithCaret->caret() >= 0) {
-          caret = effectiveChangeWithCaret->caret();
+        if (effectiveChangeWithCaret && effectiveChangeWithCaret->caret() != std::string::npos) {
+            caret = effectiveChangeWithCaret->caret();
         // Default caret location is change-independent: old location + length new text
         } else {
-          caret = range.min() + text.length();
+            caret = range.min() + static_cast<size_t>(text.length());
         }
 
-        // sticky selection, keeps the selection around the text
+
         if (stickySelection) {
           range.set(range.min(), caret);
         } else {

--- a/edbee-lib/edbee/models/textdocument.cpp
+++ b/edbee-lib/edbee/models/textdocument.cpp
@@ -387,6 +387,7 @@ size_t TextDocument::lineCount()
 /// Returns the character at the given position
 QChar TextDocument::charAt(size_t idx)
 {
+    Q_ASSERT(idx != std::string::npos);
     return buffer()->charAt(idx);
 }
 
@@ -410,6 +411,7 @@ QChar TextDocument::charAtOrNull(size_t idx)
 /// @return the character offset
 size_t TextDocument::offsetFromLine(size_t line)
 {
+    Q_ASSERT(line != std::string::npos);
     return buffer()->offsetFromLine(line);
 }
 
@@ -419,6 +421,7 @@ size_t TextDocument::offsetFromLine(size_t line)
 /// @return the line number (0 is the first line )
 size_t TextDocument::lineFromOffset(size_t offset)
 {
+    Q_ASSERT(offset != std::string::npos);
     return buffer()->lineFromOffset(offset);
 }
 
@@ -429,7 +432,7 @@ size_t TextDocument::lineFromOffset(size_t offset)
 /// @return the column position of the given offset
 size_t TextDocument::columnFromOffsetAndLine(size_t offset, size_t line)
 {
-    return buffer()->columnFromOffsetAndLine(offset,line);
+    return buffer()->columnFromOffsetAndLine(offset, line);
 }
 
 

--- a/edbee-lib/edbee/models/textdocument.h
+++ b/edbee-lib/edbee/models/textdocument.h
@@ -12,7 +12,6 @@
 
 namespace edbee {
 
-
 class TextGrammar;
 class Change;
 class ChangeGroup;
@@ -40,139 +39,129 @@ class TextUndoStack;
 ///
 class EDBEE_EXPORT TextDocument : public QObject
 {
-
 Q_OBJECT
 
 public:
 
-    TextDocument( QObject* parent=0);
+    TextDocument(QObject* parent = nullptr);
     virtual ~TextDocument();
 
-    /// This method should return the active textbuffer
+    /// Returns the active textbuffer
     /// Warning you should NEVER directly modify the textbuffer unless you're absolutely sure what you're doing!
     virtual TextBuffer* buffer() const = 0 ;
 
-    /// This method can be used to change the number of reserved fields by the document
+    /// Can be used to change the number of reserved fields by the document
     /// Increasing the amount will result in a realoc
     /// Decreasting the fieldcount reults in the lost of the 'old' fields
     /// At least the 'PredefinedFieldCount' amont of fields are required
-    virtual void setLineDataFieldsPerLine( int count );
+    virtual void setLineDataFieldsPerLine(int count);
 
     /// this method can be used to give a 'custom' line data item to a given line
     virtual TextLineDataManager* lineDataManager() { return textLineDataManager_; }
     virtual void giveLineDataManager(TextLineDataManager* manager);
-    virtual void giveLineData( int line, int field, TextLineData* dataItem );
-    virtual TextLineData* getLineData( int line, int field );
+    virtual void giveLineData(int line, int field, TextLineData* dataItem);
+    virtual TextLineData* getLineData(int line, int field);
 //    virtual TextLineData* takeLineData( int line, int field ) = 0;
 
-    /// Should return the document-scopes of this document
+    /// Returns the document-scopes of this document
     virtual TextDocumentScopes* scopes() = 0;
 
-    /// This method should return the current encoding
+    /// Returns the current encoding
     virtual TextCodec* encoding() = 0;
-    virtual void setEncoding( TextCodec* codec ) = 0;
+    virtual void setEncoding(TextCodec* codec) = 0;
 
-    /// This method should return the current line ending
+    /// Returns the current line ending
     virtual const LineEnding* lineEnding() = 0 ;
-    virtual void setLineEnding( const LineEnding* lineENding ) = 0;
+    virtual void setLineEnding(const LineEnding* lineEnding) = 0;
 
-    ///  Should return the current document lexer
+    /// Returns the current document lexer
     virtual TextLexer* textLexer() = 0;
 
-    /// This method should return the current language grammar
+    /// Returns the current language grammar
     virtual TextGrammar* languageGrammar() = 0;
 
     /// Changes the language grammar.
     /// This method should emit a grammarChanged signal (if the grammar is changed)
-    virtual void setLanguageGrammar( TextGrammar* grammar ) = 0;
+    virtual void setLanguageGrammar(TextGrammar* grammar) = 0;
 
-
-    /// This method should return the autcompletion provider list
+    /// Returns the autcompletion provider list
     virtual TextAutoCompleteProviderList* autoCompleteProviderList() = 0;
 
     /// this method should return a reference to the undo stack
     virtual TextUndoStack* textUndoStack() = 0;
-    virtual void beginUndoGroup(ChangeGroup* group=0);
-    virtual void endUndoGroup(int coalesceId, bool flatten=false );
+    virtual void beginUndoGroup(ChangeGroup* group = nullptr);
+    virtual void endUndoGroup(int coalesceId, bool flatten = false);
     virtual void endUndoGroupAndDiscard();
     virtual bool isUndoCollectionEnabled();
-    virtual void setUndoCollectionEnabled( bool enabled );
+    virtual void setUndoCollectionEnabled(bool enabled);
     virtual bool isUndoRunning();
     virtual bool isRedoRunning();
     virtual bool isUndoOrRedoRunning();
     virtual bool isPersisted();
-    virtual void setPersisted(bool enabled=true);
+    virtual void setPersisted(bool enabled = true);
 
-    /// this method should return the config
     virtual TextEditorConfig* config() const = 0;
 
-    virtual void setDocumentFilter( TextDocumentFilter* filter );
-    virtual void giveDocumentFilter( TextDocumentFilter* filter );
+    virtual void setDocumentFilter(TextDocumentFilter* filter);
+    virtual void giveDocumentFilter(TextDocumentFilter* filter);
     virtual TextDocumentFilter* documentFilter();
 
-    void beginChanges( TextEditorController* controller );
+    void beginChanges(TextEditorController* controller);
     void replaceRangeSet(TextRangeSet& rangeSet, const QString& text, bool stickySelection = false);
     void replaceRangeSet(TextRangeSet& rangeSet, const QStringList& texts, bool stickySelection = false);
-    void giveSelection( TextEditorController* controller,  TextRangeSet* rangeSet);
-    void endChanges( int coalesceId );
+    void giveSelection(TextEditorController* controller,  TextRangeSet* rangeSet);
+    void endChanges(int coalesceId);
 
+    Change* executeAndGiveChange(Change* change , int coalesceId);
 
-
-    Change* executeAndGiveChange(Change* change , int coalesceId );
-
-
-//    void giveChange( TextChange* change, bool merge  );
-    virtual Change* giveChangeWithoutFilter( Change* change, int coalesceId) = 0;
+    // void giveChange( TextChange* change, bool merge  );
+    virtual Change* giveChangeWithoutFilter(Change* change, int coalesceId) = 0;
     void append(const QString& text, int coalesceId=0 );
-    void replace( int offset, int length, const QString& text, int coalesceId=0);
-    void setText( const QString& text );
+    void replace( int offset, int length, const QString& text, int coalesceId = 0);
+    void setText(const QString& text);
 
     // raw access for filling the document
     void rawAppendBegin();
     void rawAppendEnd();
-    void rawAppend( QChar c );
+    void rawAppend(QChar c);
     void rawAppend(const QChar *chars, int length );
 
 public:
 
  // Methods directly forwarded to the  textbuffer
-
-    int length();
-    int lineCount();
-    QChar charAt(int idx);
-    QChar charAtOrNull(int idx);
-    int offsetFromLine( int line );
-    int lineFromOffset( int offset );
-    int columnFromOffsetAndLine( int offset, int line=-1 );
-    int offsetFromLineAndColumn( int line, int column );
-    int lineLength( int line );
-    int lineLengthWithoutNewline( int line );
+    size_t length();
+    size_t lineCount();
+    QChar charAt(size_t idx);
+    QChar charAtOrNull(size_t idx);
+    size_t offsetFromLine(size_t line);
+    size_t lineFromOffset(size_t offset);
+    size_t columnFromOffsetAndLine(size_t offset, size_t line = std::string::npos);
+    size_t offsetFromLineAndColumn(size_t line, size_t column);
+    size_t lineLength(size_t line);
+    size_t lineLengthWithoutNewline(size_t line);
     QString text();
-    QString textPart( int offset, int length );
-    QString lineWithoutNewline( int line );
-    QString line( int line );
+    QString textPart(size_t offset, size_t length);
+    QString lineWithoutNewline(size_t line);
+    QString line(size_t line);
 
 signals:
 
-    void textAboutToBeChanged( edbee::TextBufferChange change );
-    void textChanged( edbee::TextBufferChange change, QString oldText = QString() );
+    void textAboutToBeChanged(edbee::TextBufferChange change);
+    void textChanged(edbee::TextBufferChange change, QString oldText = QString());
 
-    /// This signal is emitted if the persisted state is changed
+    /// Emits if the persisted state is changed
     void persistedChanged(bool persisted);
 
-    /// This signal is emitted if the grammar has been changed
+    /// Emits if the grammar has been changed
     void languageGrammarChanged();
 
-    /// this signal is emitted if the scoped range has been changed
-    void lastScopedOffsetChanged( int previousOffset, int lastScopedOffset );
-
+    /// Emits if the scoped range has been changed
+    void lastScopedOffsetChanged(int previousOffset, int lastScopedOffset);
 
 private:
-    TextDocumentFilter* documentFilter_;             ///< The document filter if the filter is owned
-    TextDocumentFilter* documentFilterRef_;          ///< The reference to the document filter.
-
-    TextLineDataManager* textLineDataManager_;               ///< A class for managing text line data items
-
+    TextDocumentFilter* documentFilter_;            ///< The document filter if the filter is owned
+    TextDocumentFilter* documentFilterRef_;         ///< The reference to the document filter.
+    TextLineDataManager* textLineDataManager_;      ///< A class for managing text line data items
 };
 
 } // edbee

--- a/edbee-lib/edbee/models/textdocument.h
+++ b/edbee-lib/edbee/models/textdocument.h
@@ -54,13 +54,13 @@ public:
     /// Increasing the amount will result in a realoc
     /// Decreasting the fieldcount reults in the lost of the 'old' fields
     /// At least the 'PredefinedFieldCount' amont of fields are required
-    virtual void setLineDataFieldsPerLine(int count);
+    virtual void setLineDataFieldsPerLine(size_t count);
 
     /// this method can be used to give a 'custom' line data item to a given line
     virtual TextLineDataManager* lineDataManager() { return textLineDataManager_; }
     virtual void giveLineDataManager(TextLineDataManager* manager);
-    virtual void giveLineData(int line, int field, TextLineData* dataItem);
-    virtual TextLineData* getLineData(int line, int field);
+    virtual void giveLineData(size_t line, size_t field, TextLineData* dataItem);
+    virtual TextLineData* getLineData(size_t line, size_t field);
 //    virtual TextLineData* takeLineData( int line, int field ) = 0;
 
     /// Returns the document-scopes of this document

--- a/edbee-lib/edbee/models/textdocument.h
+++ b/edbee-lib/edbee/models/textdocument.h
@@ -116,15 +116,15 @@ public:
 
     // void giveChange( TextChange* change, bool merge  );
     virtual Change* giveChangeWithoutFilter(Change* change, int coalesceId) = 0;
-    void append(const QString& text, int coalesceId=0 );
-    void replace( int offset, int length, const QString& text, int coalesceId = 0);
+    void append(const QString& text, int coalesceId=0);
+    void replace(size_t offset, size_t length, const QString& text, int coalesceId = 0);
     void setText(const QString& text);
 
     // raw access for filling the document
     void rawAppendBegin();
     void rawAppendEnd();
     void rawAppend(QChar c);
-    void rawAppend(const QChar *chars, int length );
+    void rawAppend(const QChar *chars, size_t length);
 
 public:
 

--- a/edbee-lib/edbee/models/textdocument.h
+++ b/edbee-lib/edbee/models/textdocument.h
@@ -156,7 +156,7 @@ signals:
     void languageGrammarChanged();
 
     /// Emits if the scoped range has been changed
-    void lastScopedOffsetChanged(int previousOffset, int lastScopedOffset);
+    void lastScopedOffsetChanged(size_t previousOffset, size_t lastScopedOffset);
 
 private:
     TextDocumentFilter* documentFilter_;            ///< The document filter if the filter is owned

--- a/edbee-lib/edbee/models/textdocumentscopes.cpp
+++ b/edbee-lib/edbee/models/textdocumentscopes.cpp
@@ -60,8 +60,8 @@ QString ScopedTextRange::toString() const
 
 /// Creates a scoped text range based on a scope textrange
 MultiLineScopedTextRangeReference::MultiLineScopedTextRangeReference(MultiLineScopedTextRange& range)
-    : ScopedTextRange( range.anchor(), range.caret(), range.scope() )
-    , multiScopeRef_( &range )
+    : ScopedTextRange(range.anchor(), range.caret(), range.scope())
+    , multiScopeRef_(&range)
 {
 }
 
@@ -99,21 +99,21 @@ ScopedTextRangeList::~ScopedTextRangeList()
 
 
 /// Retursn the number of scoped textranges in the list
-int ScopedTextRangeList::size() const
+size_t ScopedTextRangeList::size() const
 {
-    return ranges_.size();
+    return static_cast<size_t>(ranges_.size());
 }
 
 
 /// Returns the scoped textrange at the given list
-ScopedTextRange* ScopedTextRangeList::at(int idx)
+ScopedTextRange* ScopedTextRangeList::at(size_t idx)
 {
-    Q_ASSERT(idx < ranges_.size() );
-    return ranges_.at(idx);
+    Q_ASSERT(idx < size());
+    return ranges_.at(static_cast<qsizetype>(idx));
 }
 
 
-/// give a rnage to the range set
+/// give a range to the range set
 /// @param range the scoped text range
 void ScopedTextRangeList::giveRange(ScopedTextRange* range)
 {
@@ -155,9 +155,9 @@ QString ScopedTextRangeList::toString()
 {
     QString result;
     result.append( independent_ ? "[-]" : "[M]");
-    foreach( ScopedTextRange* scope, ranges_ ) {
-        if( !result.isEmpty() ) { result.append("| "); }
-        result.append( scope->toString() );
+    foreach(ScopedTextRange* scope, ranges_) {
+        if (!result.isEmpty()) { result.append("| "); }
+        result.append( scope->toString());
     }
     return result;
 }
@@ -168,10 +168,10 @@ QString ScopedTextRangeList::toString()
 
 /// The multiline scoped textrange
 /// @param anchor
-MultiLineScopedTextRange::MultiLineScopedTextRange(int anchor, int caret, TextScope* scope )
-    : ScopedTextRange(anchor,caret,scope)
-    , ruleRef_(0)
-    , endRegExp_(0)
+MultiLineScopedTextRange::MultiLineScopedTextRange(size_t anchor, size_t caret, TextScope* scope)
+    : ScopedTextRange(anchor, caret, scope)
+    , ruleRef_(nullptr)
+    , endRegExp_(nullptr)
 {
 }
 
@@ -211,14 +211,15 @@ RegExp*MultiLineScopedTextRange::endRegExp()
 }
 
 
-/// This method compares selection ranges
+/// Compares selection ranges
 bool MultiLineScopedTextRange::lessThan(MultiLineScopedTextRange* r1, MultiLineScopedTextRange* r2)
 {
-    int diff = r1->min() - r2->min();
-    if( diff == 0 ) {
-        diff = r2->length() - r1->length();     // larger areas need to be placed before smaller areas
-    }
-    return ( diff < 0);
+    size_t min1 = r1->min();
+    size_t min2 = r2->min();
+
+    if (min1 < min2) return true;
+    if (min1 == min2)  return r1->length() < r2->length();
+    return false;
 }
 
 
@@ -240,15 +241,15 @@ TextDocumentScopes* MultiLineScopedTextRangeSet::textDocumentScopes()
 /// @param scopeManager the scopemanager to use (when 0 this defaults to the global edbee scopemanager)
 TextScope::TextScope(const QString& fullScope)
     : scopeAtomCount_(0)
-    , scopeAtoms_(0)
+    , scopeAtoms_(nullptr)
 {
     QStringList scopeElementNames = fullScope.split(".");
-    scopeAtomCount_ = scopeElementNames.length();
+    scopeAtomCount_ = static_cast<size_t>(scopeElementNames.length());
 
     TextScopeManager* sm = Edbee::instance()->scopeManager();
     scopeAtoms_ = new TextScopeAtomId[scopeAtomCount_];
-    for( int i=0; i < scopeAtomCount_; ++i ) {
-        TextScopeAtomId id = sm->findOrRegisterScopeAtom(scopeElementNames.at(i));
+    for (size_t i = 0; i < scopeAtomCount_; ++i) {
+        TextScopeAtomId id = sm->findOrRegisterScopeAtom(scopeElementNames.at(static_cast<qsizetype>(i)));
         scopeAtoms_[i] = id;
     }
 }
@@ -256,9 +257,8 @@ TextScope::TextScope(const QString& fullScope)
 /// this method constructs a blank text scope.
 TextScope::TextScope()
     : scopeAtomCount_(0)
-    , scopeAtoms_(0)
+    , scopeAtoms_(nullptr)
 {
-
 }
 
 
@@ -269,29 +269,28 @@ TextScope::~TextScope()
 }
 
 
-/// This method returns the name of this scope
+/// Returns the name of this scope
 const QString TextScope::name()
 {
     QString str;
     TextScopeManager* sm = Edbee::instance()->scopeManager();
-    for( int i=0; i < scopeAtomCount_; ++i ) {
-        if( i ) { str.append("."); }
-        str.append( sm->atomName( scopeAtoms_[i] )) ;
+    for (size_t i = 0; i < scopeAtomCount_; ++i) {
+        if (i) { str.append("."); }
+        str.append(sm->atomName(scopeAtoms_[i])) ;
     }
-
     return str;
 }
 
 
 /// returns the number of atom items
-int TextScope::atomCount()
+size_t TextScope::atomCount()
 {
     return scopeAtomCount_;
 }
 
 
-/// This method returns the atom at the given index
-TextScopeAtomId TextScope::atomAt(int idx) const
+/// Returns the atom at the given index
+TextScopeAtomId TextScope::atomAt(size_t idx) const
 {
     Q_ASSERT(idx < scopeAtomCount_ );
     return scopeAtoms_[idx];
@@ -303,45 +302,45 @@ TextScopeAtomId TextScope::atomAt(int idx) const
 /// @param scope the scope to check
 bool TextScope::startsWith(TextScope* scope)
 {
-    if( scope->atomCount() > atomCount() ) { return false; }    // match is never possible
+    if (scope->atomCount() > atomCount()) { return false; }    // match is never possible
     TextScopeAtomId wildCard = Edbee::instance()->scopeManager()->wildcardId();
-    for( int i=0; i<scope->scopeAtomCount_; ++i ) {
+    for (size_t i = 0; i <scope->scopeAtomCount_; ++i) {
         TextScopeAtomId atomId = scopeAtoms_[i];
         TextScopeAtomId scopeAtomId = scope->scopeAtoms_[i];
-        bool atomEqual =  atomId == scopeAtomId || atomId == wildCard || scopeAtomId == wildCard ;
-        if( !atomEqual ) { return false; }
+        bool atomEqual =  atomId == scopeAtomId || atomId == wildCard || scopeAtomId == wildCard;
+        if (!atomEqual) { return false; }
     }
     return true;
 }
 
 
-/// This method returns the 'index' of the given full-scope. This is a kind of substring search
+/// Returns the 'index' of the given full-scope. This is a kind of substring search
 ///
 /// - wildcard atoms will always match
 ///
 /// @param scope the scope to search
-/// @return -1 if not found else the index where the scope is found
-int TextScope::rindexOf(TextScope* scope)
+/// @return std::string::npos if not found else the index where the scope is found
+size_t TextScope::rindexOf(TextScope* scope)
 {
-    int searchSize = scope->atomCount();
-    int end = atomCount() - searchSize;
+    size_t searchSize = scope->atomCount();
+    size_t end = atomCount() - searchSize;
 
     TextScopeAtomId wildCard = Edbee::instance()->scopeManager()->wildcardId();
 
-    for( int idx=end; idx>=0; --idx ) {
+    for (size_t idx = end; idx != std::string::npos; --idx) {
 
         // try to match the scopes
-        int i=0;
-        for(; i<searchSize; ++i ) {
-            TextScopeAtomId atomId = scopeAtoms_[idx+i];
+        size_t i=0;
+        for (; i < searchSize; ++i) {
+            TextScopeAtomId atomId = scopeAtoms_[idx + i];
             TextScopeAtomId scopeAtomId = scope->scopeAtoms_[i];
-            bool atomEqual =  atomId == scopeAtomId || atomId == wildCard || scopeAtomId == wildCard ;
-            if( !atomEqual ) { break; }
+            bool atomEqual =  atomId == scopeAtomId || atomId == wildCard || scopeAtomId == wildCard;
+            if (!atomEqual) { break; }
         }
         // when at the end we've found it
-        if( i == searchSize ) { return idx; }
+        if (i == searchSize) { return idx; }
     }
-    return -1;
+    return std::string::npos;
 }
 
 
@@ -371,11 +370,11 @@ TextScopeList::TextScopeList(QVector<ScopedTextRange *>& ranges)
 }
 
 
-/// This method returns the total number of atoms
-int TextScopeList::atomCount() const
+/// Returns the total number of atoms
+size_t TextScopeList::atomCount() const
 {
-    int result = 0;
-    for( int i=0,cnt=size(); i<cnt; ++i ) {
+    size_t result = 0;
+    for (qsizetype i = 0, cnt = static_cast<qsizetype>(size()); i < cnt; ++i ) {
         result += at(i)->atomCount();
     }
     return result;
@@ -386,9 +385,9 @@ int TextScopeList::atomCount() const
 QString TextScopeList::toString()
 {
     QString result;
-    for( int i=0; i<size(); ++i ) {
-        if( i ) { result.append(" "); }
-        result.append( at(i)->name() );
+    for (qsizetype i = 0; i < static_cast<qsizetype>(size()); ++i) {
+        if (i) { result.append(" "); }
+        result.append(at(i)->name());
     }
     return result;
 }
@@ -402,9 +401,9 @@ TextScopeSelector::TextScopeSelector(const QString& selector)
 {
     QStringList selectorList = selector.split(",");
     selectorList_.reserve(selectorList.size());
-    foreach( QString sel, selectorList ) {
+    foreach(QString sel, selectorList) {
         sel = sel.trimmed();
-        selectorList_.append( Edbee::instance()->scopeManager()->createTextScopeList(sel) );
+        selectorList_.append(Edbee::instance()->scopeManager()->createTextScopeList(sel));
     }
 }
 
@@ -417,19 +416,18 @@ TextScopeSelector::~TextScopeSelector()
 }
 
 
-/// This method calculates the matching score of the scope with this selector
+/// Calculates the matching score of the scope with this selector
 /// Currently the scope-calculation is very 'basic'. Just enough to perform the most basic form of matching
 ///
 /// The algorithm returns 1.0 on a full match...
-///
 ///
 /// @param scopeList the list of scopes
 /// @return the matching score. -1 means no match found. >= 0 a match has been found
 double TextScopeSelector::calculateMatchScore(const TextScopeList* scopeList)
 {
-    double result=-1.0;
-    foreach( TextScopeList* selector, selectorList_ ) {
-        result = qMax( result, calculateMatchScoreForSelector( selector, scopeList) );
+    double result = -1.0;
+    foreach(TextScopeList* selector, selectorList_) {
+        result = qMax(result, calculateMatchScoreForSelector(selector, scopeList));
     }
     return result;
 }
@@ -439,19 +437,18 @@ double TextScopeSelector::calculateMatchScore(const TextScopeList* scopeList)
 QString TextScopeSelector::toString()
 {
     QString result;
-    for( int i=0,cnt=selectorList_.size(); i<cnt; ++i ) {
-        if( i ) { result.append(", "); }
+    for (qsizetype i = 0, cnt = selectorList_.size(); i < cnt; ++i) {
+        if (i) { result.append(", "); }
         result.append(selectorList_.at(i)->toString());
     }
     return result;
 }
 
 
-/// This method calculates the matching score of the scope with this selector
+/// Calculates the matching score of the scope with this selector
 /// Currently the scope-calculation is very 'basic'. Just enough to perform the most basic form of matching
 ///
 /// The algorithm returns 1.0 on a full match...
-///
 ///
 /// @param scopeList the list of scopes
 /// @return the matching score. -1 means no match found. >= 0 a match has been found
@@ -462,29 +459,29 @@ double TextScopeSelector::calculateMatchScoreForSelector(TextScopeList* selector
 
     // this method checks if the scope matches
     bool foundMatch=false;
-    int nextScopeIdx = scopeList->size()-1;
-    for( int selectorIdx=selector->size()-1; selectorIdx>=0; --selectorIdx ) {
+    qsizetype nextScopeIdx = scopeList->size()-1;
+    for (qsizetype selectorIdx = selector->size() - 1; selectorIdx >= 0; --selectorIdx) {
         TextScope* selectorPath = selector->at(selectorIdx);
         foundMatch=false;
 
         // find the given selector scope in the list
-        for( int scopeIdx=nextScopeIdx; scopeIdx>= 0; --scopeIdx ) {
+        for (qsizetype scopeIdx = nextScopeIdx; scopeIdx >= 0; --scopeIdx) {
             TextScope* scope = scopeList->at(scopeIdx);
-            power += scope->atomCount();
+            power += static_cast<double>(scope->atomCount());
 
             // dit we found the scope
-            if( scope->startsWith(selectorPath ) ) {
-                nextScopeIdx = scopeIdx-1;
+            if (scope->startsWith(selectorPath)) {
+                nextScopeIdx = scopeIdx - 1;
                 foundMatch = true;
-                for( int i=0,iCnt=selectorPath->atomCount(); i<iCnt; ++i ) {
-                    result += 1.0 / pow( 2, power - i );
+                for (size_t i = 0, iCnt = selectorPath->atomCount(); i < iCnt; ++i) {
+                    result += 1.0 / pow(2, power - static_cast<double>(i));
                 }
                 break;
             }
         }
 
         // no match found?
-        if( !foundMatch ) { return -1; }
+        if (!foundMatch) { return -1; }
     }
     return result;
 }
@@ -504,25 +501,25 @@ TextScopeManager::TextScopeManager()
 /// The destructor of the scope manager
 TextScopeManager::~TextScopeManager()
 {
-    foreach( TextScope* textScope, textScopeList_ ) { delete textScope; }
+    foreach(TextScope* textScope, textScopeList_) { delete textScope; }
     textScopeList_.clear();
     textScopeRefMap_.clear();
 }
 
 
-/// This method clears and delets all scopes. WARNING this destroys all registered text-scopes
-/// This method also registers the wildcard scope atom id
+/// Clears and delets all scopes. WARNING this destroys all registered text-scopes
+/// and registers the wildcard scope atom id
 void TextScopeManager::reset()
 {
     // delete and clear the scopemaps
-    if( !textScopeList_.isEmpty() ) {
-        foreach( TextScope* textScope, textScopeList_ ) { delete textScope; }
+    if (!textScopeList_.isEmpty()) {
+        foreach(TextScope* textScope, textScopeList_ ) { delete textScope; }
         textScopeList_.clear();
         textScopeRefMap_.clear();
     }
 
     // clear the atomlists
-    if( !atomNameList_.isEmpty() ) {
+    if (!atomNameList_.isEmpty()) {
         atomNameList_.clear();
         atomNameMap_.clear();
     }
@@ -533,7 +530,7 @@ void TextScopeManager::reset()
     // create a blank textscope
     TextScope* scope = new TextScope();
     textScopeList_.append(scope);
-    textScopeRefMap_.insert("",scope);
+    textScopeRefMap_.insert("", scope);
 }
 
 
@@ -544,27 +541,27 @@ TextScopeAtomId TextScopeManager::wildcardId()
 }
 
 
-/// This method registers the scope element
+/// Registers the scope element
 TextScopeAtomId TextScopeManager::findOrRegisterScopeAtom(const QString& atom)
 {
 //    element = element.toLower().trimmed();
-    TextScopeAtomId id = atomNameMap_.value(atom,-1);
-    if( id >= 0 ) { return id; }
+    TextScopeAtomId id = atomNameMap_.value(atom, -1);
+    if (id >= 0) { return id; }
     atomNameList_.append(atom);
-    id = atomNameList_.size()-1;
-    atomNameMap_.insert(atom,id);
+    id = static_cast<short>(atomNameList_.size() - 1);
+    atomNameMap_.insert(atom, id);
     return id;
 }
 
 
-/// This method finds or creates a full-scope
+/// Finds or creates a full-scope
 TextScope* TextScopeManager::refTextScope(const QString& scopeString)
 {
-    TextScope* scope = textScopeRefMap_.value(scopeString,0);
-    if( scope ) { return scope; }
+    TextScope* scope = textScopeRefMap_.value(scopeString, 0);
+    if (scope) { return scope; }
     scope = new TextScope(scopeString);
     textScopeList_.append(scope);
-    textScopeRefMap_.insert(scopeString,scope);
+    textScopeRefMap_.insert(scopeString, scope);
     return scope;
 }
 
@@ -577,13 +574,13 @@ TextScope* TextScopeManager::refEmptyScope()
 }
 
 
-/// This method creates a text-scope list from the given scope string
+/// Creates a text-scope list from the given scope string
 TextScopeList* TextScopeManager::createTextScopeList(const QString& scopeListString)
 {
     QStringList scopeParts = scopeListString.split(" ");
-    TextScopeList* list = new TextScopeList(scopeParts.size());
-    for( int i=0, cnt=scopeParts.size(); i<cnt; ++i ) {
-        list->append(  refTextScope(scopeParts.at(i)) );
+    TextScopeList* list = new TextScopeList(static_cast<int>(scopeParts.size()));
+    for (qsizetype i = 0, cnt=scopeParts.size(); i < cnt; ++i) {
+        list->append(refTextScope(scopeParts.at(i)));
     }
     return list;
 }
@@ -592,7 +589,7 @@ TextScopeList* TextScopeManager::createTextScopeList(const QString& scopeListStr
 /// Returns the name of the given atom id
 const QString& TextScopeManager::atomName(TextScopeAtomId id)
 {
-    Q_ASSERT(0 <= id && id < atomNameList_.length() );
+    Q_ASSERT(0 <= id && id < atomNameList_.length());
     return atomNameList_.at(id);
 }
 
@@ -602,8 +599,8 @@ const QString& TextScopeManager::atomName(TextScopeAtomId id)
 
 /// A multilinescoped textrange set
 MultiLineScopedTextRangeSet::MultiLineScopedTextRangeSet(TextDocument *textDocument , TextDocumentScopes *textDocumentScopes)
-    : TextRangeSetBase( textDocument )
-    , textDocumentScopesRef_( textDocumentScopes )
+    : TextRangeSetBase(textDocument)
+    , textDocumentScopesRef_(textDocumentScopes)
 {
 }
 
@@ -617,7 +614,7 @@ MultiLineScopedTextRangeSet::~MultiLineScopedTextRangeSet()
 /// Completely empties the scope list
 void MultiLineScopedTextRangeSet::reset()
 {
-    qDeleteAll( scopedRangeList_ );
+    qDeleteAll(scopedRangeList_);
     scopedRangeList_.clear();
 }
 
@@ -682,7 +679,7 @@ void MultiLineScopedTextRangeSet::toSingleRange()
 }
 
 
-/// This method sorts all ranges
+/// Sorts all ranges
 void MultiLineScopedTextRangeSet::sortRanges()
 {
     std::sort(scopedRangeList_.begin(), scopedRangeList_.end(), MultiLineScopedTextRange::lessThan);
@@ -692,53 +689,52 @@ void MultiLineScopedTextRangeSet::sortRanges()
 /// this method returns the scoped range
 MultiLineScopedTextRange& MultiLineScopedTextRangeSet::scopedRange(size_t idx)
 {
-    Q_ASSERT( 0 <= idx && idx < rangeCount() );
-    return *(scopedRangeList_[idx]);
+    Q_ASSERT(0 <= idx && idx < rangeCount());
+    return *(scopedRangeList_[static_cast<qsizetype>(idx)]);
 }
 
 
 /// Adds a textrange with the given name
-MultiLineScopedTextRange& MultiLineScopedTextRangeSet::addRange(int anchor, int caret, const QString& name, TextGrammarRule* rule )
+MultiLineScopedTextRange& MultiLineScopedTextRangeSet::addRange(size_t anchor, size_t caret, const QString& name, TextGrammarRule* rule)
 {
     MultiLineScopedTextRange* tr = new MultiLineScopedTextRange(anchor, caret, Edbee::instance()->scopeManager()->refTextScope(name) );
-    tr->setGrammarRule( rule );
-    scopedRangeList_.append( tr  );
+    tr->setGrammarRule(rule);
+    scopedRangeList_.append(tr);
     return *tr;
 }
 
 
-/// This method removes all ranges after a given offset. This means it will remove all
+/// Removes all ranges after a given offset. This means it will remove all
 /// complete ranges after the given offset. Ranges that start before the offset and
 /// end after the offset are 'invalidated' which means the end offset is placed to the end of the document
-void MultiLineScopedTextRangeSet::removeAndInvalidateRangesAfterOffset(int offset)
+void MultiLineScopedTextRangeSet::removeAndInvalidateRangesAfterOffset(size_t offset)
 {
-    int len = textDocument()->length();
+    size_t len = textDocument()->length();
     beginChanges();
-    for( int idx=rangeCount()-1; idx >= 0; idx-- ) {
+    for (size_t idx = rangeCount() - 1; idx != std::string::npos; --idx) {
         TextRange& range = this->range(idx);
-        if( range.caret() >= offset && range.anchor() >= offset ) {
+        if (range.caret() >= offset && range.anchor() >= offset) {
             removeRange(idx);
-        } else if( range.min() < offset && range.max() >= offset ) {
+        } else if (range.min() < offset && range.max() >= offset) {
             range.maxVar() = len;   // move the marker to the end
         }
-
     }
     endChangesWithoutProcessing();  // we only deleted the last range. Do the result is still sorted
 }
 
 
-/// This method gives the scoped text range to this object
+/// Gives the scoped text range to this object
 void MultiLineScopedTextRangeSet::giveScopedTextRange(MultiLineScopedTextRange* textScope)
 {
-    scopedRangeList_.append( textScope );
+    scopedRangeList_.append(textScope);
 }
 
 
-/// This method process the changes if required
-void MultiLineScopedTextRangeSet::processChangesIfRequired(bool joinBorders )
+/// Process the changes if required
+void MultiLineScopedTextRangeSet::processChangesIfRequired(bool joinBorders)
 {
-    Q_UNUSED( joinBorders );
-    if( !changing_ ) {
+    Q_UNUSED(joinBorders);
+    if (!changing_) {
         ++changing_; // prevent changing by functions below:
         //mergeOverlappingRanges(joinBorders);
         sortRanges();
@@ -751,7 +747,7 @@ void MultiLineScopedTextRangeSet::processChangesIfRequired(bool joinBorders )
 QString MultiLineScopedTextRangeSet::toString()
 {
     QString result;
-    for( int i=0,cnt=rangeCount(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = rangeCount(); i < cnt; ++i) {
         MultiLineScopedTextRange& range = scopedRange(i);
         result.append(range.toString());
         result.append("|");
@@ -766,19 +762,19 @@ QString MultiLineScopedTextRangeSet::toString()
 /// The constructor for storing/managing the textdocument scopes
 /// @param textDocument the textdocument this scoping is for
 TextDocumentScopes::TextDocumentScopes(TextDocument* textDocument)
-    : textDocumentRef_( textDocument )
-    , defaultScopedRange_(0,0,Edbee::instance()->scopeManager()->refTextScope("text.plain"))
-    , scopedRanges_( textDocument, this )
+    : textDocumentRef_(textDocument)
+    , defaultScopedRange_(0, 0, Edbee::instance()->scopeManager()->refTextScope("text.plain"))
+    , scopedRanges_(textDocument, this)
     , lastScopedOffset_(0)
 {
-    connect( textDocument, SIGNAL(languageGrammarChanged()), this, SLOT(grammarChanged()) );
+    connect(textDocument, SIGNAL(languageGrammarChanged()), this, SLOT(grammarChanged()));
 }
 
 
 /// The destructor
 TextDocumentScopes::~TextDocumentScopes()
 {
-    for( int i=0,cnt=lineRangeList_.length(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = lineRangeList_.length(); i < cnt; ++i) {
         delete lineRangeList_.at(i);
     }
     lineRangeList_.clear();
@@ -786,7 +782,7 @@ TextDocumentScopes::~TextDocumentScopes()
 
 
 /// returns the last scoped offset
-int TextDocumentScopes::lastScopedOffset()
+size_t TextDocumentScopes::lastScopedOffset()
 {
     return lastScopedOffset_;
 }
@@ -794,17 +790,17 @@ int TextDocumentScopes::lastScopedOffset()
 
 /// Sets the last scoped offset
 /// @param offset the last scoped offset
-void TextDocumentScopes::setLastScopedOffset(int offset)
+void TextDocumentScopes::setLastScopedOffset(size_t offset)
 {
-    int previousOffset = lastScopedOffset_ ;
-    if( previousOffset != offset ) {
+    size_t previousOffset = lastScopedOffset_ ;
+    if (previousOffset != offset) {
         lastScopedOffset_ = offset;
-        emit lastScopedOffsetChanged( previousOffset, lastScopedOffset_);
+        emit lastScopedOffsetChanged(previousOffset, lastScopedOffset_);
     }
 }
 
 
-/// This method sets the default scope
+/// Sets the default scope
 /// @param the name of the scope
 /// @param rule the rule that matched
 void TextDocumentScopes::setDefaultScope(const QString& name, TextGrammarRule* rule )
@@ -814,14 +810,14 @@ void TextDocumentScopes::setDefaultScope(const QString& name, TextGrammarRule* r
 }
 
 
-/// This method sets the scoped line list
+/// Sets the scoped line list
 /// @param line the line
 /// @param list the list with all scopes on the given line
-void TextDocumentScopes::giveLineScopedRangeList(int line, ScopedTextRangeList* list)
+void TextDocumentScopes::giveLineScopedRangeList(size_t line, ScopedTextRangeList* list)
 {
-    int len = lineRangeList_.length();
-    if( line >= len ) {
-        lineRangeList_.fill(len,0,0,line-len+1);
+    size_t len = lineRangeList_.length();
+    if (line >= len) {
+        lineRangeList_.fill(len, 0, 0, line - len + 1);
     }
     delete lineRangeList_.at(line); // delete a possible old value
     lineRangeList_.set(line, list);
@@ -829,18 +825,18 @@ void TextDocumentScopes::giveLineScopedRangeList(int line, ScopedTextRangeList* 
 
 
 
-/// This method returns all scoped ranges on the given line
+/// Returns all scoped ranges on the given line
 /// @param line the line to retrieve the scoped ranges for
 /// @return the scoped textrange list
-ScopedTextRangeList* TextDocumentScopes::scopedRangesAtLine(int line)
+ScopedTextRangeList* TextDocumentScopes::scopedRangesAtLine(size_t line)
 {
-    if( line >= lineRangeList_.length() || line < 0 ) { return 0; }
+    if (line >= lineRangeList_.length() || line < 0) { return nullptr; }
     return lineRangeList_.at(line);
 }
 
 
 /// Returns the number of scopes lines in the lineRangeList_
-int TextDocumentScopes::scopedLineCount()
+size_t TextDocumentScopes::scopedLineCount()
 {
     return lineRangeList_.length();
 }
@@ -853,53 +849,51 @@ void TextDocumentScopes::giveMultiLineScopedTextRange(MultiLineScopedTextRange *
 }
 
 
-/// This method invalidates all scopes after the given offset
+/// Invalidates all scopes after the given offset
 /// @param offset the offset from which to remove the offset
-void TextDocumentScopes::removeScopesAfterOffset(int offset)
+void TextDocumentScopes::removeScopesAfterOffset(size_t offset)
 {
-    if( offset == 0 ) {
+    if (offset == 0) {
         scopedRanges_.clear();
     } else {
         scopedRanges_.removeAndInvalidateRangesAfterOffset(offset);
     }
-    if( offset < lastScopedOffset_ ) {
+    if(offset < lastScopedOffset_) {
         setLastScopedOffset(offset);
     }
 
-
     // delete/remove all line ranges (after this line)
-    int line = this->textDocument()->lineFromOffset(offset) + 1;
-    if( line < lineRangeList_.length() ) {
-        for( int i=line,cnt=lineRangeList_.length(); i<cnt; ++i ) {
+    size_t line = this->textDocument()->lineFromOffset(offset) + 1;
+    if (line < lineRangeList_.length()) {
+        for(size_t i = line, cnt = lineRangeList_.length(); i < cnt; ++i) {
             delete lineRangeList_.at(i);
         }
-
-        lineRangeList_.replace(line, lineRangeList_.length()-line, 0, 0 );
+        lineRangeList_.replace(line, lineRangeList_.length() - line, 0, 0);
     }
 }
 
 
-/// This method retursn the default scoped textrange
+/// Retursn the default scoped textrange
 /// Currently this is done very dirty, by retrieving the defaultscoped range the begin and end is set tot he complete document
 /// a better solution would be a subclass that always returns 0 for an anchor and the documentlength for the caret
 MultiLineScopedTextRange& TextDocumentScopes::defaultScopedRange()
 {
-    defaultScopedRange_.set(0,textDocument()->length() );   // make sure this is always set like this
+    defaultScopedRange_.set(0, textDocument()->length());   // make sure this is always set like this
     return defaultScopedRange_;
 }
 
 
-/// This method returns all scope-ranges at the given offset-ranges
-QVector<MultiLineScopedTextRange*> TextDocumentScopes::multiLineScopedRangesBetweenOffsets(int offsetBegin, int offsetEnd)
+/// Returns all scope-ranges at the given offset-ranges
+QVector<MultiLineScopedTextRange*> TextDocumentScopes::multiLineScopedRangesBetweenOffsets(size_t offsetBegin, size_t offsetEnd)
 {
     QVector<MultiLineScopedTextRange*> result;
-    result.append( &defaultScopedRange_ );
-    int minOffset=0;
-    for( int i=0, cnt=scopedRanges_.rangeCount(); i<cnt && minOffset <= /** CHANGED 2013-01-22, was < */ offsetEnd; ++i ) {
+    result.append( &defaultScopedRange_);
+    size_t minOffset = 0;
+    for (size_t i = 0, cnt = scopedRanges_.rangeCount(); i < cnt && minOffset <= offsetEnd; ++i) {
         MultiLineScopedTextRange& range = scopedRanges_.scopedRange(i);
         minOffset = range.min();
-        int maxOffset = range.max();
-        if( (offsetBegin <= minOffset && minOffset < offsetEnd) || (minOffset <= offsetBegin && offsetBegin < maxOffset) ) {
+        size_t maxOffset = range.max();
+        if ((offsetBegin <= minOffset && minOffset < offsetEnd) || (minOffset <= offsetBegin && offsetBegin < maxOffset)) {
             result.append(&range);
         }
     }
@@ -908,67 +902,58 @@ QVector<MultiLineScopedTextRange*> TextDocumentScopes::multiLineScopedRangesBetw
 
 
 /// returns all scopes between the given offsets
-TextScopeList TextDocumentScopes::scopesAtOffset( int offset, bool includeEnd  )
+TextScopeList TextDocumentScopes::scopesAtOffset(size_t offset, bool includeEnd)
 {
     TextScopeList result;
 
-//    qlog_info() << "";
-//    qlog_info() <<  "------------[ scopesAtOffset("<<offset<<") ] --------";
-    //QVector<MultiLineScopedTextRange*> ranges = scopedRangesBetweenOffsets(offsetBegin, offsetEnd);
-    int line = textDocument()->lineFromOffset(offset);
-    int offsetInLine = offset-textDocument()->offsetFromLine(line);
+    size_t line = textDocument()->lineFromOffset(offset);
+    size_t offsetInLine = offset-textDocument()->offsetFromLine(line);
     ScopedTextRangeList* list = scopedRangesAtLine(line);
-    if( list ) {
+    if (list) {
         //scopes.reserve( ranges.size() );
-        for( int i=0,cnt=list->size(); i<cnt; ++i ) {
+        for (size_t i = 0, cnt = list->size(); i < cnt; ++i) {
             ScopedTextRange* range = list->at(i);
-//QString debug;
-//debug.append( QStringLiteral("- %1.%5: %2<=%3<%4").arg(i).arg(range->min()).arg(offsetInLine).arg(range->max()).arg(range->scope()->name()) );
-            if( range->min() <= offsetInLine ) {
-                if( offsetInLine < range->max() || (includeEnd && offsetInLine <= range->max()) ) {
-//debug.append(" Ok" );
+            if (range->min() <= offsetInLine) {
+                if (offsetInLine < range->max() || (includeEnd && offsetInLine <= range->max())) {
                    result.append(range->scope());
                 }
             }
-//qlog_info() << debug;
         }
     }
-//    qlog_info() << "";
     return result;
 }
 
 
-/// This method returns all scoped ranges at the given offset
+/// Returns all scoped ranges at the given offset
 /// Hmmm this is almost exactly the same implementation as the scopesAtOffset method !? (perhaps we should refactor this)
 ///
 /// Warning you MUST destroy (qDeleteAll) the list with scoped textranges returned by this list
 ///
 /// @param offset he offset to retrieve the scoped ranges
 /// @return the vector with text scopes. These scopes are document wide
-QVector<ScopedTextRange*> TextDocumentScopes::createScopedRangesAtOffsetList(int offset)
+QVector<ScopedTextRange*> TextDocumentScopes::createScopedRangesAtOffsetList(size_t offset)
 {
     QVector<ScopedTextRange*> result;
 
     // retrieve the line
-    int line = textDocument()->lineFromOffset(offset);
-    int lineOffset = textDocument()->offsetFromLine(line);
-    int offsetInLine = offset-lineOffset;
+    size_t line = textDocument()->lineFromOffset(offset);
+    size_t lineOffset = textDocument()->offsetFromLine(line);
+    size_t offsetInLine = offset - lineOffset;
 
     ScopedTextRangeList* list = scopedRangesAtLine(line);
-    if( list ) {
-        //scopes.reserve( ranges.size() );
-        for( int i=0,cnt=list->size(); i<cnt; ++i ) {
+    if (list) {
+        for (size_t i = 0, cnt = list->size(); i < cnt; ++i) {
             ScopedTextRange* range = list->at(i);
-            if( range->min() <= offsetInLine && offsetInLine < range->max() ) {
+            if (range->min() <= offsetInLine && offsetInLine < range->max()) {
 
                 // it's a multi-line scope reference
                 MultiLineScopedTextRange* ms = range->multiLineScopedTextRange();
-                if( ms ) {
-                    result.append( new ScopedTextRange( ms->min(), ms->max(), ms->scope() ) );
+                if (ms) {
+                    result.append(new ScopedTextRange(ms->min(), ms->max(), ms->scope()));
 
                 // it's a line scope
                 } else {
-                    result.append( new ScopedTextRange( lineOffset + range->min(), lineOffset + range->max(), range->scope() ) );
+                    result.append(new ScopedTextRange(lineOffset + range->min(), lineOffset + range->max(), range->scope()));
                 }
             }
         }
@@ -990,23 +975,22 @@ QStringList TextDocumentScopes::scopesAsStringList()
     QStringList result;
 
     // first add all multi-line scopes
-    for( int i=0,cnt=scopedRanges_.rangeCount(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = scopedRanges_.rangeCount(); i < cnt; ++i) {
         MultiLineScopedTextRange& range = scopedRanges_.scopedRange(i);
-        result.append( range.toString() );
+        result.append(range.toString());
     }
 
     result.append("**");
 
     // next add all line based scoped
-    for( int i=0,lineCnt=lineRangeList_.length(); i<lineCnt; ++i ) {
+    for(size_t i = 0, lineCnt = lineRangeList_.length(); i < lineCnt; ++i) {
         ScopedTextRangeList* list = lineRangeList_.at(i);
-        if( list != 0 ) {
-            result.append( list->toString() );
+        if (list != 0) {
+            result.append(list->toString());
         } else {
-            result.append( QStringLiteral(" << null value @ %1>>").arg(i));
+            result.append(QStringLiteral(" << null value @ %1>>").arg(i));
         }
     }
-
     return result;
 }
 
@@ -1015,7 +999,7 @@ QStringList TextDocumentScopes::scopesAsStringList()
 void TextDocumentScopes::dumpScopedLineAddresses(const QString& text)
 {
     qlog_info()<< "dumpScopedLineAddresses("<< text << "): " << lineRangeList_.length();
-    for( int i=0, cnt=lineRangeList_.length(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = lineRangeList_.length(); i < cnt; ++i) {
         qlog_info() << "-" << i << ":" << QString::number((quintptr)lineRangeList_.at(i),16);
     }
     qlog_info() << ".";
@@ -1034,7 +1018,5 @@ void TextDocumentScopes::grammarChanged()
 {
     removeScopesAfterOffset(0);
 }
-
-
 
 } // edbee

--- a/edbee-lib/edbee/models/textdocumentscopes.cpp
+++ b/edbee-lib/edbee/models/textdocumentscopes.cpp
@@ -198,7 +198,7 @@ TextGrammarRule* MultiLineScopedTextRange::grammarRule() const
 
 
 /// Gives the end regular expression
-void MultiLineScopedTextRange::giveEndRegExp( RegExp* regExp)
+void MultiLineScopedTextRange::giveEndRegExp(RegExp* regExp)
 {
     endRegExp_ = regExp;
 }

--- a/edbee-lib/edbee/models/textdocumentscopes.cpp
+++ b/edbee-lib/edbee/models/textdocumentscopes.cpp
@@ -18,8 +18,8 @@ namespace edbee {
 /// @param anchor the start of the range
 /// @param caret the caret position of the range
 /// @param scope the text scope
-ScopedTextRange::ScopedTextRange(int anchor, int caret, TextScope* scope)
-    : TextRange(anchor,caret)
+ScopedTextRange::ScopedTextRange(size_t anchor, size_t caret, TextScope* scope)
+    : TextRange(anchor, caret)
     , scopeRef_(scope)
 {
     Q_ASSERT(scopeRef_);
@@ -623,61 +623,61 @@ void MultiLineScopedTextRangeSet::reset()
 
 
 /// Returns the number of ranges
-int MultiLineScopedTextRangeSet::rangeCount() const
+size_t MultiLineScopedTextRangeSet::rangeCount() const
 {
-    return scopedRangeList_.size();
+    return static_cast<size_t>(scopedRangeList_.size());
 }
 
 
 /// returns the given textrange
-TextRange& MultiLineScopedTextRangeSet::range(int idx)
+TextRange& MultiLineScopedTextRangeSet::range(size_t idx)
 {
-    Q_ASSERT( 0 <= idx && idx < rangeCount() );
-    return *(scopedRangeList_[idx]);
+    Q_ASSERT(idx < rangeCount());
+    return *(scopedRangeList_[static_cast<qsizetype>(idx)]);
 }
 
 
 /// returns the cont range
-const TextRange& MultiLineScopedTextRangeSet::constRange(int idx) const
+const TextRange& MultiLineScopedTextRangeSet::constRange(size_t idx) const
 {
-    Q_ASSERT( 0 <= idx && idx < rangeCount() );
-    return *(scopedRangeList_[idx]);
+    Q_ASSERT(idx < rangeCount());
+    return *(scopedRangeList_[static_cast<qsizetype>(idx)]);
 }
 
 
-/// This method adds a range with the default scope
-void MultiLineScopedTextRangeSet::addRange(int anchor, int caret)
+/// Adds a range with the default scope
+void MultiLineScopedTextRangeSet::addRange(size_t anchor, size_t caret)
 {
-    scopedRangeList_.append( new MultiLineScopedTextRange(anchor, caret,Edbee::instance()->scopeManager()->refEmptyScope() ) );
+    scopedRangeList_.append(new MultiLineScopedTextRange(anchor, caret,Edbee::instance()->scopeManager()->refEmptyScope()));
 }
 
 
 ///adds the given range
 void MultiLineScopedTextRangeSet::addRange(const TextRange& range)
 {
-    addRange( range.anchor(), range.caret() );
+    addRange(range.anchor(), range.caret());
 }
 
 
 ///' removes the given scope
-void MultiLineScopedTextRangeSet::removeRange(int idx)
+void MultiLineScopedTextRangeSet::removeRange(size_t idx)
 {
-    delete scopedRangeList_[idx];
-    scopedRangeList_.removeAt(idx);
+    delete scopedRangeList_[static_cast<qsizetype>(idx)];
+    scopedRangeList_.removeAt(static_cast<qsizetype>(idx));
 }
 
 
 /// removes all scopes
 void MultiLineScopedTextRangeSet::clear()
 {
-    qDeleteAll( scopedRangeList_ );
+    qDeleteAll(scopedRangeList_);
     scopedRangeList_.clear();
 }
 
 
 void MultiLineScopedTextRangeSet::toSingleRange()
 {
-    Q_ASSERT( false ); ///< NOT IMPLEMENTED
+    Q_ASSERT(false); ///< NOT IMPLEMENTED
     //scopedRangeList_.remove(1, scopedRangeList_.size()-1);
 }
 
@@ -690,7 +690,7 @@ void MultiLineScopedTextRangeSet::sortRanges()
 
 
 /// this method returns the scoped range
-MultiLineScopedTextRange& MultiLineScopedTextRangeSet::scopedRange(int idx)
+MultiLineScopedTextRange& MultiLineScopedTextRangeSet::scopedRange(size_t idx)
 {
     Q_ASSERT( 0 <= idx && idx < rangeCount() );
     return *(scopedRangeList_[idx]);

--- a/edbee-lib/edbee/models/textdocumentscopes.h
+++ b/edbee-lib/edbee/models/textdocumentscopes.h
@@ -35,24 +35,26 @@ typedef short TextScopeAtomId;
 class EDBEE_EXPORT TextScope {
 public:
     const QString name();
-    int atomCount();
-    TextScopeAtomId atomAt(int idx) const;
+    size_t atomCount();
+    TextScopeAtomId atomAt(size_t idx) const;
 
     bool startsWith(TextScope* scope);
-    int rindexOf(TextScope* scope);
+    size_t rindexOf(TextScope* scope);
 
 private:
     TextScope( const QString& fullScope );
     TextScope();
     ~TextScope();
 
-    char scopeAtomCount_;                 ///< the number of scope-atoms
-    TextScopeAtomId* scopeAtoms_;         ///< the scope atoms
+    size_t scopeAtomCount_;              ///< the number of scope-atoms
+    TextScopeAtomId* scopeAtoms_;        ///< the scope atoms
 
     friend class TextScopeManager;
 };
 
+
 //===========================================
+
 
 /// A list of text-scopes.
 /// on a certian location, usually more then one scope is available on a given location
@@ -63,7 +65,7 @@ public:
     TextScopeList(int initialSize);
     TextScopeList(QVector<ScopedTextRange*>& ranges);
 
-    int atomCount() const;
+    size_t atomCount() const;
 
     QString toString();
 };
@@ -113,7 +115,7 @@ public:
     TextScopeSelector(const QString& selector);
     virtual ~TextScopeSelector();
 
-    double calculateMatchScore(const TextScopeList* scopeList );
+    double calculateMatchScore(const TextScopeList* scopeList);
     QString toString();
 
 private:
@@ -125,6 +127,7 @@ private:
 
 
 //===========================================
+
 
 /// The scope manager is used to manage the scopes...
 /// A scope consist out of several scope-parts:
@@ -158,11 +161,11 @@ private:
 
     // scope atoms
     QList<QString> atomNameList_;                           ///< All scope-atom names
-    QHash<QString,TextScopeAtomId> atomNameMap_;            ///< the scope atom map
+    QHash<QString, TextScopeAtomId> atomNameMap_;           ///< the scope atom map
 
     // full scopes
     QList<TextScope*> textScopeList_;                       ///< The list of full-scope
-    QHash<QString,TextScope*> textScopeRefMap_;             ///< The full-scope map
+    QHash<QString, TextScope*> textScopeRefMap_;            ///< The full-scope map
 };
 
 
@@ -221,13 +224,13 @@ public:
     explicit ScopedTextRangeList();
     virtual ~ScopedTextRangeList();
 
-    int size() const;
-    ScopedTextRange* at(int idx);
+    size_t size() const;
+    ScopedTextRange* at(size_t idx);
     void giveRange(ScopedTextRange* at);
     void giveAndPrependRange(ScopedTextRange* range);
 
     void squeeze();
-    void setIndependent(bool enable=true);
+    void setIndependent(bool enable = true);
     bool isIndependent() const;
 
     QString toString();
@@ -246,7 +249,7 @@ private:
 class EDBEE_EXPORT MultiLineScopedTextRange : public ScopedTextRange
 {
 public:
-    MultiLineScopedTextRange(int anchor, int caret, TextScope* scope);
+    MultiLineScopedTextRange(size_t anchor, size_t caret, TextScope* scope);
     virtual ~MultiLineScopedTextRange();
 
     void setGrammarRule(TextGrammarRule* rule);
@@ -258,7 +261,7 @@ public:
     static bool lessThan(MultiLineScopedTextRange* r1, MultiLineScopedTextRange* r2);
 
 private:
-    TextGrammarRule* ruleRef_;     ///< The grammar rule that found this range
+    TextGrammarRule* ruleRef_; ///< The grammar rule that found this range
     RegExp* endRegExp_;        ///< The end regexp
 };
 
@@ -287,9 +290,9 @@ public:
     virtual void toSingleRange();
     virtual void sortRanges();
     virtual MultiLineScopedTextRange& scopedRange(size_t idx);
-    virtual MultiLineScopedTextRange& addRange(int anchor, int caret, const QString& name , TextGrammarRule *rule);
+    virtual MultiLineScopedTextRange& addRange(size_t anchor, size_t caret, const QString& name , TextGrammarRule *rule);
 
-    void removeAndInvalidateRangesAfterOffset(int offset);
+    void removeAndInvalidateRangesAfterOffset(size_t offset);
 
     // adds a text scope
     void giveScopedTextRange(MultiLineScopedTextRange* textScope);
@@ -301,8 +304,8 @@ public:
 
 private:
 
-    TextDocumentScopes* textDocumentScopesRef_;     ///< A reference to the text document scopes
-    QList<MultiLineScopedTextRange*> scopedRangeList_;       ///< A list of all scoped ranges
+    TextDocumentScopes* textDocumentScopesRef_;         ///< A reference to the text document scopes
+    QList<MultiLineScopedTextRange*> scopedRangeList_;  ///< A list of all scoped ranges
 };
 
 
@@ -318,24 +321,23 @@ public:
     TextDocumentScopes(TextDocument* textDocument);
     virtual ~TextDocumentScopes();
 
-    int lastScopedOffset();
-    void setLastScopedOffset(int offset);
-
+    size_t lastScopedOffset();
+    void setLastScopedOffset(size_t offset);
 
     // scope management
     void setDefaultScope(const QString& name, TextGrammarRule *rule);
 
-    void giveLineScopedRangeList(int line, ScopedTextRangeList* list);
-    ScopedTextRangeList* scopedRangesAtLine(int line);
-    int scopedLineCount();
+    void giveLineScopedRangeList(size_t line, ScopedTextRangeList* list);
+    ScopedTextRangeList* scopedRangesAtLine(size_t line);
+    size_t scopedLineCount();
 
     void giveMultiLineScopedTextRange(MultiLineScopedTextRange* range);
-    void removeScopesAfterOffset(int offset);
+    void removeScopesAfterOffset(size_t offset);
     MultiLineScopedTextRange& defaultScopedRange();
 
-    QVector<MultiLineScopedTextRange*> multiLineScopedRangesBetweenOffsets(int offsetBegin, int offsetEnd);
-    TextScopeList scopesAtOffset(int offset , bool includeEnd = false);
-    QVector<ScopedTextRange*> createScopedRangesAtOffsetList(int offset);
+    QVector<MultiLineScopedTextRange*> multiLineScopedRangesBetweenOffsets(size_t offsetBegin, size_t offsetEnd);
+    TextScopeList scopesAtOffset(size_t offset, bool includeEnd = false);
+    QVector<ScopedTextRange*> createScopedRangesAtOffsetList(size_t offset);
 
     QString toString();
     QStringList scopesAsStringList();
@@ -350,15 +352,14 @@ protected slots:
     void grammarChanged();
 
 signals:
-    void lastScopedOffsetChanged(int previousOffset, int lastScopedOffset);
+    void lastScopedOffsetChanged(size_t previousOffset, size_t lastScopedOffset);
 
 private:
-
     TextDocument* textDocumentRef_;             ///< The default document reference
 
-    MultiLineScopedTextRange defaultScopedRange_;          ///< The default scoped text range
-    MultiLineScopedTextRangeSet scopedRanges_;             ///< A list with all (multi-line) ranges
-    GapVector<ScopedTextRangeList*>  lineRangeList_;       ///< A list of all line scopes
+    MultiLineScopedTextRange defaultScopedRange_;     ///< The default scoped text range
+    MultiLineScopedTextRangeSet scopedRanges_;        ///< A list with all (multi-line) ranges
+    GapVector<ScopedTextRangeList*> lineRangeList_;   ///< A list of all line scopes
 
     /// This special variable is used to 'remember' to which offset the document has been scoped.
     /// This should speed up the syntax highlighting drasticly because the parsing only needs to happen
@@ -368,7 +369,7 @@ private:
     /// For all 'open' multi-line scopes with an end-offset of (documentLength).
     ///
     /// The scopedToOffset_ should only mark the multi-line scopes. Single lines scopes do NOT affect other regions of the document
-    int lastScopedOffset_;            ///< How far has the text been fully scoped?
+    size_t lastScopedOffset_;            ///< How far has the text been fully scoped?
 };
 
 

--- a/edbee-lib/edbee/models/textdocumentscopes.h
+++ b/edbee-lib/edbee/models/textdocumentscopes.h
@@ -11,7 +11,6 @@
 #include <QVector>
 
 #include "edbee/models/textrange.h"
-#include "edbee/models/textlinedata.h"
 #include "edbee/util/gapvector.h"
 
 namespace edbee {
@@ -39,8 +38,8 @@ public:
     int atomCount();
     TextScopeAtomId atomAt(int idx) const;
 
-    bool startsWith( TextScope* scope );
-    int rindexOf( TextScope* scope );
+    bool startsWith(TextScope* scope);
+    int rindexOf(TextScope* scope);
 
 private:
     TextScope( const QString& fullScope );
@@ -61,8 +60,8 @@ class EDBEE_EXPORT TextScopeList : public QVector<TextScope*>
 {
 public:
     TextScopeList();
-    TextScopeList( int initialSize );
-    TextScopeList( QVector<ScopedTextRange*>& ranges );
+    TextScopeList(int initialSize);
+    TextScopeList(QVector<ScopedTextRange*>& ranges);
 
     int atomCount() const;
 
@@ -111,15 +110,14 @@ public:
 ///
 class EDBEE_EXPORT TextScopeSelector {
 public:
-    TextScopeSelector( const QString& selector );
+    TextScopeSelector(const QString& selector);
     virtual ~TextScopeSelector();
 
     double calculateMatchScore(const TextScopeList* scopeList );
     QString toString();
 
 private:
-    double calculateMatchScoreForSelector( TextScopeList* selector, const TextScopeList* scopeList );
-
+    double calculateMatchScoreForSelector(TextScopeList* selector, const TextScopeList* scopeList);
 
 private:
     QVector<TextScopeList*> selectorList_;
@@ -147,13 +145,13 @@ public:
 
     TextScopeAtomId wildcardId();
 
-    TextScopeAtomId findOrRegisterScopeAtom( const QString& atom );
-    TextScope* refTextScope( const QString& scopeString );
+    TextScopeAtomId findOrRegisterScopeAtom(const QString& atom);
+    TextScope* refTextScope(const QString& scopeString);
     TextScope* refEmptyScope();
 
-    TextScopeList* createTextScopeList(const QString &scopeListString );
+    TextScopeList* createTextScopeList(const QString &scopeListString);
 
-    const QString& atomName( TextScopeAtomId id );
+    const QString& atomName(TextScopeAtomId id);
 
 private:
     TextScopeAtomId wildCardId_;                            ///< The atom id reserved for the wildcard '*'
@@ -175,16 +173,15 @@ private:
 class EDBEE_EXPORT ScopedTextRange : public TextRange
 {
 public:
-    ScopedTextRange( int anchor, int caret, TextScope* scope );
-//    ScopedTextRange( const MultiLineScopedTextRange& range );
+    ScopedTextRange(size_t anchor, size_t caret, TextScope* scope);
     virtual ~ScopedTextRange();
 
-    void setScope( TextScope* scope );
+    void setScope(TextScope* scope);
     TextScope* scope() const;
     QString toString() const;
 
     /// returns the multi-line scoped text range
-    virtual MultiLineScopedTextRange* multiLineScopedTextRange() { return 0; }
+    virtual MultiLineScopedTextRange* multiLineScopedTextRange() { return nullptr; }
 
 
 private:
@@ -200,7 +197,7 @@ private:
 class EDBEE_EXPORT MultiLineScopedTextRangeReference : public ScopedTextRange
 {
 public:
-    MultiLineScopedTextRangeReference( MultiLineScopedTextRange& range );
+    MultiLineScopedTextRangeReference(MultiLineScopedTextRange& range);
     virtual ~MultiLineScopedTextRangeReference();
 
     /// returns the multi-line scoped text range
@@ -211,8 +208,8 @@ private:
 };
 
 
-
 //===========================================
+
 
 /// a list of textscopes
 /// This class is used for single-line scopes
@@ -225,9 +222,9 @@ public:
     virtual ~ScopedTextRangeList();
 
     int size() const;
-    ScopedTextRange* at( int idx );
-    void giveRange( ScopedTextRange* at );
-    void giveAndPrependRange(ScopedTextRange* range );
+    ScopedTextRange* at(int idx);
+    void giveRange(ScopedTextRange* at);
+    void giveAndPrependRange(ScopedTextRange* range);
 
     void squeeze();
     void setIndependent(bool enable=true);
@@ -235,14 +232,10 @@ public:
 
     QString toString();
 
-
 private:
 
     QVector<ScopedTextRange*> ranges_;  ///< the textranges
     bool independent_;                  ///< this boolean tells if the line contains a multi-lined scope start or end
-
-//    int size_;                      /// The number of ranges
-//    ScopedTextRange* ranges_;       /// The list of ranges
 };
 
 
@@ -256,13 +249,13 @@ public:
     MultiLineScopedTextRange(int anchor, int caret, TextScope* scope);
     virtual ~MultiLineScopedTextRange();
 
-    void setGrammarRule( TextGrammarRule* rule );
+    void setGrammarRule(TextGrammarRule* rule);
     TextGrammarRule* grammarRule() const;
 
-    void giveEndRegExp( RegExp* regExp );
+    void giveEndRegExp(RegExp* regExp);
     RegExp* endRegExp();
 
-    static bool lessThan( MultiLineScopedTextRange* r1, MultiLineScopedTextRange* r2);
+    static bool lessThan(MultiLineScopedTextRange* r1, MultiLineScopedTextRange* r2);
 
 private:
     TextGrammarRule* ruleRef_;     ///< The grammar rule that found this range
@@ -278,29 +271,29 @@ private:
 class EDBEE_EXPORT MultiLineScopedTextRangeSet : public TextRangeSetBase
 {
 public:
-    MultiLineScopedTextRangeSet( TextDocument* textDocument, TextDocumentScopes* textDocumentScopes );
+    MultiLineScopedTextRangeSet(TextDocument* textDocument, TextDocumentScopes* textDocumentScopes);
     virtual ~MultiLineScopedTextRangeSet();
     void reset();
 
-  // text range functionality
-    virtual int rangeCount() const;
-    virtual TextRange& range(int idx);
-    virtual const TextRange& constRange(int idx) const;
-    virtual void addRange( int anchor, int caret );
+    // text range functionality
+    virtual size_t rangeCount() const;
+    virtual TextRange& range(size_t idx);
+    virtual const TextRange& constRange(size_t idx) const;
+    virtual void addRange(size_t anchor, size_t caret);
     virtual void addRange(const TextRange& range);
 
-    virtual void removeRange( int idx );
+    virtual void removeRange(size_t idx);
     virtual void clear();
     virtual void toSingleRange();
     virtual void sortRanges();
-    virtual MultiLineScopedTextRange& scopedRange(int idx);
+    virtual MultiLineScopedTextRange& scopedRange(size_t idx);
     virtual MultiLineScopedTextRange& addRange(int anchor, int caret, const QString& name , TextGrammarRule *rule);
 
-    void removeAndInvalidateRangesAfterOffset( int offset );
+    void removeAndInvalidateRangesAfterOffset(int offset);
 
-  // adds a text scope
-    void giveScopedTextRange( MultiLineScopedTextRange* textScope );
-    void processChangesIfRequired( bool joinBorders );
+    // adds a text scope
+    void giveScopedTextRange(MultiLineScopedTextRange* textScope);
+    void processChangesIfRequired(bool joinBorders);
 
     QString toString();
 
@@ -313,7 +306,6 @@ private:
 };
 
 
-
 //===========================================
 
 
@@ -323,34 +315,34 @@ class EDBEE_EXPORT TextDocumentScopes : public QObject
 Q_OBJECT
 
 public:
-    TextDocumentScopes( TextDocument* textDocument);
+    TextDocumentScopes(TextDocument* textDocument);
     virtual ~TextDocumentScopes();
 
     int lastScopedOffset();
-    void setLastScopedOffset( int offset );
+    void setLastScopedOffset(int offset);
 
 
-  // scope management
+    // scope management
     void setDefaultScope(const QString& name, TextGrammarRule *rule);
 
-    void giveLineScopedRangeList( int line, ScopedTextRangeList* list);
-    ScopedTextRangeList* scopedRangesAtLine( int line );
+    void giveLineScopedRangeList(int line, ScopedTextRangeList* list);
+    ScopedTextRangeList* scopedRangesAtLine(int line);
     int scopedLineCount();
 
-    void giveMultiLineScopedTextRange( MultiLineScopedTextRange* range );
-    void removeScopesAfterOffset( int offset );
+    void giveMultiLineScopedTextRange(MultiLineScopedTextRange* range);
+    void removeScopesAfterOffset(int offset);
     MultiLineScopedTextRange& defaultScopedRange();
 
-    QVector<MultiLineScopedTextRange*> multiLineScopedRangesBetweenOffsets( int offsetBegin, int offsetEnd );
-    TextScopeList scopesAtOffset(int offset , bool includeEnd=false );
-    QVector<ScopedTextRange*> createScopedRangesAtOffsetList( int offset );
+    QVector<MultiLineScopedTextRange*> multiLineScopedRangesBetweenOffsets(int offsetBegin, int offsetEnd);
+    TextScopeList scopesAtOffset(int offset , bool includeEnd = false);
+    QVector<ScopedTextRange*> createScopedRangesAtOffsetList(int offset);
 
     QString toString();
     QStringList scopesAsStringList();
 
-    void dumpScopedLineAddresses( const QString& text = QString() );
+    void dumpScopedLineAddresses(const QString& text = QString());
 
-  // getters
+    // getters
     TextDocument* textDocument();
 
 protected slots:
@@ -358,15 +350,13 @@ protected slots:
     void grammarChanged();
 
 signals:
-    void lastScopedOffsetChanged(int previousOffset, int lastScopedOffset );
+    void lastScopedOffsetChanged(int previousOffset, int lastScopedOffset);
 
 private:
 
     TextDocument* textDocumentRef_;             ///< The default document reference
 
-//    TextScope* defaultScope_;                   ///< The default scope
     MultiLineScopedTextRange defaultScopedRange_;          ///< The default scoped text range
-//    QHash<QString,TextScope*> scopeMap_;                 ///< A list of all defined/used scopes (pointers to these scopes are smaller then full strings)
     MultiLineScopedTextRangeSet scopedRanges_;             ///< A list with all (multi-line) ranges
     GapVector<ScopedTextRangeList*>  lineRangeList_;       ///< A list of all line scopes
 
@@ -379,7 +369,6 @@ private:
     ///
     /// The scopedToOffset_ should only mark the multi-line scopes. Single lines scopes do NOT affect other regions of the document
     int lastScopedOffset_;            ///< How far has the text been fully scoped?
-
 };
 
 

--- a/edbee-lib/edbee/models/texteditorkeymap.cpp
+++ b/edbee-lib/edbee/models/texteditorkeymap.cpp
@@ -8,10 +8,9 @@
 
 #include "edbee/data/factorykeymap.h"
 #include "edbee/io/keymapparser.h"
-#include "edbee/models/change.h"
+//#include "edbee/models/change.h"
 #include "edbee/texteditorcontroller.h"
-#include "edbee/models/textdocument.h"
-
+//#include "edbee/models/textdocument.h"
 
 #include "edbee/debug.h"
 
@@ -27,7 +26,7 @@ TextEditorKey::TextEditorKey(const QKeySequence& seq)
 /// Clones the text editor key
 TextEditorKey* TextEditorKey::clone() const
 {
-    return new TextEditorKey( sequence_ );
+    return new TextEditorKey(sequence_);
 }
 
 
@@ -45,24 +44,13 @@ const QKeySequence& TextEditorKey::sequence()
 TextEditorKeyMap::TextEditorKeyMap(TextEditorKeyMap *parentKeyMap)
     : parentRef_(parentKeyMap)
 {
-
 }
-
-/// the copy constructor
-//TextEditorKeyMap::TextEditorKeyMap(const TextEditorKeyMap& keyMap)
-//{
-//    QMap<QKeySequence,QString>::const_iterator i = keyMap.actionMap_.constBegin();
-//    while (i != keyMap.actionMap_.constEnd()) {
-//        set( i.key(), i.value() );
-//    }
-//    maxSequenceLength_ = keyMap.maxSequenceLength_;
-//}
 
 
 /// empty the keymap
 TextEditorKeyMap::~TextEditorKeyMap()
 {
-    qDeleteAll( keyMap_ );
+    qDeleteAll(keyMap_);
 }
 
 
@@ -70,8 +58,8 @@ TextEditorKeyMap::~TextEditorKeyMap()
 /// @param keyMap the keymap to copy the keys from
 void TextEditorKeyMap::copyKeysTo(TextEditorKeyMap* keyMap)
 {
-    for( QMultiHash<QString,TextEditorKey*>::const_iterator itr = keyMap_.constBegin(); itr != keyMap_.constEnd(); ++itr ) {
-        keyMap->keyMap_.insert( itr.key(), itr.value()->clone() );
+    for (QMultiHash<QString,TextEditorKey*>::const_iterator itr = keyMap_.constBegin(); itr != keyMap_.constEnd(); ++itr) {
+        keyMap->keyMap_.insert(itr.key(), itr.value()->clone());
     }
 }
 
@@ -83,8 +71,8 @@ void TextEditorKeyMap::copyKeysTo(TextEditorKeyMap* keyMap)
 TextEditorKey* TextEditorKeyMap::get(const QString& name) const
 {
     QMultiHash<QString,TextEditorKey*>::const_iterator itr = keyMap_.find(name);
-    if( itr != keyMap_.end() ) { return itr.value(); }
-    if( parentRef_ ) { return parentRef_->get(name); }
+    if (itr != keyMap_.end()) { return itr.value(); }
+    if (parentRef_) { return parentRef_->get(name); }
     return nullptr;
 }
 
@@ -95,7 +83,7 @@ TextEditorKey* TextEditorKeyMap::get(const QString& name) const
 QKeySequence TextEditorKeyMap::getSequence(const QString& name) const
 {
     TextEditorKey* key = get(name);
-    if( !key ){ return QKeySequence(); }
+    if (!key){ return QKeySequence(); }
     return key->sequence();
 }
 
@@ -106,10 +94,10 @@ QList<TextEditorKey*> TextEditorKeyMap::getAll(const QString& name) const
 {
     QList<TextEditorKey*> result = keyMap_.values(name);
     // also add the references of the parent
-    if( parentRef_ ) {
+    if(parentRef_) {
         QList<TextEditorKey*> parentResult = parentRef_->getAll(name);
-        foreach( TextEditorKey* seq, parentResult ) {
-            if( !result.contains(seq) ) {
+        foreach (TextEditorKey* seq, parentResult) {
+            if (!result.contains(seq)) {
                 result.append(seq);
             }
         }
@@ -123,7 +111,7 @@ QList<TextEditorKey*> TextEditorKeyMap::getAll(const QString& name) const
 bool TextEditorKeyMap::has(const QString& name) const
 {
     bool result = !(keyMap_.find(name) == keyMap_.end());
-    if( !result && parentRef_ ) {
+    if (!result && parentRef_) {
         result = parentRef_->has(name);
     }
     return result;
@@ -135,7 +123,7 @@ bool TextEditorKeyMap::has(const QString& name) const
 /// @param sequence the keysequence
 void TextEditorKeyMap::add(const QString& command, TextEditorKey* sequence)
 {
-    keyMap_.insert(command,sequence);
+    keyMap_.insert(command, sequence);
 }
 
 
@@ -144,7 +132,7 @@ void TextEditorKeyMap::add(const QString& command, TextEditorKey* sequence)
 /// @param sequence the keysequence
 void TextEditorKeyMap::add(const QString& command, const QKeySequence& seq)
 {
-    keyMap_.insert(command, new TextEditorKey(seq) );
+    keyMap_.insert(command, new TextEditorKey(seq));
 }
 
 
@@ -157,9 +145,9 @@ bool TextEditorKeyMap::add(const QString& command, const QString& seq)
 {
     // when the given keys-string is a 'standard-key' name we use the standard key
     QKeySequence::StandardKey standardKey = TextEditorKeyMap::standardKeyFromString(seq);
-    if( standardKey != QKeySequence::UnknownKey) {
-        foreach(QKeySequence sequence,QKeySequence::keyBindings(standardKey)) {
-            add( command, new TextEditorKey( QKeySequence(sequence) ) );
+    if (standardKey != QKeySequence::UnknownKey) {
+        foreach (QKeySequence sequence,QKeySequence::keyBindings(standardKey)) {
+            add(command, new TextEditorKey( QKeySequence(sequence)));
         }
         return true;
     }
@@ -167,26 +155,20 @@ bool TextEditorKeyMap::add(const QString& command, const QString& seq)
     // When it's not a standard key we try a textual key sequence
     QKeySequence normalKey = QKeySequence(seq);
     if( normalKey != QKeySequence::UnknownKey ) {
-        add( command, new TextEditorKey( normalKey ) );
+        add(command, new TextEditorKey(normalKey));
         return true;
     }
 
     // well this didn't go well
     return false;
-
 }
 
-
-//void TextEditorKeyMap::set(const QString& name, const QKeySequence::StandardKey key)
-//{
-//    keyMap_.insertMulti(name, QKeySequence(key));
-//}
 
 /// replace the given command with the given key sequence
 /// all other keysequences (on this level) are ignored
 void TextEditorKeyMap::replace(const QString& name, TextEditorKey* sequence)
 {
-    qDeleteAll( keyMap_.values(name) );
+    qDeleteAll(keyMap_.values(name));
     keyMap_.insert(name,sequence);
 }
 
@@ -204,121 +186,121 @@ QString TextEditorKeyMap::findBySequence(QKeySequence sequence, QKeySequence::Se
     QMultiHash<QString,TextEditorKey*>::iterator itr = keyMap_.begin();
     while (itr != keyMap_.end()) {
         match =  sequence.matches( itr.value()->sequence() );
-        if( match != QKeySequence::NoMatch ) {
+        if (match != QKeySequence::NoMatch) {
             return itr.key();
         }
         ++itr;
     }
-    if( parentRef_ ) return parentRef_->findBySequence(sequence,match);
+    if (parentRef_) return parentRef_->findBySequence(sequence, match);
     match = QKeySequence::NoMatch;
     return "";
 }
-
 
 
 /// This method joins 2 key-sequences to 1 sequence (if possible)
 /// if seq1 + se2 length > 4 seq2 is returned
 QKeySequence TextEditorKeyMap::joinKeySequences(const QKeySequence seq1, const QKeySequence seq2)
 {
-    if( seq1.count() + seq2.count() > 4 ) { return seq2; }
+    if (seq1.count() + seq2.count() > 4) { return seq2; }
     int idx=0;
-    int keys[] = {0,0,0,0};
-    for( int i=0; i < seq1.count(); ++i ) {
+    int keys[] = { 0, 0, 0, 0};
+    for (uint i = 0, cnt = static_cast<uint>(seq1.count()); i < cnt; ++i) {
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         keys[idx++] = seq1[i];
 #else
         keys[idx++] = seq1[i].toCombined();
 #endif
     }
-    for( int i=0; i < seq2.count(); ++i ) {
+    for (uint i = 0, cnt = static_cast<uint>(seq2.count()); i < cnt; ++i) {
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         keys[idx++] = seq2[i];
 #else
         keys[idx++] = seq2[i].toCombined();
 #endif
     }
-    return QKeySequence(keys[0],keys[1],keys[2],keys[3]);
+    return QKeySequence(keys[0], keys[1], keys[2], keys[3]);
 }
 
 
 /// a map of all standard keys
 static QHash<QString,QKeySequence::StandardKey> stringToStandardKey;
 
+
 /// converts a string to a standard key
 /// if the standard key isn't found it returns 'QKeySequence::UnknownKey '
-QKeySequence::StandardKey TextEditorKeyMap::standardKeyFromString( const QString& str )
+QKeySequence::StandardKey TextEditorKeyMap::standardKeyFromString(const QString& str)
 {
     QHash<QString,QKeySequence::StandardKey>& h = stringToStandardKey;
-    if( h.isEmpty() ) {
-        h.insert( "add_tab", QKeySequence::AddTab );
-        h.insert( "back", QKeySequence::Back );
-        h.insert( "bold", QKeySequence::Bold );
-        h.insert( "close", QKeySequence::Close );
-        h.insert( "copy", QKeySequence::Copy );
-        h.insert( "cut", QKeySequence::Cut );
-        h.insert( "delete", QKeySequence::Delete );
-        h.insert( "delete_end_of_line", QKeySequence::DeleteEndOfLine );
-        h.insert( "delete_end_of_word", QKeySequence::DeleteEndOfWord );
-        h.insert( "delete_start_of_word", QKeySequence::DeleteStartOfWord );
-        h.insert( "find", QKeySequence::Find );
-        h.insert( "find_next", QKeySequence::FindNext );
-        h.insert( "find_previous", QKeySequence::FindPrevious );
-        h.insert( "forward", QKeySequence::Forward );
-        h.insert( "help_contents", QKeySequence::HelpContents );
-        h.insert( "insert_line_separator", QKeySequence::InsertLineSeparator );
-        h.insert( "insert_paragraph_separator", QKeySequence::InsertParagraphSeparator );
-        h.insert( "italic", QKeySequence::Italic );
-        h.insert( "move_to_end_of_block", QKeySequence::MoveToEndOfBlock );
-        h.insert( "move_to_end_of_document", QKeySequence::MoveToEndOfDocument );
-        h.insert( "move_to_end_of_line", QKeySequence::MoveToEndOfLine );
-        h.insert( "move_to_next_char", QKeySequence::MoveToNextChar );
-        h.insert( "move_to_next_line", QKeySequence::MoveToNextLine );
-        h.insert( "move_to_next_page", QKeySequence::MoveToNextPage );
-        h.insert( "move_to_next_word", QKeySequence::MoveToNextWord );
-        h.insert( "move_to_previous_char", QKeySequence::MoveToPreviousChar );
-        h.insert( "move_to_previous_line", QKeySequence::MoveToPreviousLine );
-        h.insert( "move_to_previous_page", QKeySequence::MoveToPreviousPage );
-        h.insert( "move_to_previous_word", QKeySequence::MoveToPreviousWord );
-        h.insert( "move_to_start_of_block", QKeySequence::MoveToStartOfBlock );
-        h.insert( "move_to_start_of_document", QKeySequence::MoveToStartOfDocument );
-        h.insert( "move_to_start_of_line", QKeySequence::MoveToStartOfLine );
-        h.insert( "new", QKeySequence::New );
-        h.insert( "next_child", QKeySequence::NextChild );
-        h.insert( "open", QKeySequence::Open );
-        h.insert( "paste", QKeySequence::Paste );
-        h.insert( "preferences", QKeySequence::Preferences );
-        h.insert( "previous_child", QKeySequence::PreviousChild );
-        h.insert( "print", QKeySequence::Print );
-        h.insert( "quit", QKeySequence::Quit );
-        h.insert( "redo", QKeySequence::Redo );
-        h.insert( "refresh", QKeySequence::Refresh );
-        h.insert( "replace", QKeySequence::Replace );
-        h.insert( "save_as", QKeySequence::SaveAs );
-        h.insert( "save", QKeySequence::Save );
-        h.insert( "select_all", QKeySequence::SelectAll );
-        h.insert( "select_end_of_block", QKeySequence::SelectEndOfBlock );
-        h.insert( "select_end_of_document", QKeySequence::SelectEndOfDocument );
-        h.insert( "select_end_of_line", QKeySequence::SelectEndOfLine );
-        h.insert( "select_next_char", QKeySequence::SelectNextChar );
-        h.insert( "select_next_line", QKeySequence::SelectNextLine );
-        h.insert( "select_next_page", QKeySequence::SelectNextPage );
-        h.insert( "select_next_word", QKeySequence::SelectNextWord );
-        h.insert( "select_previous_char", QKeySequence::SelectPreviousChar );
-        h.insert( "select_previous_line", QKeySequence::SelectPreviousLine );
-        h.insert( "select_previous_page", QKeySequence::SelectPreviousPage );
-        h.insert( "select_previous_word", QKeySequence::SelectPreviousWord );
-        h.insert( "select_start_of_block", QKeySequence::SelectStartOfBlock );
-        h.insert( "select_start_of_document", QKeySequence::SelectStartOfDocument );
-        h.insert( "select_start_of_line", QKeySequence::SelectStartOfLine );
-        h.insert( "underline", QKeySequence::Underline );
-        h.insert( "undo", QKeySequence::Undo );
-        h.insert( "unknown_key", QKeySequence::UnknownKey );
-        h.insert( "whats_this", QKeySequence::WhatsThis );
-        h.insert( "zoom_in", QKeySequence::ZoomIn );
-        h.insert( "zoom_out", QKeySequence::ZoomOut );
-        h.insert( "full_screen", QKeySequence::FullScreen );
+    if (h.isEmpty()) {
+        h.insert("add_tab", QKeySequence::AddTab);
+        h.insert("back", QKeySequence::Back);
+        h.insert("bold", QKeySequence::Bold);
+        h.insert("close", QKeySequence::Close);
+        h.insert("copy", QKeySequence::Copy);
+        h.insert("cut", QKeySequence::Cut);
+        h.insert("delete", QKeySequence::Delete);
+        h.insert("delete_end_of_line", QKeySequence::DeleteEndOfLine);
+        h.insert("delete_end_of_word", QKeySequence::DeleteEndOfWord);
+        h.insert("delete_start_of_word", QKeySequence::DeleteStartOfWord);
+        h.insert("find", QKeySequence::Find);
+        h.insert("find_next", QKeySequence::FindNext);
+        h.insert("find_previous", QKeySequence::FindPrevious);
+        h.insert("forward", QKeySequence::Forward);
+        h.insert("help_contents", QKeySequence::HelpContents);
+        h.insert("insert_line_separator", QKeySequence::InsertLineSeparator);
+        h.insert("insert_paragraph_separator", QKeySequence::InsertParagraphSeparator);
+        h.insert("italic", QKeySequence::Italic);
+        h.insert("move_to_end_of_block", QKeySequence::MoveToEndOfBlock);
+        h.insert("move_to_end_of_document", QKeySequence::MoveToEndOfDocument);
+        h.insert("move_to_end_of_line", QKeySequence::MoveToEndOfLine);
+        h.insert("move_to_next_char", QKeySequence::MoveToNextChar);
+        h.insert("move_to_next_line", QKeySequence::MoveToNextLine);
+        h.insert("move_to_next_page", QKeySequence::MoveToNextPage);
+        h.insert("move_to_next_word", QKeySequence::MoveToNextWord);
+        h.insert("move_to_previous_char", QKeySequence::MoveToPreviousChar);
+        h.insert("move_to_previous_line", QKeySequence::MoveToPreviousLine);
+        h.insert("move_to_previous_page", QKeySequence::MoveToPreviousPage);
+        h.insert("move_to_previous_word", QKeySequence::MoveToPreviousWord);
+        h.insert("move_to_start_of_block", QKeySequence::MoveToStartOfBlock);
+        h.insert("move_to_start_of_document", QKeySequence::MoveToStartOfDocument);
+        h.insert("move_to_start_of_line", QKeySequence::MoveToStartOfLine);
+        h.insert("new", QKeySequence::New);
+        h.insert("next_child", QKeySequence::NextChild);
+        h.insert("open", QKeySequence::Open);
+        h.insert("paste", QKeySequence::Paste);
+        h.insert("preferences", QKeySequence::Preferences);
+        h.insert("previous_child", QKeySequence::PreviousChild);
+        h.insert("print", QKeySequence::Print);
+        h.insert("quit", QKeySequence::Quit);
+        h.insert("redo", QKeySequence::Redo);
+        h.insert("refresh", QKeySequence::Refresh);
+        h.insert("replace", QKeySequence::Replace);
+        h.insert("save_as", QKeySequence::SaveAs);
+        h.insert("save", QKeySequence::Save);
+        h.insert("select_all", QKeySequence::SelectAll);
+        h.insert("select_end_of_block", QKeySequence::SelectEndOfBlock);
+        h.insert("select_end_of_document", QKeySequence::SelectEndOfDocument);
+        h.insert("select_end_of_line", QKeySequence::SelectEndOfLine);
+        h.insert("select_next_char", QKeySequence::SelectNextChar);
+        h.insert("select_next_line", QKeySequence::SelectNextLine);
+        h.insert("select_next_page", QKeySequence::SelectNextPage);
+        h.insert("select_next_word", QKeySequence::SelectNextWord);
+        h.insert("select_previous_char", QKeySequence::SelectPreviousChar);
+        h.insert("select_previous_line", QKeySequence::SelectPreviousLine);
+        h.insert("select_previous_page", QKeySequence::SelectPreviousPage);
+        h.insert("select_previous_word", QKeySequence::SelectPreviousWord);
+        h.insert("select_start_of_block", QKeySequence::SelectStartOfBlock);
+        h.insert("select_start_of_document", QKeySequence::SelectStartOfDocument);
+        h.insert("select_start_of_line", QKeySequence::SelectStartOfLine);
+        h.insert("underline", QKeySequence::Underline);
+        h.insert("undo", QKeySequence::Undo);
+        h.insert("unknown_key", QKeySequence::UnknownKey);
+        h.insert("whats_this", QKeySequence::WhatsThis);
+        h.insert("zoom_in", QKeySequence::ZoomIn);
+        h.insert("zoom_out", QKeySequence::ZoomOut);
+        h.insert("full_screen", QKeySequence::FullScreen);
     }
-    return h.value(str, QKeySequence::UnknownKey );
+    return h.value(str, QKeySequence::UnknownKey);
 }
 
 
@@ -326,9 +308,9 @@ QKeySequence::StandardKey TextEditorKeyMap::standardKeyFromString( const QString
 QString TextEditorKeyMap::toString() const
 {
     QString str;
-    for( QMultiHash<QString,TextEditorKey*>::const_iterator itr = keyMap_.constBegin(); itr != keyMap_.constEnd(); ++itr ) {
-        if( !str.isEmpty()) str.append(",");
-        str.append( QStringLiteral("%1:%2").arg(itr.key()).arg(itr.value()->sequence().toString()) );
+    for (QMultiHash<QString,TextEditorKey*>::const_iterator itr = keyMap_.constBegin(); itr != keyMap_.constEnd(); ++itr) {
+        if (!str.isEmpty()) str.append(",");
+        str.append(QStringLiteral("%1:%2").arg(itr.key(), itr.value()->sequence().toString()));
     }
     return str;
 }
@@ -337,7 +319,6 @@ QString TextEditorKeyMap::toString() const
 //----------------------------------------------------
 
 
-/// destructs all keymaps
 TextKeyMapManager::TextKeyMapManager()
 {
     keyMapHash_.insert("", new TextEditorKeyMap());
@@ -347,37 +328,36 @@ TextKeyMapManager::TextKeyMapManager()
 /// The textkeymap manager destructor
 TextKeyMapManager::~TextKeyMapManager()
 {
-    qDeleteAll( keyMapHash_);
+    qDeleteAll(keyMapHash_);
 }
 
 
-/// This method loads all keymaps.
-///
+/// loads all keymaps.
 void TextKeyMapManager::loadAllKeyMaps(const QString& path)
 {
     QDir dir(path);
     QStringList filters("*.json");
-    foreach( QFileInfo fileInfo, dir.entryInfoList( filters, QDir::Files, QDir::Name ) ) {
-        loadKeyMap( fileInfo.absoluteFilePath() );
+    foreach (QFileInfo fileInfo, dir.entryInfoList( filters, QDir::Files, QDir::Name)) {
+        loadKeyMap(fileInfo.absoluteFilePath());
     }
 }
 
 
-/// This method loads a single keymap
+/// Loads a single keymap
 void TextKeyMapManager::loadKeyMap(const QString& file)
 {
     // parse the given file
-    QFileInfo fileInfo( file );
+    QFileInfo fileInfo(file);
     QString name = fileInfo.baseName();
-    if( name == "default" ) { name = ""; }
+    if (name == "default") { name = ""; }
 
     // parse the given keymap file
     KeyMapParser parser;
-    if( !parser.parse( file, findOrCreate(name) ) ) {
-        qlog_warn() << QObject::tr("Error parsing %1: %2 ").arg(file).arg(parser.errorMessage());
+    if (!parser.parse(file, findOrCreate(name))) {
+        qlog_warn() << QObject::tr("Error parsing %1: %2 ").arg(file, parser.errorMessage());
 
         // when there's an error parsing the defaultkeymap, fallback to the factory
-        if( name == "" ) {
+        if (name == "") {
             qlog_warn() << "Error loading default keymap: fallback to the factory keymap!";
             loadFactoryKeyMap();
         }
@@ -386,10 +366,10 @@ void TextKeyMapManager::loadKeyMap(const QString& file)
 }
 
 
-/// This method loads the internal factory keymap
+/// Loads the internal factory keymap
 void TextKeyMapManager::loadFactoryKeyMap()
 {
-    FactoryKeyMap().fill( findOrCreate("") );
+    FactoryKeyMap().fill( findOrCreate(""));
 }
 
 
@@ -404,13 +384,12 @@ TextEditorKeyMap* TextKeyMapManager::get(const QString& name)
 TextEditorKeyMap* TextKeyMapManager::findOrCreate(const QString& name)
 {
     TextEditorKeyMap* keyMap = keyMapHash_.value(name);
-    if( !keyMap ) {
+    if (!keyMap) {
         keyMap = new TextEditorKeyMap();
-        keyMapHash_.insert( name, keyMap );
+        keyMapHash_.insert(name, keyMap);
     }
     return keyMap;
 }
-
 
 
 } // edbee

--- a/edbee-lib/edbee/models/textgrammar.cpp
+++ b/edbee-lib/edbee/models/textgrammar.cpp
@@ -40,8 +40,8 @@ TextGrammarRule::~TextGrammarRule()
 /// @return the main grammar rule
 TextGrammarRule* TextGrammarRule::createMainRule(TextGrammar* grammar, const QString& scopeName)
 {
-    TextGrammarRule* rule = new TextGrammarRule( grammar, MainRule );
-    rule->setScopeName( scopeName );
+    TextGrammarRule* rule = new TextGrammarRule(grammar, MainRule);
+    rule->setScopeName(scopeName);
     return rule;
 }
 
@@ -51,7 +51,7 @@ TextGrammarRule* TextGrammarRule::createMainRule(TextGrammar* grammar, const QSt
 /// @return the TextGrammarRule that include the rule list
 TextGrammarRule* TextGrammarRule::createRuleList(TextGrammar* grammar)
 {
-    TextGrammarRule* rule = new TextGrammarRule( grammar, RuleList );
+    TextGrammarRule* rule = new TextGrammarRule(grammar, RuleList);
     return rule;
 }
 
@@ -62,7 +62,7 @@ TextGrammarRule* TextGrammarRule::createRuleList(TextGrammar* grammar)
 /// @return an include grammar rule
 TextGrammarRule* TextGrammarRule::createIncludeRule(TextGrammar* grammar, const QString& includeName)
 {
-    TextGrammarRule* rule = new TextGrammarRule( grammar, IncludeCall );
+    TextGrammarRule* rule = new TextGrammarRule(grammar, IncludeCall);
     rule->setIncludeName(includeName);
     return rule;
 }
@@ -75,9 +75,9 @@ TextGrammarRule* TextGrammarRule::createIncludeRule(TextGrammar* grammar, const 
 /// @return the created grammar rule
 TextGrammarRule* TextGrammarRule::createSingleLineRegExp(TextGrammar* grammar, const QString& scopeName, const QString& regExp)
 {
-    TextGrammarRule* rule = new TextGrammarRule( grammar, SingleLineRegExp );
-    rule->setScopeName( scopeName );
-    rule->giveMatchRegExp( TextGrammarRule::createRegExp( regExp ) );
+    TextGrammarRule* rule = new TextGrammarRule(grammar, SingleLineRegExp);
+    rule->setScopeName(scopeName);
+    rule->giveMatchRegExp(TextGrammarRule::createRegExp(regExp));
     return rule;
 }
 
@@ -94,7 +94,7 @@ TextGrammarRule* TextGrammarRule::createMultiLineRegExp(TextGrammar* grammar, co
     rule->setScopeName(scopeName);
     rule->setContentScopeName(contentScopeName);
     rule->giveMatchRegExp(TextGrammarRule::createRegExp(beginRegExp));
-    rule->setEndRegExpString( endRegExp );
+    rule->setEndRegExpString(endRegExp);
     return rule;
 }
 

--- a/edbee-lib/edbee/models/textgrammar.cpp
+++ b/edbee-lib/edbee/models/textgrammar.cpp
@@ -88,12 +88,12 @@ TextGrammarRule* TextGrammarRule::createSingleLineRegExp(TextGrammar* grammar, c
 /// @param beginRegExp the start regexp to use
 /// @param endRegExp the end regular expression to use
 /// @return TextGrammarRule the multiple grammar rule
-TextGrammarRule* TextGrammarRule::createMultiLineRegExp( TextGrammar* grammar, const QString& scopeName, const QString& contentScopeName, const QString& beginRegExp, const QString& endRegExp )
+TextGrammarRule* TextGrammarRule::createMultiLineRegExp(TextGrammar* grammar, const QString& scopeName, const QString& contentScopeName, const QString& beginRegExp, const QString& endRegExp)
 {
-    TextGrammarRule* rule = new TextGrammarRule( grammar, MultiLineRegExp );
+    TextGrammarRule* rule = new TextGrammarRule(grammar, MultiLineRegExp);
     rule->setScopeName(scopeName);
     rule->setContentScopeName(contentScopeName);
-    rule->giveMatchRegExp( TextGrammarRule::createRegExp( beginRegExp ));
+    rule->giveMatchRegExp(TextGrammarRule::createRegExp(beginRegExp));
     rule->setEndRegExpString( endRegExp );
     return rule;
 }
@@ -101,9 +101,9 @@ TextGrammarRule* TextGrammarRule::createMultiLineRegExp( TextGrammar* grammar, c
 
 /// returns the child rule at the given index
 /// @param idx the index of the grammar rule
-TextGrammarRule* TextGrammarRule::rule(int idx) const
+TextGrammarRule* TextGrammarRule::rule(qsizetype idx) const
 {
-    Q_ASSERT( 0 <= idx && idx < ruleCount() );
+    Q_ASSERT( 0 <= idx && idx < ruleCount());
     return ruleList_.at(idx);
 }
 
@@ -137,7 +137,7 @@ void TextGrammarRule::setEndRegExpString(const QString& str)
 QString TextGrammarRule::toString(bool includePatterns)
 {
     QString r;
-    switch( instruction_ ) {
+    switch (instruction_) {
         case MainRule: r.append("MainRule"); break;
         case RuleList: r.append("RuleList"); break;
         case SingleLineRegExp: r.append("SingleLineRegExp"); break;
@@ -147,16 +147,16 @@ QString TextGrammarRule::toString(bool includePatterns)
         default: r.append("Unkown");
     }
 
-    r.append(":").append( scopeName_ );
-    if( instruction_ == IncludeCall ) {
+    r.append(":").append(scopeName_);
+    if (instruction_ == IncludeCall) {
         r.append(" ");
         r.append(includeName());
     }
 
-    if( includePatterns && matchRegExp_ ) { r.append(", begin: ").append( matchRegExp_->pattern() ); }
-    if( includePatterns && !endRegExpString_.isEmpty() ) { r.append(", end: ").append( endRegExpString_ ); }
-    r.append( QStringLiteral(", %1 subrules").arg(ruleCount() ) );
-    r.append( QStringLiteral(", %1 captures").arg(matchCaptures().size()));
+    if (includePatterns && matchRegExp_) { r.append(", begin: ").append(matchRegExp_->pattern()); }
+    if (includePatterns && !endRegExpString_.isEmpty()) { r.append(", end: ").append(endRegExpString_); }
+    r.append(QStringLiteral(", %1 subrules").arg(ruleCount()));
+    r.append(QStringLiteral(", %1 captures").arg(matchCaptures().size()));
     return r;
 }
 
@@ -166,13 +166,12 @@ QString TextGrammarRule::toString(bool includePatterns)
 /// @return the RegExp object
 RegExp* TextGrammarRule::createRegExp(const QString& regexp)
 {
-    RegExp* result = new RegExp( regexp, RegExp::EngineOniguruma ); //, Qt::CaseSensitive, QRegExp::RegExp2 );
-    if( !result->isValid() ) {
+    RegExp* result = new RegExp(regexp, RegExp::EngineOniguruma); //, Qt::CaseSensitive, QRegExp::RegExp2 );
+    if (!result->isValid()) {
         qlog_warn() << "Error in regexp: " << result->errorString() << "\n" << regexp;
     }
     return result;
 }
-
 
 
 //==========================
@@ -184,7 +183,7 @@ RegExp* TextGrammarRule::createRegExp(const QString& regexp)
 TextGrammar::TextGrammar(const QString& name, const QString& displayName)
     : name_(name)
     , displayName_(displayName)
-    , mainRule_(0)
+    , mainRule_(nullptr)
 {
 
 }
@@ -193,7 +192,7 @@ TextGrammar::TextGrammar(const QString& name, const QString& displayName)
 /// The textgrammar destructor
 TextGrammar::~TextGrammar()
 {
-    qDeleteAll( repository_ );
+    qDeleteAll(repository_);
     repository_.clear();
     delete mainRule_;
 }
@@ -236,10 +235,10 @@ QStringList TextGrammar::fileExtensions() const
 }
 
 
-/// This method adds the given grammar rule to the repos
+/// Adds the given grammar rule to the repos
 void TextGrammar::giveToRepos(const QString& name, TextGrammarRule* rule)
 {
-    repository_.insert(name,rule);
+    repository_.insert(name, rule);
 }
 
 
@@ -247,9 +246,9 @@ void TextGrammar::giveToRepos(const QString& name, TextGrammarRule* rule)
 /// @param name the name of the rule
 /// @param defValue the grammar rule to return if not found
 /// @return the found grammar rule (or the defValue if not found)
-TextGrammarRule *TextGrammar::findFromRepos(const QString& name, TextGrammarRule* defValue )
+TextGrammarRule *TextGrammar::findFromRepos(const QString& name, TextGrammarRule* defValue)
 {
-    return repository_.value(name, defValue );
+    return repository_.value(name, defValue);
 }
 
 
@@ -266,20 +265,20 @@ void TextGrammar::addFileExtension(const QString& ext)
 
 /// The text grammar manager constructor
 TextGrammarManager::TextGrammarManager()
-    : defaultGrammarRef_(0)
+    : defaultGrammarRef_(nullptr)
 {
 
     // always make sure there's a default grammar
-    defaultGrammarRef_ = new TextGrammar( "text.plain", "Plain Text" );
-    defaultGrammarRef_->giveMainRule( TextGrammarRule::createMainRule(defaultGrammarRef_,"text.plain") );
-    giveGrammar( defaultGrammarRef_ );
+    defaultGrammarRef_ = new TextGrammar("text.plain", "Plain Text");
+    defaultGrammarRef_->giveMainRule( TextGrammarRule::createMainRule(defaultGrammarRef_,"text.plain"));
+    giveGrammar(defaultGrammarRef_);
 }
 
 
 /// The detstructor (deletes all grammars)
 TextGrammarManager::~TextGrammarManager()
 {
-    qDeleteAll( grammarMap_ );
+    qDeleteAll(grammarMap_);
     grammarMap_.clear();
 }
 
@@ -292,16 +291,16 @@ TextGrammarManager::~TextGrammarManager()
 TextGrammar* TextGrammarManager::readGrammarFile(const QString& file)
 {
     lastErrorMessage_.clear();
-    TextGrammar* grammar = nullptr;
-    QString lastErrorMessage;
 
+    TextGrammar* grammar = nullptr;
     TmLanguageParser parser;
+
     grammar = parser.parse(file);
-    if(grammar) {
+    if (grammar) {
         giveGrammar(grammar);
     } else {
         QFileInfo fileInfo(file);
-        lastErrorMessage_ = QObject::tr("Error reading file %1:%2").arg(fileInfo.absoluteFilePath()).arg(parser.lastErrorMessage());
+        lastErrorMessage_ = QObject::tr("Error reading file %1:%2").arg(fileInfo.absoluteFilePath(), parser.lastErrorMessage());
         qlog_warn() << lastErrorMessage_;
     }
     return grammar;
@@ -310,14 +309,12 @@ TextGrammar* TextGrammarManager::readGrammarFile(const QString& file)
 
 /// reads all grammar files in the given path
 /// @param path the path to read all grammar files from
-void TextGrammarManager::readAllGrammarFilesInPath(const QString& path )
+void TextGrammarManager::readAllGrammarFilesInPath(const QString& path)
 {
-//    qlog_info() << "readAllGrammarFilesInPath(" << path << ")";
     QDir dir(path);
     QStringList filters = { "*.tmLanguage", "*.tmLanguage.json" };
-    foreach( QFileInfo fileInfo, dir.entryInfoList( filters, QDir::Files, QDir::Name ) ) {
-//        qlog_info() << "- parse" << fileInfo.baseName() << ".";
-        readGrammarFile( fileInfo.absoluteFilePath());
+    foreach (QFileInfo fileInfo, dir.entryInfoList( filters, QDir::Files, QDir::Name) ) {
+        readGrammarFile(fileInfo.absoluteFilePath());
     }
 }
 
@@ -325,56 +322,56 @@ void TextGrammarManager::readAllGrammarFilesInPath(const QString& path )
 /// This method returns the given language grammar
 TextGrammar* TextGrammarManager::get(const QString &name)
 {
-    return grammarMap_.value(name,0);
+    return grammarMap_.value(name, nullptr);
 }
 
 
-/// This method gives a language grammar to the document
+/// Gives a language grammar to the document
 /// @param grammar the grammar to give
 void TextGrammarManager::giveGrammar(TextGrammar* grammar)
 {
     const QString name = grammar->name();
 
     // when the grammar already exists delete it
-    if( grammarMap_.contains(name)) {
+    if (grammarMap_.contains(name)) {
         TextGrammar* oldGrammar = grammarMap_.take(name);
 
         // when the old grammar was the default, replace the default (feels pretty dirty)
-        if( defaultGrammarRef_ == oldGrammar ) {
+        if (defaultGrammarRef_ == oldGrammar) {
             defaultGrammarRef_ = grammar;
         }
 
         // clearup the old one
         delete oldGrammar;
     }
-    grammarMap_.insert(name,grammar);
+    grammarMap_.insert(name, grammar);
 }
 
 
-/// This method returns all grammar names
+/// Returns all grammar names
 QList<QString> TextGrammarManager::grammarNames()
 {
     return grammarMap_.keys();
 }
 
 
-/// This method returns the values
+/// Returns the values
 QList<TextGrammar*> TextGrammarManager::grammars()
 {
     return grammarMap_.values();
 }
 
 
-/// This method is used to compare the grammarnames of textgrammars
+/// ompares the grammarnames of textgrammars
 /// @param g1 the first grammar
 /// @param g2 the second grammar to compare
-static bool grammarsDisplayNameSorterLessThen( const TextGrammar* g1, const TextGrammar* g2 )
+static bool grammarsDisplayNameSorterLessThen(const TextGrammar* g1, const TextGrammar* g2)
 {
     return g1->displayName().toLower() < g2->displayName().toLower();
 }
 
 
-/// This utility function returns all grammars sorted on displayname
+/// Returns all grammars sorted on displayname
 /// Warning, this method sorts the grammars so calling this method multiple times is not what you want to do
 /// @return the list of grammars sorted on displayname
 QList<TextGrammar*> TextGrammarManager::grammarsSortedByDisplayName()
@@ -390,9 +387,10 @@ QList<TextGrammar*> TextGrammarManager::grammarsSortedByDisplayName()
 /// @return the defaultGrammar if no grammar was found
 TextGrammar* TextGrammarManager::detectGrammarWithFilename(const QString& fileName)
 {
-    foreach( TextGrammar* grammar, grammarMap_.values() ) {
-        foreach( QString ext, grammar->fileExtensions() ) {
-            if( fileName.endsWith( QStringLiteral(".%1").arg(ext) ) ) return grammar;
+    auto grammarMapValues = grammarMap_.values();
+    foreach (TextGrammar* grammar, grammarMapValues) {
+        foreach (QString ext, grammar->fileExtensions()) {
+            if (fileName.endsWith( QStringLiteral(".%1").arg(ext))) return grammar;
         }
     }
     return this->defaultGrammar();

--- a/edbee-lib/edbee/models/textgrammar.h
+++ b/edbee-lib/edbee/models/textgrammar.h
@@ -51,28 +51,28 @@ public:
 
     qsizetype ruleCount() const { return ruleList_.size(); }
     TextGrammarRule* rule(qsizetype idx) const;
-    void giveRule( TextGrammarRule* rule );
+    void giveRule(TextGrammarRule* rule);
 
-    void giveMatchRegExp( RegExp* regExp );
-    void setEndRegExpString( const QString& str );
+    void giveMatchRegExp(RegExp* regExp);
+    void setEndRegExpString(const QString& str);
 
     Instruction instruction() const { return instruction_; }
-    void setInstruction( Instruction ins ) { instruction_ = ins; }
+    void setInstruction(Instruction ins) { instruction_ = ins; }
     QString scopeName() const  { return scopeName_; }
-    void setScopeName( const QString& scopeName ) { scopeName_ = scopeName; }
+    void setScopeName(const QString& scopeName) { scopeName_ = scopeName; }
     RegExp* matchRegExp() const { return matchRegExp_; }
     QString endRegExpString() const { return endRegExpString_; }
-    const QMap<int,QString>& matchCaptures() { return matchCaptures_; }
-    const QMap<int,QString>& endCaptures() { return endCaptures_; }
+    const QMap<size_t, QString>& matchCaptures() { return matchCaptures_; }
+    const QMap<size_t, QString>& endCaptures() { return endCaptures_; }
     QString contentScopeName() const { return contentScopeName_; }
-    void setContentScopeName( const QString& name) { contentScopeName_ = name; }
+    void setContentScopeName(const QString& name) { contentScopeName_ = name; }
 
     /// the include name is stored in the content-scopename
-    QString includeName() { return contentScopeName_;  }
-    void setIncludeName( const QString& name ) { contentScopeName_ = name; }
+    QString includeName() { return contentScopeName_; }
+    void setIncludeName(const QString& name) { contentScopeName_ = name; }
 
-    void setCapture( int idx, const QString& name ) { matchCaptures_.insert(idx,name); }
-    void setEndCapture( int idx, const QString& name ) { endCaptures_.insert(idx,name); }
+    void setCapture(size_t idx, const QString& name) { matchCaptures_.insert(idx, name); }
+    void setEndCapture(size_t idx, const QString& name) { endCaptures_.insert(idx, name); }
 
     QString toString(bool includePatterns=true);
 
@@ -81,7 +81,7 @@ public:
     class Iterator
     {
     public:
-        Iterator( const TextGrammarRule* rule ) : index_(0), ruleRef_(rule){}
+        Iterator(const TextGrammarRule* rule) : index_(0), ruleRef_(rule) {}
         bool hasNext() { return index_ < ruleRef_->ruleCount(); }
         TextGrammarRule* next() { return ruleRef_->rule(index_++); }
     private:
@@ -90,29 +90,28 @@ public:
     };
 
     Iterator* createIterator() { return new Iterator(this); }
-
     TextGrammar* grammar() { return grammarRef_; }
 
 private:
 
-    static RegExp* createRegExp( const QString& regexp );
+    static RegExp* createRegExp(const QString& regexp);
 
 
 private:
-    TextGrammar* grammarRef_;        ///< The grammar this rule belongs toe
-    Instruction instruction_;            ///< THe instruction to execute
-    QString scopeName_;                  ///< the scope name of this grammar
+    TextGrammar* grammarRef_;             ///< The grammar this rule belongs toe
+    Instruction instruction_;             ///< THe instruction to execute
+    QString scopeName_;                   ///< the scope name of this grammar
 
-    RegExp* matchRegExp_;                ///< The begin-matcher (or simple matcher)
-    //RegExp* endRegExp_;                  ///< The end regular expression matcher
-    QString endRegExpString_;            ///< The end regexp is a string
+    RegExp* matchRegExp_;                 ///< The begin-matcher (or simple matcher)
+    //RegExp* endRegExp_;                 ///< The end regular expression matcher
+    QString endRegExpString_;             ///< The end regexp is a string
 
-    QMap<int,QString> matchCaptures_;    ///< all captures that need to be performed
-    QMap<int,QString> endCaptures_;      ///< all end captures that need to be performed
+    QMap<size_t, QString> matchCaptures_; ///< all captures that need to be performed
+    QMap<size_t, QString> endCaptures_;   ///< all end captures that need to be performed
 
-    QString contentScopeName_;           ///< The content scopename
+    QString contentScopeName_;            ///< The content scopename
 
-    QList<TextGrammarRule*> ruleList_;   ///< Sub-rules to execute
+    QList<TextGrammarRule*> ruleList_;    ///< Sub-rules to execute
 };
 
 

--- a/edbee-lib/edbee/models/textgrammar.h
+++ b/edbee-lib/edbee/models/textgrammar.h
@@ -26,23 +26,22 @@ public:
 
     /// the instructions
     enum Instruction {
-        MainRule,                   ///< The main rule has no regexp matches
-        RuleList,                   ///< A list of rules (no regexp)
-        SingleLineRegExp,           ///< A single line regexp
-        MultiLineRegExp,            ///< A multi-line regexp (begin end)
-        IncludeCall,                ///< Includes another scope
-        Parser                      ///< A full parser (not yet supported, by added as idea for the future). But could be marked by multiple regexps
+        MainRule,         ///< The main rule has no regexp matches
+        RuleList,         ///< A list of rules (no regexp)
+        SingleLineRegExp, ///< A single line regexp
+        MultiLineRegExp,  ///< A multi-line regexp (begin end)
+        IncludeCall,      ///< Includes another scope
+        Parser            ///< A full parser (not yet supported, by added as idea for the future). But could be marked by multiple regexps
     };
 
-
-    TextGrammarRule( TextGrammar* grammar, Instruction instruction );
+    TextGrammarRule(TextGrammar* grammar, Instruction instruction);
     ~TextGrammarRule();
 
-    static TextGrammarRule* createMainRule( TextGrammar* grammar, const QString& scopeName );
-    static TextGrammarRule* createRuleList( TextGrammar* grammar );
-    static TextGrammarRule* createSingleLineRegExp( TextGrammar* grammar, const QString& scopeName, const QString& regExp );
-    static TextGrammarRule* createMultiLineRegExp( TextGrammar* grammar, const QString& scopeName, const QString& contentScopeName, const QString& beginRegExp, const QString& endRegExp );
-    static TextGrammarRule* createIncludeRule( TextGrammar* grammar, const QString& includeName );
+    static TextGrammarRule* createMainRule(TextGrammar* grammar, const QString& scopeName);
+    static TextGrammarRule* createRuleList(TextGrammar* grammar );
+    static TextGrammarRule* createSingleLineRegExp(TextGrammar* grammar, const QString& scopeName, const QString& regExp);
+    static TextGrammarRule* createMultiLineRegExp(TextGrammar* grammar, const QString& scopeName, const QString& contentScopeName, const QString& beginRegExp, const QString& endRegExp);
+    static TextGrammarRule* createIncludeRule(TextGrammar* grammar, const QString& includeName);
 
     inline bool isMainRule() { return instruction_ == MainRule; }
     inline bool isRuleList() { return instruction_ == RuleList; }
@@ -50,8 +49,8 @@ public:
     inline bool isSingleLineRegExp() { return instruction_ == SingleLineRegExp; }
     inline bool isIncludeCall() { return instruction_ == IncludeCall; }
 
-    int ruleCount() const { return ruleList_.size(); }
-    TextGrammarRule* rule( int idx ) const;
+    qsizetype ruleCount() const { return ruleList_.size(); }
+    TextGrammarRule* rule(qsizetype idx) const;
     void giveRule( TextGrammarRule* rule );
 
     void giveMatchRegExp( RegExp* regExp );
@@ -124,26 +123,26 @@ private:
 class EDBEE_EXPORT TextGrammar {
 public:
 
-    TextGrammar( const QString& name, const QString& displayName );
-    ~TextGrammar();
+    TextGrammar(const QString& name, const QString& displayName);
+    virtual ~TextGrammar();
 
-    void giveMainRule( TextGrammarRule* mainRule );
+    void giveMainRule(TextGrammarRule* mainRule);
 
     QString name() const;
     QString displayName() const;
     TextGrammarRule* mainRule() const;
     QStringList fileExtensions() const;
 
-    void giveToRepos( const QString& name, TextGrammarRule* rule);
-    TextGrammarRule* findFromRepos( const QString& name, TextGrammarRule* defValue = 0  );
-    void addFileExtension( const QString& ext );
+    void giveToRepos(const QString& name, TextGrammarRule* rule);
+    TextGrammarRule* findFromRepos( const QString& name, TextGrammarRule* defValue = nullptr);
+    void addFileExtension(const QString& ext);
 
 private:
     QString name_;                               ///< the display name of this
     QString displayName_;                        ///< the name to display
-    TextGrammarRule *mainRule_;                      ///< the 'main' rule of this grammar
-    QMap<QString, TextGrammarRule*> repository_;     ///< A map with all named grammar rules
-    QStringList fileExtensions_;                  ///< A list with all file-extensions
+    TextGrammarRule *mainRule_;                  ///< the 'main' rule of this grammar
+    QMap<QString, TextGrammarRule*> repository_; ///< A map with all named grammar rules
+    QStringList fileExtensions_;                 ///< A list with all file-extensions
 };
 
 
@@ -158,11 +157,11 @@ protected:
     virtual ~TextGrammarManager();
 
 public:
-    TextGrammar* readGrammarFile(const QString& file );
-    void readAllGrammarFilesInPath(const QString& path );
+    TextGrammar* readGrammarFile(const QString& file);
+    void readAllGrammarFilesInPath(const QString& path);
 
-    TextGrammar* get( const QString& name );
-    void giveGrammar( TextGrammar* grammar );
+    TextGrammar* get(const QString& name);
+    void giveGrammar(TextGrammar* grammar);
 
     QList<QString> grammarNames();
     QList<TextGrammar*> grammars();

--- a/edbee-lib/edbee/models/textlexer.cpp
+++ b/edbee-lib/edbee/models/textlexer.cpp
@@ -11,8 +11,8 @@
 namespace edbee {
 
 TextLexer::TextLexer( TextDocumentScopes* scopes)
-    : textDocumentScopesRef_( scopes )
-    , grammarRef_(0)
+    : textDocumentScopesRef_(scopes)
+    , grammarRef_(nullptr)
 {
 }
 
@@ -20,7 +20,7 @@ void TextLexer::setGrammar(TextGrammar* grammar)
 {
     Q_ASSERT(grammar);
     grammarRef_ = grammar;
-    textScopes()->setDefaultScope( grammarRef_->mainRule()->scopeName(), grammarRef_->mainRule() );
+    textScopes()->setDefaultScope(grammarRef_->mainRule()->scopeName(), grammarRef_->mainRule());
     textScopes()->removeScopesAfterOffset(0); // invalidate the complete scopes
 }
 
@@ -29,6 +29,5 @@ TextDocument* TextLexer::textDocument()
 {
     return textDocumentScopesRef_->textDocument();
 }
-
 
 } // edbee

--- a/edbee-lib/edbee/models/textlexer.h
+++ b/edbee-lib/edbee/models/textlexer.h
@@ -19,29 +19,27 @@ public:
     TextLexer( TextDocumentScopes* scopes );
     virtual ~TextLexer() {}
 
-    /// This method is called to notify the lexer some data has been changed
-//    virtual void textReplaced( int offset, int length, int newLength ) = 0;
-    virtual void textChanged( const edbee::TextBufferChange& change ) = 0;
+    /// Inform the lexer some data has been changed
+    // virtual void textReplaced( int offset, int length, int newLength ) = 0;
+    virtual void textChanged(const edbee::TextBufferChange& change) = 0;
 
-
-    /// This method is called to notify the lexer the grammar has been changed
-    void setGrammar( TextGrammar* grammar );
+    /// Inform the lexer the grammar has been changed
+    void setGrammar(TextGrammar* grammar);
     inline TextGrammar* grammar() { return grammarRef_; }
 
-    /// This method is called when the given range needs to be lexed
+    /// Lex the given range
     /// WARNING, this method must be VERY optimized and should 'remember' the lexing
     /// states between calls. To invalidate the scopes/lexing state the textReplaced method can be used
     ///
     /// @param beginOffset the first offset
     /// @param endOffset the last offset to
-    virtual void lexRange( int beginOffset, int endOffset ) = 0;
-
+    virtual void lexRange(size_t beginOffset, size_t endOffset ) = 0;
 
     TextDocumentScopes* textScopes() { return textDocumentScopesRef_; }
     TextDocument* textDocument();
 
 private:
-    TextDocumentScopes* textDocumentScopesRef_;     ///< A Text document refs
+    TextDocumentScopes* textDocumentScopesRef_; ///< A Text document refs
     TextGrammar* grammarRef_;                   ///< The reference to the active grammar
 };
 

--- a/edbee-lib/edbee/models/textlinedata.cpp
+++ b/edbee-lib/edbee/models/textlinedata.cpp
@@ -14,89 +14,87 @@ namespace edbee {
 
 /// construct the text line data item
 TextLineDataList::TextLineDataList()
-    : lineDataList_(0)
+    : lineDataList_(nullptr)
 {
 }
 
 TextLineDataList::~TextLineDataList()
 {
-    if( lineDataList_ ) {
-//        Q_ASSERT(false);    /// YOU MUST call destroy before the destructor!
+    if (lineDataList_) {
         qlog_warn() << "** Warning TextLineDataList requires manual destruction! ** ";
     }
 }
 
-/// destroys the data items
-void TextLineDataList::destroy( TextLineDataManager* manager )
-{
-    if( lineDataList_ ) {
 
-        for( int i=0, cnt=manager->fieldsPerLine(); i<cnt; ++i ) {
+/// destroys the data items
+void TextLineDataList::destroy(TextLineDataManager* manager)
+{
+    if (lineDataList_) {
+        for (size_t i = 0, cnt = manager->fieldsPerLine(); i < cnt; ++i) {
             delete lineDataList_[i];
-            lineDataList_[i] = 0;
+            lineDataList_[i] = nullptr;
         }
     }
     delete[] lineDataList_;
-    lineDataList_ = 0;
+    lineDataList_ = nullptr;
 }
 
 
-
-/// this method gives a given dat item to the given field position
-void TextLineDataList::give(TextLineDataManager* manager, int field, TextLineData* dataItem)
+/// give data item to the given field position
+void TextLineDataList::give(TextLineDataManager* manager, size_t field, TextLineData* dataItem)
 {
-    Q_ASSERT( field < manager->fieldsPerLine() );
-    if( !lineDataList_ ) { lineDataList_ = new TextLineData*[ manager->fieldsPerLine() ](); }
+    Q_ASSERT(field < manager->fieldsPerLine());
+    if (!lineDataList_) { lineDataList_ = new TextLineData*[manager->fieldsPerLine()](); }
     delete lineDataList_[field];    // delete the old item
     lineDataList_[field] = dataItem;
 }
 
 
-/// This method returns the given data item and transfers the ownership. The item in the list is set to 0
+/// Returns the given data item and transfers the ownership. The item in the list is set to 0
 /// @param manager the manager to use
 /// @param field the field index to retrieve
 /// @return the TextLineData item in the given field or 0
-TextLineData *TextLineDataList::take(TextLineDataManager* manager, int field)
+TextLineData* TextLineDataList::take(TextLineDataManager* manager, size_t field)
 {
-    Q_ASSERT( field < manager->fieldsPerLine() );
+    Q_ASSERT(field < manager->fieldsPerLine());
     Q_UNUSED(manager);
-    if( !lineDataList_ ) { return 0; }
+    if (!lineDataList_) { return nullptr; }
     TextLineData* dataItem = lineDataList_[field];
-    lineDataList_[field] = 0;
+    lineDataList_[field] = nullptr;
     return dataItem;
 }
 
-/// This method returns the given data item /
+
+/// Returns the given data item
 /// @param manager the manager to use
 /// @param field the field index to retrieve
 /// @return the TextLineData item in the given field or 0
-TextLineData *TextLineDataList::at(TextLineDataManager* manager, int field)
+TextLineData* TextLineDataList::at(TextLineDataManager* manager, size_t field)
 {
-    Q_ASSERT( field < manager->fieldsPerLine() );
+    Q_ASSERT(field < manager->fieldsPerLine());
     Q_UNUSED(manager);
-    if( !lineDataList_ ) { return 0; }
+    if (!lineDataList_) { return nullptr; }
     return lineDataList_[field];
 }
 
 
 /// This method reallocates the number of fields
-void TextLineDataList::realloc(TextLineDataManager* manager , int oldFieldsPerLine, int newFieldsPerLine)
+void TextLineDataList::realloc(TextLineDataManager* manager, size_t oldFieldsPerLine, size_t newFieldsPerLine)
 {
-//qlog_info() << "realloc:" << oldFieldsPerLine << " >> " << newFieldsPerLine;
     TextLineData** oldData = lineDataList_;
 
     // copy the data
-    if( oldData ) {
-        lineDataList_ = new TextLineData*[ manager->fieldsPerLine() ]();
-        int copyCount = qMin( oldFieldsPerLine, newFieldsPerLine );
-        for( int i=0; i < copyCount; ++i ) {
+    if (oldData) {
+        lineDataList_ = new TextLineData*[manager->fieldsPerLine()]();
+        size_t copyCount = qMin(oldFieldsPerLine, newFieldsPerLine);
+        for (size_t i = 0; i < copyCount; ++i ) {
             lineDataList_[i] = oldData[i];
-            oldData[i] = 0;
+            oldData[i] = nullptr;
         }
 
-        for( int i=copyCount; i<oldFieldsPerLine; ++i ) {
+        for (size_t i = copyCount; i < oldFieldsPerLine; ++i) {
             delete oldData[i];
-            oldData[i] = 0;
+            oldData[i] = nullptr;
         }
         delete[] oldData;
     }
@@ -106,29 +104,30 @@ void TextLineDataList::realloc(TextLineDataManager* manager , int oldFieldsPerLi
 //-------
 
 
-TextLineDataManager::TextLineDataManager(int fieldsPerLine)
-    : fieldsPerLine_( fieldsPerLine )
+TextLineDataManager::TextLineDataManager(size_t fieldsPerLine)
+    : fieldsPerLine_(fieldsPerLine)
     , textLineDataList_(2)
 {
     textLineDataList_.setGrowSize(2);
     // add a 0 element
-    textLineDataList_.fill(0,0,0,1);
+    textLineDataList_.fill(0, 0, 0, 1);
 }
+
 
 TextLineDataManager::~TextLineDataManager()
 {
     clear();
 }
 
+
 /// this method clears all field items
 void TextLineDataManager::clear()
 {
-    for( int i=0,cnt=textLineDataList_.length(); i < cnt; ++i  ) {
+    for (size_t i=0, cnt = textLineDataList_.length(); i < cnt; ++i) {
         TextLineDataList* list = textLineDataList_.at(i);
-        if( list ) {
+        if (list) {
             list->destroy(this);
             delete list;
-//            textLineDataList_.set(i,0);
         }
     }
     textLineDataList_.clear();
@@ -137,148 +136,113 @@ void TextLineDataManager::clear()
 
 
 /// this method gives the given data at the given line and field
-void TextLineDataManager::give(int line, int field, TextLineData* dataItem)
+void TextLineDataManager::give(size_t line, size_t field, TextLineData* dataItem)
 {
-    Q_ASSERT(field<fieldsPerLine_);
+    Q_ASSERT(field < fieldsPerLine_);
     TextLineDataList* list = textLineDataList_.at(line);
-    if( !list ) { textLineDataList_.set(line, list = new TextLineDataList() ); }
-    list->give( this, field, dataItem );
-    emit lineDataChanged( line, 1, 1 );
-}
-
-TextLineData *TextLineDataManager::take(int line, int field)
-{
-    Q_ASSERT(field<fieldsPerLine_);
-    TextLineDataList* list = textLineDataList_.at(line);
-    if( list ) { return list->take( this, field ); }
-    return 0;
-}
-
-TextLineData *TextLineDataManager::get(int line, int field)
-{
-    Q_ASSERT(field<fieldsPerLine_);
-    TextLineDataList* list = textLineDataList_.at(line);
-    if( list ) { return list->at( this, field ); }
-    return 0;
+    if (!list) { textLineDataList_.set(line, list = new TextLineDataList()); }
+    list->give(this, field, dataItem);
+    emit lineDataChanged(line, 1, 1);
 }
 
 
-/// This method is called to notify that some lines have been replaced
-//void TextLineDataManager::linesReplaced(int lineStart, int lineCount, int newLineCount)
-//{
-//    Q_ASSERT(false);
-///// TODO: use linedatalist-textchange for storing undo/redo operations
-//qlog_info() << "TODO: We need to support destroy line data operation!";
+TextLineData* TextLineDataManager::take(size_t line, size_t field)
+{
+    Q_ASSERT(field<fieldsPerLine_);
+    TextLineDataList* list = textLineDataList_.at(line);
+    if (list) { return list->take(this, field); }
+    return nullptr;
+}
 
-/* WE MUST MAKE THIS  A TEXT CHANGE !!
-    // remove all items
-    for( int i=lineStart,end=lineStart+lineCount; i<end; ++i ){
-        TextLineDataList* list = textLineDataList_.at(i);
 
-        LineDataTextChange* linesRemoves
+TextLineData* TextLineDataManager::get(size_t line,size_t field)
+{
+    Q_ASSERT(field<fieldsPerLine_);
+    TextLineDataList* list = textLineDataList_.at(line);
+    if (list) { return list->at(this, field); }
+    return nullptr;
+}
 
-        if( list ) { list->destroy(this); }
-        delete list;
-    }
 
-//    // remove all items
-//    for( int i=lineStart,end=lineStart+lineCount; i<end; ++i ){
-//        TextLineDataList* list = textLineDataList_.at(i);
-//        if( list ) { list->destroy(this); }
-//        delete list;
-//    }
-//
-//  // replace all old items with 0 values
-//  textLineDataList_.fill( lineStart, lineCount, 0, newLineCount );
-*/
-//}
-
-//void TextLineDataManager::dumpGapvector()
-//{
-//    qlog_info() << "GAPVECTOR: ["<<textLineDataList_.gapBegin() << ","<<textLineDataList_.gapEnd()<<">";
-//    for( int i=0; i < textLineDataList_.capacity(); ++i ) {
-//        TextLineDataList* item = textLineDataList_.rawAt(i);
-//        qlog_info() << "-" << i <<  ":" << QStringLiteral("%1").arg((quintptr)item);
-//    }
-//    qlog_info()<<"- done";
-
-//}
-
-/// This method can be used to change the number of reserved fields by the document
+/// Can be used to change the number of reserved fields by the document
 /// Increasing the amount will result in a realoc
 /// Decreasting the fieldcount reults in the lost of the 'old' fields
 /// At least the 'PredefinedFieldCount' amont of fields are required
-void TextLineDataManager::setFieldsPerLine(int count)
+void TextLineDataManager::setFieldsPerLine(size_t count)
 {
-    Q_ASSERT( count >= PredefinedFieldCount );
-    for( int i=0,cnt=textLineDataList_.length(); i < cnt; ++i  ) {
+    Q_ASSERT(count >= PredefinedFieldCount);
+    for (size_t i = 0, cnt = textLineDataList_.length(); i < cnt; ++i) {
         TextLineDataList* list = textLineDataList_.at(i);
-        if( list ) {
-            list->realloc(this, fieldsPerLine_, count );
+        if (list) {
+            list->realloc(this, fieldsPerLine_, count);
         }
     }
     fieldsPerLine_ = count;
 }
 
-/// This method creates a new lines replace change
-Change* TextLineDataManager::createLinesReplacedChange(int lineStart, int lineCount, int newLineCount )
+
+/// Creates a new lines replace change
+Change* TextLineDataManager::createLinesReplacedChange(size_t lineStart, size_t lineCount, size_t newLineCount )
 {
     // no changes
-    if( lineCount == 0 && lineCount == newLineCount ) { return 0; }
+    if(lineCount == 0 && lineCount == newLineCount) { return nullptr; }
 
-    LineDataListChange* change = new LineDataListChange(this,lineStart, lineCount, newLineCount );
+    LineDataListChange* change = new LineDataListChange(this, lineStart, lineCount, newLineCount);
     return change;
 }
 
 
-/// This method takes the given list (and repalces it with a 0 value)
-TextLineDataList* TextLineDataManager::takeList(int line)
+/// Takes the given list (and replaces it with a wnullptr)
+TextLineDataList* TextLineDataManager::takeList(size_t line)
 {
     TextLineDataList* list = textLineDataList_[line];
-    textLineDataList_[line] = 0;
+    textLineDataList_[line] = nullptr;
     return list;
 }
 
-/// This method gives a list to the given line
+
+/// Gives a list to the given line
 /// emits a lineDataChanged signal
-void TextLineDataManager::giveList(int line, TextLineDataList *newList)
+void TextLineDataManager::giveList(size_t line, TextLineDataList* newList)
 {
     // delete the old list if required
     TextLineDataList* list = textLineDataList_[line];
-    if( list ) {
+    if (list) {
         list->destroy(this);
         delete list;
     }
     textLineDataList_[line] = newList;
-    emit lineDataChanged( line, 1, 1 );
+    emit lineDataChanged(line, 1, 1);
 }
 
-/// replace the given area with no-data
+
+/// Replace the given area with no-data
 /// emits a lineDataChanged signal
-void TextLineDataManager::fillWithEmpty(int line, int length, int newLength)
+void TextLineDataManager::fillWithEmpty(size_t line, size_t length, size_t newLength)
 {
 
     destroyRange(line, length);
-    textLineDataList_.fill( line, length, 0, newLength );
-//qlog_info() << "- TextLineDataManager::fillWithEmpty( line: " << line << ", length " << length << " newLength: " << newLength << ") len:" << this->textLineDataList_.length();
-    emit lineDataChanged( line, length, newLength );
+    textLineDataList_.fill(line, length, 0, newLength);
+    emit lineDataChanged(line, length, newLength);
 }
+
 
 /// Replace the given items with
 /// emits a lineDataChanged signal
-void TextLineDataManager::replace(int line, int length, TextLineDataList** items, int newLength )
+void TextLineDataManager::replace(size_t line, size_t length, TextLineDataList** items, size_t newLength)
 {
     destroyRange(line, length);
-    textLineDataList_.replace( line, length, items, newLength );
-    emit lineDataChanged( line, length, newLength );
+    textLineDataList_.replace(line, length, items, newLength);
+    emit lineDataChanged(line, length, newLength);
 }
 
+
 /// destroys all items in the given range
-void TextLineDataManager::destroyRange(int line, int length)
+void TextLineDataManager::destroyRange(size_t line, size_t length)
 {
-    for( int i=0; i<length; i++ ) {
-        TextLineDataList* list = takeList(line+i);
-        if( list ) {
+    for (size_t i = 0; i < length; i++) {
+        TextLineDataList* list = takeList(line + i);
+        if (list) {
             list->destroy(this);
             delete list;
         }

--- a/edbee-lib/edbee/models/textlinedata.h
+++ b/edbee-lib/edbee/models/textlinedata.h
@@ -119,7 +119,7 @@ public slots:
 //    void dumpGapvector();
 signals:
 
-    void lineDataChanged( int line, int length, int newLength );   ///< This signal is emitted if line-data is changed
+    void lineDataChanged(int line, int length, int newLength);   ///< This signal is emitted if line-data is changed
 
 private:
 

--- a/edbee-lib/edbee/models/textlinedata.h
+++ b/edbee-lib/edbee/models/textlinedata.h
@@ -12,10 +12,9 @@
 
 namespace edbee {
 
-
 enum TextLineDataPredefinedFields {
     LineTextScopesField=0,
-    //    LineDataMarkers,      /// Bookmarks etc
+    // LineDataMarkers,      /// Bookmarks etc
     LineAppendTextLayoutFormatListField=1,
     PredefinedFieldCount=2
 };
@@ -25,13 +24,11 @@ class Change;
 class TextLineDataManager;
 
 
-
 /// A text line item reference
 class EDBEE_EXPORT TextLineData {
 public:
     TextLineData() {}
     virtual ~TextLineData() {}
-//    bool undoable() = 0;
 };
 
 /// a simple class to store a QString in a line
@@ -39,9 +36,9 @@ template<typename T>
 class EDBEE_EXPORT BasicTextLineData : public TextLineData
 {
 public:
-    BasicTextLineData( const T& val ) : value_(val) {}
+    BasicTextLineData(const T& val) : value_(val) {}
     T value() { return value_; }
-    void setValue( const T& value ) { value_ = value; }
+    void setValue(const T& value) { value_ = value; }
 
 private:
     T value_;
@@ -51,26 +48,30 @@ private:
 typedef BasicTextLineData<QString> QStringTextLineData;
 typedef BasicTextLineData<QList<QTextLayout::FormatRange>> LineAppendTextLayoutFormatListData;
 
+
 //-------
+
 
 /// the line data items
 class EDBEE_EXPORT TextLineDataList {
 public:
-    TextLineDataList( );
+    TextLineDataList();
     virtual ~TextLineDataList();
-    virtual void destroy( TextLineDataManager* manager );
+    virtual void destroy(TextLineDataManager* manager);
 
-    void give( TextLineDataManager* manager, int field, TextLineData *dataItem );
-    TextLineData* take( TextLineDataManager* manager, int field );
-    TextLineData* at( TextLineDataManager* manager, int field );
+    void give(TextLineDataManager* manager, size_t field, TextLineData *dataItem);
+    TextLineData* take(TextLineDataManager* manager, size_t field);
+    TextLineData* at(TextLineDataManager* manager, size_t field);
 
-    void realloc( TextLineDataManager* manager, int oldFieldPerLine, int newFieldsPerLine );
+    void realloc(TextLineDataManager* manager, size_t oldFieldPerLine, size_t newFieldsPerLine);
 
 private:
     TextLineData** lineDataList_;   ///< The text line data items
 };
 
+
 //-------
+
 
 /// This manager manages all line definitions
 class EDBEE_EXPORT TextLineDataManager : public QObject
@@ -78,39 +79,39 @@ class EDBEE_EXPORT TextLineDataManager : public QObject
 Q_OBJECT
 
 public:
-    TextLineDataManager( int fieldsPerLine = PredefinedFieldCount);
+    TextLineDataManager(size_t fieldsPerLine = PredefinedFieldCount);
     virtual ~TextLineDataManager();
 
     void clear();
 
 
-    void give(int line, int field, TextLineData *dataItem );
-    TextLineData* take(int line, int field );
-    TextLineData* get( int line, int field );
+    void give(size_t line, size_t field, TextLineData *dataItem);
+    TextLineData* take(size_t line, size_t field);
+    TextLineData* get(size_t line, size_t field);
 
     /// returns the number of items per line
-    int fieldsPerLine() { return fieldsPerLine_; }
-    void setFieldsPerLine( int count );
+    size_t fieldsPerLine() { return fieldsPerLine_; }
+    void setFieldsPerLine(size_t count);
 
     /// returns the number of items
-    int length() const { return textLineDataList_.length(); }
+    size_t length() const { return textLineDataList_.length(); }
     /// returns the textline data list item
-    TextLineDataList* at(int idx) const { return textLineDataList_.at(idx); }
+    TextLineDataList* at(size_t idx) const { return textLineDataList_.at(idx); }
 
     // internal functions
-    Change* createLinesReplacedChange( int lineStart, int lineCount, int newLineCount );
-    TextLineDataList* takeList( int line );
-    void giveList( int line, TextLineDataList* list );
+    Change* createLinesReplacedChange(size_t lineStart, size_t lineCount, size_t newLineCount);
+    TextLineDataList* takeList(size_t line);
+    void giveList(size_t line, TextLineDataList* list);
 
-    void fillWithEmpty( int line, int length, int newLength );
-    void replace( int line, int length, TextLineDataList** items, int newLength );
+    void fillWithEmpty(size_t line, size_t length, size_t newLength);
+    void replace(size_t line, size_t length, TextLineDataList** items, size_t newLength);
 
     /// internal method for direct accesss
     GapVector<TextLineDataList*>* textLineDataList() { return &textLineDataList_; }
 
 protected:
 
-    void destroyRange( int line, int length );
+    void destroyRange(size_t line, size_t length);
 
 
 public slots:
@@ -119,13 +120,12 @@ public slots:
 //    void dumpGapvector();
 signals:
 
-    void lineDataChanged(int line, int length, int newLength);   ///< This signal is emitted if line-data is changed
+    void lineDataChanged(size_t line, size_t length, size_t newLength);   ///< This signal is emitted if line-data is changed
 
 private:
 
-    int fieldsPerLine_;                                  ///< The number of items per line
+    size_t fieldsPerLine_;                              ///< The number of items per line
     GapVector<TextLineDataList*>  textLineDataList_;    ///< The textline data list
-//    NoGapVector<TextLineDataList*>  textLineDataList_;
 };
 
 

--- a/edbee-lib/edbee/models/textrange.cpp
+++ b/edbee-lib/edbee/models/textrange.cpp
@@ -1131,7 +1131,7 @@ TextRangeSet *TextRangeSet::clone() const
 /// returns the selection range
 TextRange& TextRangeSet::range(size_t idx)
 {
-    Q_ASSERT(idx >= 0);
+    Q_ASSERT(idx != std::string::npos);
     Q_ASSERT(idx < static_cast<size_t>(selectionRanges_.size()));
     return selectionRanges_[static_cast<qsizetype>(idx)];
 }

--- a/edbee-lib/edbee/models/textrange.cpp
+++ b/edbee-lib/edbee/models/textrange.cpp
@@ -41,7 +41,7 @@ void TextRange::fixCaretForUnicode(TextDocument *doc, ptrdiff_t direction)
 /// @param anchor the anchor location to set
 void TextRange::setAnchorBounded(TextDocument* doc, size_t anchor)
 {
-    setAnchor(qBound(0u, anchor, doc->length()));
+    setAnchor(qBound(static_cast<size_t>(0), anchor, doc->length()));
 }
 
 
@@ -50,7 +50,7 @@ void TextRange::setAnchorBounded(TextDocument* doc, size_t anchor)
 /// @param caret the caret position to set
 void TextRange::setAnchorBounded(TextDocument *doc, ptrdiff_t anchor)
 {
-    setAnchor(static_cast<size_t>(qBound(0, anchor, static_cast<ptrdiff_t>(doc->length()))));
+    setAnchor(static_cast<size_t>(qBound(static_cast<ptrdiff_t>(0), anchor, static_cast<ptrdiff_t>(doc->length()))));
 }
 
 
@@ -59,7 +59,7 @@ void TextRange::setAnchorBounded(TextDocument *doc, ptrdiff_t anchor)
 /// @param caret the caret position to set
 void TextRange::setCaretBounded(TextDocument* doc, size_t caret)
 {
-    setCaret(qBound(0u, caret, doc->length()));
+    setCaret(qBound(static_cast<size_t>(0), caret, doc->length()));
 }
 
 
@@ -68,7 +68,7 @@ void TextRange::setCaretBounded(TextDocument* doc, size_t caret)
 /// @param caret the caret position to set
 void TextRange::setCaretBounded(TextDocument *doc, ptrdiff_t caret)
 {
-    setCaret(static_cast<size_t>(qBound(0, caret, static_cast<ptrdiff_t>(doc->length()))));
+    setCaret(static_cast<size_t>(qBound(static_cast<ptrdiff_t>(0), caret, static_cast<ptrdiff_t>(doc->length()))));
 }
 
 

--- a/edbee-lib/edbee/models/textrange.cpp
+++ b/edbee-lib/edbee/models/textrange.cpp
@@ -1,10 +1,11 @@
 // edbee - Copyright (c) 2012-2025 by Rick Blommers and contributors
 // SPDX-License-Identifier: MIT
 
+#include "textrange.h"
+
 #include <QStringList>
 
 #include "textdocument.h"
-#include "textrange.h"
 #include "texteditorconfig.h"
 #include "edbee/debug.h"
 
@@ -19,7 +20,7 @@ bool TextRange::lessThan(TextRange &r1, TextRange &r2)
 
 /// Makes sure the caret isn't in-between a unicode boundary
 /// refs #19 - Dirty hack to improve caret-movement by skipping non-BMP characters
-void TextRange::fixCaretForUnicode(TextDocument *doc, int direction)
+void TextRange::fixCaretForUnicode(TextDocument *doc, ptrdiff_t direction)
 {
     if (caret_ >= doc->length()) return;
 
@@ -90,7 +91,7 @@ QString TextRange::toString() const
 /// Moves the caret the given amount
 /// @param doc the document to move the caret for
 /// @param amount the amount to move
-void TextRange::moveCaret(TextDocument* doc, int amount)
+void TextRange::moveCaret(TextDocument* doc, ptrdiff_t amount)
 {
     setCaretBounded(doc, static_cast<ptrdiff_t>(caret_) + amount);
     fixCaretForUnicode(doc, amount);
@@ -100,7 +101,7 @@ void TextRange::moveCaret(TextDocument* doc, int amount)
 /// move the caret or deselect the given amount
 /// @param doc the document to move the caret in
 /// @param amount the amount to move
-void TextRange::moveCaretOrDeselect(TextDocument* doc, int amount)
+void TextRange::moveCaretOrDeselect(TextDocument* doc, ptrdiff_t amount)
 {
     // when there's a selection clear it (move the caret to the right side
     if (hasSelection()) {
@@ -125,7 +126,7 @@ void TextRange::moveCaretOrDeselect(TextDocument* doc, int amount)
 /// @param var the initial position
 /// @param amount the amount to move
 /// returns the new position
-size_t TextRange::moveWhileChar(TextDocument* doc, size_t pos, int amount, const QString& chars)
+size_t TextRange::moveWhileChar(TextDocument* doc, size_t pos, ptrdiff_t amount, const QString& chars)
 {
     size_t docLength = doc->length();
     if (amount < 0) {
@@ -145,7 +146,7 @@ size_t TextRange::moveWhileChar(TextDocument* doc, size_t pos, int amount, const
 
 /// This method charactes until the given chargroup is found
 /// When moving to the LEFT the cursor is placed AFTER the found character
-size_t TextRange::moveUntilChar(TextDocument* doc, size_t pos, int amount, const QString& chars)
+size_t TextRange::moveUntilChar(TextDocument* doc, size_t pos, ptrdiff_t amount, const QString& chars)
 {
     size_t docLength = doc->length();
     if (amount < 0) {
@@ -164,32 +165,32 @@ size_t TextRange::moveUntilChar(TextDocument* doc, size_t pos, int amount, const
 
 
 /// moves the caret while a character is moving
-void TextRange::moveCaretWhileChar(TextDocument* doc, int amount, const QString& chars)
+void TextRange::moveCaretWhileChar(TextDocument* doc, ptrdiff_t amount, const QString& chars)
 {
     caret_ = moveWhileChar(doc, caret_, amount, chars);
 }
 
 
-void TextRange::moveCaretUntilChar(TextDocument *doc, int amount, const QString& chars)
+void TextRange::moveCaretUntilChar(TextDocument *doc, ptrdiff_t amount, const QString& chars)
 {
     caret_ = moveUntilChar(doc, caret_, amount, chars);
 }
 
 
-void TextRange::moveAnchortWhileChar(TextDocument *doc, int amount, const QString &chars)
+void TextRange::moveAnchortWhileChar(TextDocument *doc, ptrdiff_t amount, const QString &chars)
 {
     anchor_ = moveWhileChar(doc, anchor_, amount, chars);
 }
 
 
-void TextRange::moveAnchorUntilChar(TextDocument *doc, int amount, const QString &chars)
+void TextRange::moveAnchorUntilChar(TextDocument *doc, ptrdiff_t amount, const QString &chars)
 {
     anchor_ = moveWhileChar(doc, anchor_, amount, chars);
 }
 
 
 /// Moves the caret to/from the given seperator
-void TextRange::moveCaretByCharGroup(TextDocument *doc, int amount, const QString& whitespace, const QStringList& characterGroups)
+void TextRange::moveCaretByCharGroup(TextDocument *doc, ptrdiff_t amount, const QString& whitespace, const QStringList& characterGroups)
 {
     size_t count = static_cast<size_t>(qAbs(amount));
 
@@ -248,7 +249,7 @@ void TextRange::moveCaretByCharGroup(TextDocument *doc, int amount, const QStrin
 /// @param doc the document this range operates on
 /// @param amount the direction to move to
 /// @par    am whitespace the characters that need to be interpreted as whitespace
-void TextRange::moveCaretToLineBoundary(TextDocument* doc, int amount, const QString& whitespace)
+void TextRange::moveCaretToLineBoundary(TextDocument* doc, ptrdiff_t amount, const QString& whitespace)
 {
     TextBuffer* buf     = doc->buffer();
     size_t caret           = caret_;
@@ -320,7 +321,7 @@ void TextRange::moveCaretToLineBoundaryAtOffset(TextDocument *doc, size_t newOff
 /// -1 means expand lines to top (and add extra lines)
 /// 1 means expand lines at the bottom (and add extras lines)
 /// 0 is a special case, it moves the caret to the start of the current line and expands to the end of the line. It does not add lines
-void TextRange::expandToFullLine(TextDocument* doc, int amount)
+void TextRange::expandToFullLine(TextDocument* doc, ptrdiff_t amount)
 {
     size_t minOffset = min();
     size_t maxOffset = max();
@@ -803,7 +804,7 @@ void TextRangeSetBase::substractRange(size_t minB, size_t maxB)
 
 
 /// Expands the selection so it selects full lines
-void TextRangeSetBase::expandToFullLines(int amount)
+void TextRangeSetBase::expandToFullLines(ptrdiff_t amount)
 {
     for (size_t i = 0, cnt = rangeCount(); i < cnt; ++i) {
         range(i).expandToFullLine(textDocument(), amount);
@@ -865,7 +866,7 @@ void TextRangeSetBase::toggleWordSelectionAt(size_t offset, const QString& white
 
 
 /// Moves the carets by character
-void TextRangeSetBase::moveCarets(int amount)
+void TextRangeSetBase::moveCarets(ptrdiff_t amount)
 {
     for (size_t i = 0, cnt = rangeCount(); i < cnt; ++i) {
         range(i).moveCaret(textDocument(), amount);
@@ -875,7 +876,7 @@ void TextRangeSetBase::moveCarets(int amount)
 
 
 /// Moves the carets or deslects the given character
-void TextRangeSetBase::moveCaretsOrDeselect(int amount)
+void TextRangeSetBase::moveCaretsOrDeselect(ptrdiff_t amount)
 {
     for (size_t i = 0, cnt = rangeCount(); i < cnt; ++i) {
         range(i).moveCaretOrDeselect(textDocument(), amount);
@@ -885,7 +886,7 @@ void TextRangeSetBase::moveCaretsOrDeselect(int amount)
 
 
 /// Moves the carets
-void TextRangeSetBase::moveCaretsByCharGroup(int amount, const QString& whitespace, const QStringList& characterGroups)
+void TextRangeSetBase::moveCaretsByCharGroup(ptrdiff_t amount, const QString& whitespace, const QStringList& characterGroups)
 {
     for (size_t rangeIdx=rangeCount() - 1; rangeIdx != std::string::npos; --rangeIdx) {
         range(rangeIdx).moveCaretByCharGroup(textDocument(), amount, whitespace, characterGroups);
@@ -897,7 +898,7 @@ void TextRangeSetBase::moveCaretsByCharGroup(int amount, const QString& whitespa
 /// Moves all carets to the given line boundary (line-boundary automatically switches between column 0 and first non-whitespace character)
 /// @param direction the direction < 0 to the start of the line (or first char)  > 0 to the end of the line
 /// @param whitespace the characters to see as whitespace
-void TextRangeSetBase::moveCaretsToLineBoundary(int direction , const QString& whitespace)
+void TextRangeSetBase::moveCaretsToLineBoundary(ptrdiff_t direction, const QString& whitespace)
 {
     // process all carets
     for (size_t rangeIdx = rangeCount() - 1; rangeIdx != std::string::npos; --rangeIdx) {
@@ -1032,7 +1033,7 @@ void TextRangeSetBase::changeSpatial(size_t pos, size_t length, size_t newLength
 {
     if (rangeCount() == 0) return;
 
-    int stickyDelta = sticky ? 0 : -1;
+    ptrdiff_t stickyDelta = sticky ? 0 : -1;
 
     // change the ranges
     ptrdiff_t endPos = static_cast<ptrdiff_t>(pos + length);

--- a/edbee-lib/edbee/models/textrange.cpp
+++ b/edbee-lib/edbee/models/textrange.cpp
@@ -10,7 +10,7 @@
 
 namespace edbee {
 
-/// This method compares selection ranges
+/// Compares selection ranges
 bool TextRange::lessThan(TextRange &r1, TextRange &r2)
 {
     return r1.min() < r2.min();
@@ -21,43 +21,61 @@ bool TextRange::lessThan(TextRange &r1, TextRange &r2)
 /// refs #19 - Dirty hack to improve caret-movement by skipping non-BMP characters
 void TextRange::fixCaretForUnicode(TextDocument *doc, int direction)
 {
-    if( caret_ >= doc->length() ) return;
+    if (caret_ >= doc->length()) return;
 
     // unicode-emoji hack (Really really dirty!!)
     int code = doc->charAt(caret_).unicode();
-//qlog_info() << "fixCaretForUnicode: >> " << caret_ << " : " << code <<  "(" << direction << ")";
-    if( 0xDC00 <= code && code <= 0xDFFF ) {
-        if( direction > 0 ) {
-            setCaretBounded( doc, caret_ + 1 );
+    if (0xDC00 <= code && code <= 0xDFFF) {
+        if (direction > 0) {
+            setCaretBounded(doc, caret_ + 1);
         } else {
-            setCaretBounded( doc, caret_ - 1 );
+            setCaretBounded(doc, caret_ - 1);
         }
     }
 }
 
+
 /// Sets the anchor to the given location, and forces the anchor to say between the document bounds
 /// @param doc document to set the anchor for
 /// @param anchor the anchor location to set
-void TextRange::setAnchorBounded(TextDocument* doc, int anchor)
+void TextRange::setAnchorBounded(TextDocument* doc, size_t anchor)
 {
-    setAnchor( qBound( 0,  anchor, doc->length() ) );
+    setAnchor(qBound(0u, anchor, doc->length()));
 }
 
 
 /// Sets the caret to the given location, and forces the caret to say between the document bounds
 /// @param doc the document (used for checking the document bounds)
 /// @param caret the caret position to set
-void TextRange::setCaretBounded(TextDocument* doc, int caret)
+void TextRange::setAnchorBounded(TextDocument *doc, ptrdiff_t anchor)
 {
-    setCaret( qBound( 0,  caret, doc->length() ) );
+    setAnchor(static_cast<size_t>(qBound(0, anchor, static_cast<ptrdiff_t>(doc->length()))));
+}
+
+
+/// Sets the caret to the given location, and forces the caret to say between the document bounds
+/// @param doc the document (used for checking the document bounds)
+/// @param caret the caret position to set
+void TextRange::setCaretBounded(TextDocument* doc, size_t caret)
+{
+    setCaret(qBound(0u, caret, doc->length()));
+}
+
+
+/// Sets the caret to the given location, and forces the caret to say between the document bounds
+/// @param doc the document (used for checking the document bounds)
+/// @param caret the caret position to set
+void TextRange::setCaretBounded(TextDocument *doc, ptrdiff_t caret)
+{
+    setCaret(static_cast<size_t>(qBound(0, caret, static_cast<ptrdiff_t>(doc->length()))));
 }
 
 
 /// Changes the length by modifying the max-variable
-void TextRange::setLength(int newLength)
+void TextRange::setLength(size_t newLength)
 {
-    int& vMin = minVar();
-    int& vMax = maxVar();
+    size_t& vMin = minVar();
+    size_t& vMax = maxVar();
     vMax = vMin + newLength;
 }
 
@@ -72,10 +90,10 @@ QString TextRange::toString() const
 /// Moves the caret the given amount
 /// @param doc the document to move the caret for
 /// @param amount the amount to move
-void TextRange::moveCaret(TextDocument* doc, int amount )
+void TextRange::moveCaret(TextDocument* doc, int amount)
 {
-    setCaretBounded( doc, caret_ + amount );
-    fixCaretForUnicode(doc,amount);
+    setCaretBounded(doc, static_cast<ptrdiff_t>(caret_) + amount);
+    fixCaretForUnicode(doc, amount);
 }
 
 
@@ -85,19 +103,19 @@ void TextRange::moveCaret(TextDocument* doc, int amount )
 void TextRange::moveCaretOrDeselect(TextDocument* doc, int amount)
 {
     // when there's a selection clear it (move the caret to the right side
-    if( hasSelection() ) {
-        if( amount < 0 ) {
+    if (hasSelection()) {
+        if (amount < 0) {
             setCaret(min());
         } else {
             setCaret(max());
         }
-        setAnchor( caret() );
+        setAnchor(caret());
 
     // just moves the caret
     } else {
-        setCaretBounded( doc, caret_ + amount );
+        setCaretBounded(doc, static_cast<ptrdiff_t>(caret_) + amount);
     }
-    fixCaretForUnicode(doc,amount);
+    fixCaretForUnicode(doc, amount);
 }
 
 
@@ -106,15 +124,20 @@ void TextRange::moveCaretOrDeselect(TextDocument* doc, int amount)
 /// @param doc the text document
 /// @param var the initial position
 /// @param amount the amount to move
-int TextRange::moveWhileChar(TextDocument* doc, int pos, int amount, const QString& chars)
+/// returns the new position
+size_t TextRange::moveWhileChar(TextDocument* doc, size_t pos, int amount, const QString& chars)
 {
-    int docLength = doc->length();
-    if( amount < 0 ) {
+    size_t docLength = doc->length();
+    if (amount < 0) {
         --pos;   // first move left
-        while( pos >= 0 && chars.indexOf( doc->charAt(pos) )>=0 ) { --pos; }
+        while (pos != std::string::npos && chars.indexOf(doc->charAt(pos)) >= 0) {
+            --pos;
+        }
         ++pos;
     } else {
-        while( pos <  docLength && chars.indexOf( doc->charAt(pos) )>=0 ) { ++pos; }
+        while(pos < docLength && chars.indexOf(doc->charAt(pos)) >= 0) {
+            ++pos;
+        }
     }
     return pos;
 }
@@ -122,15 +145,19 @@ int TextRange::moveWhileChar(TextDocument* doc, int pos, int amount, const QStri
 
 /// This method charactes until the given chargroup is found
 /// When moving to the LEFT the cursor is placed AFTER the found character
-int TextRange::moveUntilChar(TextDocument* doc, int pos, int amount, const QString& chars)
+size_t TextRange::moveUntilChar(TextDocument* doc, size_t pos, int amount, const QString& chars)
 {
-    int docLength = doc->length();
-    if( amount < 0 ) {
+    size_t docLength = doc->length();
+    if (amount < 0) {
         --pos;
-        while( pos >= 0 && chars.indexOf( doc->charAt(pos) )<0 ) { --pos; }
+        while (pos != std::string::npos && chars.indexOf(doc->charAt(pos)) == -1) {
+            --pos;
+        }
         ++pos;
     } else {
-        while( pos <  docLength && chars.indexOf( doc->charAt(pos) )<0 ) { ++pos; }
+        while (pos < docLength && chars.indexOf(doc->charAt(pos)) == -1) {
+            ++pos;
+        }
     }
     return pos;
 }
@@ -139,117 +166,121 @@ int TextRange::moveUntilChar(TextDocument* doc, int pos, int amount, const QStri
 /// moves the caret while a character is moving
 void TextRange::moveCaretWhileChar(TextDocument* doc, int amount, const QString& chars)
 {
-    caret_ = moveWhileChar(doc, caret_, amount, chars );
+    caret_ = moveWhileChar(doc, caret_, amount, chars);
 }
 
 
 void TextRange::moveCaretUntilChar(TextDocument *doc, int amount, const QString& chars)
 {
-    caret_ = moveUntilChar(doc, caret_, amount, chars );
+    caret_ = moveUntilChar(doc, caret_, amount, chars);
 }
 
 
 void TextRange::moveAnchortWhileChar(TextDocument *doc, int amount, const QString &chars)
 {
-    anchor_ = moveWhileChar(doc, anchor_, amount, chars );
+    anchor_ = moveWhileChar(doc, anchor_, amount, chars);
 }
 
 
 void TextRange::moveAnchorUntilChar(TextDocument *doc, int amount, const QString &chars)
 {
-    anchor_ = moveWhileChar(doc, anchor_, amount, chars );
+    anchor_ = moveWhileChar(doc, anchor_, amount, chars);
 }
 
 
-/// This method moves the caret to/from the given seperator
-void TextRange::moveCaretByCharGroup(TextDocument *doc, int amount, const QString& whitespace, const QStringList& characterGroups )
+/// Moves the caret to/from the given seperator
+void TextRange::moveCaretByCharGroup(TextDocument *doc, int amount, const QString& whitespace, const QStringList& characterGroups)
 {
-    int count = qAbs(amount);
+    size_t count = static_cast<size_t>(qAbs(amount));
 
-    for( int i=0; i<count; ++i ) {
+    for (size_t i = 0; i < count; ++i) {
 
         // first 'skip' the whitespaces
-        int oldCaret = caret_;
-        moveCaretWhileChar( doc, amount, whitespace );
+        size_t oldCaret = caret_;
+        moveCaretWhileChar(doc, amount, whitespace);
 
         // find the character group
         QChar chr;
-        if( amount < 0 ) {
+        if (amount < 0) {
             if( caret_ == 0 ) return;
-            chr = doc->charAt( caret_-1 );
+            chr = doc->charAt(caret_ - 1);
         } else {
-            if( caret_ == doc->length() ) return;
-            chr = doc->charAt( caret_ );
+            if (caret_ == doc->length()) return;
+            chr = doc->charAt(caret_);
         }
 
         // newline is a special operation :(
-        if( chr == '\n') {
-            if( caret_ == oldCaret ) {
-                caret_ += amount < 0 ? -1 : 1;
+        if (chr == '\n') {
+            if (caret_ == oldCaret) {
+                if (amount < 0) {
+                    caret_ -= 1;
+                    Q_ASSERT(caret_ != std::string::npos);
+                } else {
+                    caret_ += 1;
+
+                }
             }
         } else {
-
             // while the character is found
             bool found = false;
-            for( int i=0,cnt= characterGroups.length(); i<cnt; ++i ) {
+            for (qsizetype i=0, cnt = characterGroups.length(); i < cnt; ++i) {
                 const QString& group = characterGroups.at(i);
-                if( group.indexOf(chr) >= 0 ) {
-                    moveCaretWhileChar(doc,amount,group);
+                if (group.indexOf(chr) >= 0) {
+                    moveCaretWhileChar(doc, amount, group);
                     found = true;
                     break;
                 }
             }
 
             // all other characters are valid
-            if( !found ) {
+            if (!found) {
                 QString str = characterGroups.join("");
                 str.append(whitespace);
                 str.append('\n');
-                moveCaretUntilChar(doc,amount,str);
+                moveCaretUntilChar(doc, amount, str);
             }
         }
     }
 }
 
 
-/// This moves the caret to a line boundary
+/// Moves the caret to a line boundary
 /// @param doc the document this range operates on
 /// @param amount the direction to move to
 /// @par    am whitespace the characters that need to be interpreted as whitespace
-void TextRange::moveCaretToLineBoundary(TextDocument* doc, int amount, const QString& whitespace )
+void TextRange::moveCaretToLineBoundary(TextDocument* doc, int amount, const QString& whitespace)
 {
     TextBuffer* buf     = doc->buffer();
-    int caret           = caret_;
-    int line            = doc->lineFromOffset( caret );
-    int offsetNextLine  = doc->offsetFromLine( line + 1 );
-    if( amount < 0 ) {
-        int lineStart = doc->offsetFromLine( line );
+    size_t caret           = caret_;
+    size_t line            = doc->lineFromOffset(caret);
+    size_t offsetNextLine  = doc->offsetFromLine(line + 1);
+    if (amount < 0) {
+        size_t lineStart = doc->offsetFromLine(line);
 
         // find the first word
-        int wordStart = buf->findCharPosWithinRangeOrClamp( lineStart, 1, whitespace, false, lineStart, offsetNextLine );
-        if( caret > wordStart || lineStart ==  caret ) {
+        size_t wordStart = buf->findCharPosWithinRangeOrClamp(lineStart, 1u, whitespace, false, lineStart, offsetNextLine);
+        if (caret > wordStart || lineStart ==  caret) {
             caret = wordStart;
         } else {
             caret = lineStart;
         }
     } else {
-
         caret = offsetNextLine;
-        if( line != doc->lineCount()-1 ) {
+        if (line != doc->lineCount() - 1) {
             --caret;
         }
-
     }
-    setCaretBounded( doc, caret );
+    setCaretBounded(doc, caret);
 }
 
+
 /// Moves the caret to a word boundary  (used for word dragging selections)
-void TextRange::moveCaretToWordBoundaryAtOffset(TextDocument *doc, int newOffset)
+void TextRange::moveCaretToWordBoundaryAtOffset(TextDocument *doc, size_t newOffset)
 {
     TextEditorConfig* config = doc->config();
 
     // left direction
-    if( newOffset < anchor()) {
+    if (newOffset < anchor()) {
         setAnchor(max());
         setCaret(newOffset);
         moveCaretByCharGroup(doc, -1, config->whitespaces(), config->charGroups());
@@ -260,16 +291,17 @@ void TextRange::moveCaretToWordBoundaryAtOffset(TextDocument *doc, int newOffset
     }
 }
 
+
 /// Moves the caret to a word boundary  (used for word dragging selections)
-void TextRange::moveCaretToLineBoundaryAtOffset(TextDocument *doc, int newOffset)
+void TextRange::moveCaretToLineBoundaryAtOffset(TextDocument *doc, size_t newOffset)
 {
-    int firstLine = doc->lineFromOffset(min());
-    int lastLine = doc->lineFromOffset(max());
+    size_t firstLine = doc->lineFromOffset(min());
+    size_t lastLine = doc->lineFromOffset(max());
 
     // changed offset
     setCaret(newOffset);
 
-    int newLine = doc->lineFromOffset(newOffset);
+    size_t newLine = doc->lineFromOffset(newOffset);
 
     // left direction
     if( newLine < lastLine ) {
@@ -282,6 +314,7 @@ void TextRange::moveCaretToLineBoundaryAtOffset(TextDocument *doc, int newOffset
     }
 }
 
+
 /// Expands the selection range so it only consists of full lines
 /// amount specifies the amount (and the direction) of the expansions
 /// -1 means expand lines to top (and add extra lines)
@@ -293,41 +326,37 @@ void TextRange::expandToFullLine(TextDocument* doc, int amount)
     int maxOffset = max();
 
     // select the current line (everse caret
-    if( amount == 0 ) {
-        minOffset = doc->offsetFromLine( doc->lineFromOffset(minOffset) );
-        maxOffset = doc->offsetFromLine( doc->lineFromOffset(maxOffset)+1);
+    if (amount == 0) {
+        minOffset = doc->offsetFromLine(doc->lineFromOffset(minOffset));
+        maxOffset = doc->offsetFromLine(doc->lineFromOffset(maxOffset) + 1);
         caret_ = minOffset;
         anchor_ = maxOffset;
-
     } else if( amount > 0 ) {
-        minOffset = doc->offsetFromLine( doc->lineFromOffset(minOffset) );
-        maxOffset = doc->offsetFromLine( doc->lineFromOffset(maxOffset)+amount );
+        minOffset = doc->offsetFromLine(doc->lineFromOffset(minOffset));
+        maxOffset = doc->offsetFromLine(doc->lineFromOffset(maxOffset) + amount);
 
         caret_ = maxOffset;
         anchor_ = minOffset;
-
     } else {
-
-        int minLine = doc->lineFromOffset( minOffset );
-        int minLineStartOffset = doc->offsetFromLine( minLine );
+        int minLine = doc->lineFromOffset(minOffset);
+        int minLineStartOffset = doc->offsetFromLine(minLine);
 
         // only select line above if the full line isn't selected yet
-        if( minOffset == minLineStartOffset ) {
-            if( minOffset > 0 ) { --minOffset; }
+        if (minOffset == minLineStartOffset) {
+            if (minOffset > 0) { --minOffset; }
         }
         ++amount;
-        minOffset = doc->offsetFromLine( doc->lineFromOffset(minOffset) + amount );
+        minOffset = doc->offsetFromLine(doc->lineFromOffset(minOffset) + amount);
 
         // select to eol if required
-        int maxLine = doc->lineFromOffset( maxOffset );
-        int maxLineStartOffset = doc->offsetFromLine( maxLine );
-        if( maxLineStartOffset != maxOffset ) {
-            maxOffset = doc->offsetFromLine( doc->lineFromOffset(maxOffset)+1 );
+        int maxLine = doc->lineFromOffset(maxOffset);
+        int maxLineStartOffset = doc->offsetFromLine(maxLine);
+        if (maxLineStartOffset != maxOffset) {
+            maxOffset = doc->offsetFromLine(doc->lineFromOffset(maxOffset) + 1);
         }
 
         caret_ = minOffset;
         anchor_ = maxOffset;
-
     }
 }
 
@@ -335,20 +364,20 @@ void TextRange::expandToFullLine(TextDocument* doc, int amount)
 /// This method deselects the last character if it's a newline.
 void TextRange::deselectTrailingNewLine(TextDocument* doc)
 {
-    if( caret_ != anchor_ && doc->charAtOrNull(max()-1)=='\n' ) {
+    if (caret_ != anchor_ && doc->charAtOrNull(max() - 1) == '\n') {
         --maxVar();
     }
 }
 
 
 /// Internal method, for finding a character group with the given character
-static QString findCharGroup( QChar c, const QString& whitespace, const QStringList& characterGroups )
+static QString findCharGroup( QChar c, const QString& whitespace, const QStringList& characterGroups)
 {
     QString foundGroup;
-    if( whitespace.indexOf(c) >= 0) {
+    if (whitespace.indexOf(c) >= 0) {
         foundGroup = whitespace;
     } else {
-        for( int i=0,cnt=characterGroups.length(); i<cnt; ++i ) {
+        for (int i = 0, cnt = characterGroups.length(); i < cnt; ++i) {
             if( characterGroups.at(i).indexOf(c) >=0 ) {
                 foundGroup = characterGroups.at(i);
                 break;
@@ -358,55 +387,60 @@ static QString findCharGroup( QChar c, const QString& whitespace, const QStringL
     return foundGroup;
 }
 
+
 /// Expands the selection to a words
-void TextRange::expandToWord(TextDocument *doc, const QString& whitespace, const QStringList& characterGroups )
+void TextRange::expandToWord(TextDocument *doc, const QString& whitespace, const QStringList& characterGroups)
 {
-    int& min = minVar();
-    int& max = maxVar();
+    size_t& min = minVar();
+    size_t& max = maxVar();
 
     // first check which character is under the caret to find the character grouop
-    if( min > 0 ) {
-        QString group = findCharGroup( doc->charAt(min-1), whitespace, characterGroups );
-        if( group.isEmpty() ) {
+    if (min > 0) {
+        QString group = findCharGroup(doc->charAt(min - 1), whitespace, characterGroups);
+        if (group.isEmpty()) {
             group = characterGroups.join("").append(whitespace);     // the 'else' group
-            min = moveUntilChar(doc,min,-1,group);
+            min = moveUntilChar(doc, min, -1, group);
         } else {
-            min = moveWhileChar(doc,min,-1,group);
+            min = moveWhileChar(doc, min, -1, group);
         }
     }
 
-    if( max < doc->length() ) {
-        QString group = findCharGroup( doc->charAt(max), whitespace, characterGroups );
-        if( group.isEmpty() ) {
+    if (max < doc->length()) {
+        QString group = findCharGroup(doc->charAt(max), whitespace, characterGroups);
+        if (group.isEmpty()) {
             group = characterGroups.join("").append(whitespace);     // the 'else' group
-            max = moveUntilChar(doc,max,1,group);
+            max = moveUntilChar(doc, max, 1, group);
         } else {
-            max = moveWhileChar(doc,max,1,group);
+            max = moveWhileChar(doc, max, 1, group);
         }
     }
 }
+
 
 void TextRange::expandToIncludeRange(TextRange& range)
 {
-    int& min = minVar();
-    int& max = maxVar();
-    min = qMin( min, range.min() );
-    max = qMax( max, range.max() );
+    size_t& min = minVar();
+    size_t& max = maxVar();
+    min = qMin(min, range.min());
+    max = qMax(max, range.max());
 }
+
 
 /// Sets the bounds
 void TextRange::forceBounds(TextDocument *doc)
 {
-    setAnchorBounded( doc, anchor_ );
-    setCaretBounded( doc, caret_ );
+    setAnchorBounded(doc, anchor_);
+    setCaretBounded(doc, caret_ );
 }
+
 
 /// This method checks if the two ranges are equal
 /// @param range the range to compare it to
-bool TextRange::equals( const TextRange& range)
+bool TextRange::equals(const TextRange& range)
 {
     return range.caret_ == caret_ && range.anchor_ == anchor_;
 }
+
 
 /// Checks if two ranges touch eachother. Touching means that the start and end of two ranges are onto eachother
 /// Possible situations ( [ = anchor, > = caret, ( = don't care )
@@ -417,31 +451,40 @@ bool TextRange::touches(TextRange& range)
     int max1 = max();
     int min2 = range.min();
     int max2 = range.max();
-    return( max1 == min2 || max2 == min1 );
+    return (max1 == min2 || max2 == min1);
 }
 
+
 /// checks if the given position is in this textrange
-bool TextRange::contains(int pos)
+bool TextRange::contains(size_t pos)
 {
     return min() <= pos && pos < max();
 }
 
+/// some extra validations to assert non negative values
+void TextRange::assertValid() const
+{
+    Q_ASSERT(caret_ < std::string::npos - length());
+    Q_ASSERT(anchor_ < std::string::npos - length());
+}
 
 
 //=========================================================================
 
 
-TextRangeSetBase::TextRangeSetBase(TextDocument* doc )
-    : textDocumentRef_( doc )
+TextRangeSetBase::TextRangeSetBase(TextDocument* doc)
+    : textDocumentRef_(doc)
     , changing_(0)
 {
 }
 
+
 /// this method returns the last range
 TextRange &TextRangeSetBase::lastRange()
 {
-    return range( rangeCount()-1);
+    return range(rangeCount() - 1);
 }
+
 
 /// the first range
 TextRange &TextRangeSetBase::firstRange()
@@ -450,89 +493,95 @@ TextRange &TextRangeSetBase::firstRange()
 }
 
 
-/// This method returns the range index at the given offset
+/// Returns the range index at the given offset
 /// @param offset the offset to check
-/// @return the offset index or -1 if not found
-int TextRangeSetBase::rangeIndexAtOffset(int offset)
+/// @return the offset index or (npos) if not found
+size_t TextRangeSetBase::rangeIndexAtOffset(size_t offset)
 {
     // find the range of this offset
-    for( int i=0, cnt = rangeCount(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = rangeCount(); i < cnt; ++i) {
         TextRange& found = this->range(i);
-        int minOffset = found.min();
-        int maxOffset = found.max();
-        if( minOffset <= offset && offset <= maxOffset ) {
+        size_t minOffset = found.min();
+        size_t maxOffset = found.max();
+        if (minOffset <= offset && offset <= maxOffset) {
             return i;
         }
     }
-    return -1;
+    return std::string::npos;
 }
 
 
 /// returns the range indices that are being overlapped by the given offsetBegin and offsetEnd
 /// @param offsetBegin the offset to search
 /// @param offsetEnd the end-offset to search
-/// @param firstIndex(out) The first index found (-1 if not found)
-/// @param lastIndex(out) The last index found (-1 if not found)
+/// @param firstIndex(out) The first index found (npos if not found)
+/// @param lastIndex(out) The last index found (npos if not found)
 /// @return true if the range is found
-bool TextRangeSetBase::rangesBetweenOffsets( int offsetBegin, int offsetEnd, int& firstIndex, int& lastIndex )
+bool TextRangeSetBase::rangesBetweenOffsets(size_t offsetBegin, size_t offsetEnd, size_t& firstIndex, size_t& lastIndex)
 {
-    firstIndex = -1;
-    lastIndex  = -1;
-    /// Todo optimize with a binairy search
-    for( int i=0, cnt = rangeCount(); i<cnt; ++i ) {
-        TextRange& range = this->range(i);
-        int minOffset = range.min();
-        int maxOffset = range.max();
+    firstIndex = std::string::npos;
+    lastIndex  = std::string::npos;
 
-        if( (offsetBegin <= minOffset && minOffset <= offsetEnd) || (minOffset <= offsetBegin && offsetBegin <= maxOffset) ) {
-            if( firstIndex < 0 ) firstIndex = i;
+    /// Todo optimize with a binairy search
+    for (size_t i = 0, cnt = rangeCount(); i < cnt; ++i) {
+        TextRange& range = this->range(i);
+        size_t minOffset = range.min();
+        size_t maxOffset = range.max();
+
+        if ((offsetBegin <= minOffset && minOffset <= offsetEnd) || (minOffset <= offsetBegin && offsetBegin <= maxOffset)) {
+            if (firstIndex == std::string::npos) firstIndex = i;
             lastIndex = i;
         }
     }
-    return firstIndex>=0;
+
+    return firstIndex != std::string::npos;
 }
+
 
 /// returns the range indices that are being overlapped by the given offsetBegin and offsetEnd
 /// @param offsetBegin the offset to search
 /// @param offsetEnd the end-offset to search
-/// @param firstIndex(out) The first index found (-1 if not found)
-/// @param lastIndex(out) The last index found (-1 if not found)
-/// @return true if the range is found
-bool TextRangeSetBase::rangesBetweenOffsetsExlusiveEnd(int offsetBegin, int offsetEnd, int &firstIndex, int &lastIndex)
+/// @param firstIndex(out) The first index found (npos if not found)
+/// @param lastIndex(out) The last index found (npos if not found)
+/// @return true if the range is found (firstIndex and lastIndex are filled
+bool TextRangeSetBase::rangesBetweenOffsetsExlusiveEnd(size_t offsetBegin, size_t offsetEnd, size_t &firstIndex, size_t &lastIndex)
 {
-    firstIndex = -1;
-    lastIndex  = -1;
+    firstIndex = std::string::npos;
+    lastIndex  = std::string::npos;
     /// Todo optimize with a binairy search
-    for( int i=0, cnt = rangeCount(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = rangeCount(); i < cnt; ++i) {
         TextRange& range = this->range(i);
-        int minOffset = range.min();
-        int maxOffset = range.max();
+        size_t minOffset = range.min();
+        size_t maxOffset = range.max();
 
-        if( (offsetBegin <= minOffset && minOffset < offsetEnd) || (minOffset <= offsetBegin && offsetBegin < maxOffset) ) {
-            if( firstIndex < 0 ) firstIndex = i;
+        if ((offsetBegin <= minOffset && minOffset < offsetEnd) || (minOffset <= offsetBegin && offsetBegin < maxOffset)) {
+            if (firstIndex == std::string::npos) firstIndex = i;
             lastIndex = i;
         }
     }
-    return firstIndex>=0;
+    return firstIndex != std::string::npos;
 }
 
 
 /// Returns the range indices that are being used on the given line
-bool TextRangeSetBase::rangesAtLine(int line, int& firstIndex, int& lastIndex)
+/// @return true if the range is found (firstIndex and lastIndex are filled
+bool TextRangeSetBase::rangesAtLine(size_t line, size_t& firstIndex, size_t& lastIndex)
 {
     TextDocument* doc = textDocument();
-    int offsetBegin = doc->offsetFromLine(line);
-    int offsetEnd   = doc->offsetFromLine(line+1)-1;
-    return rangesBetweenOffsets( offsetBegin, offsetEnd, firstIndex, lastIndex );
+    size_t offsetBegin = doc->offsetFromLine(line);
+    size_t offsetEnd   = doc->offsetFromLine(line + 1) - 1;
+    return rangesBetweenOffsets(offsetBegin, offsetEnd, firstIndex, lastIndex);
 }
 
+
 /// Returns the range indices that are being used on the given line (Excluding the last offset)
-bool TextRangeSetBase::rangesAtLineExclusiveEnd(int line, int &firstIndex, int &lastIndex)
+/// @return true if the range is found (firstIndex and lastIndex are filled
+bool TextRangeSetBase::rangesAtLineExclusiveEnd(size_t line, size_t &firstIndex, size_t &lastIndex)
 {
     TextDocument* doc = textDocument();
-    int offsetBegin = doc->offsetFromLine(line);
-    int offsetEnd   = doc->offsetFromLine(line+1)-1;
-    return rangesBetweenOffsetsExlusiveEnd( offsetBegin, offsetEnd, firstIndex, lastIndex );
+    size_t offsetBegin = doc->offsetFromLine(line);
+    size_t offsetEnd   = doc->offsetFromLine(line + 1) - 1;
+    return rangesBetweenOffsetsExlusiveEnd(offsetBegin, offsetEnd, firstIndex, lastIndex);
 }
 
 
@@ -540,19 +589,19 @@ bool TextRangeSetBase::rangesAtLineExclusiveEnd(int line, int &firstIndex, int &
 /// A selection is an range with a different anchor then it's caret
 bool TextRangeSetBase::hasSelection()
 {
-    for( int i=0, cnt = rangeCount(); i<cnt; ++i ) {
-        if( range(i).hasSelection() ) return true;
+    for (size_t i = 0, cnt = rangeCount(); i < cnt; ++i) {
+        if (range(i).hasSelection()) return true;
     }
     return false;
 }
 
 
 /// This method checks if two selections are equal
-bool TextRangeSetBase::equals( TextRangeSetBase& sel)
+bool TextRangeSetBase::equals(TextRangeSetBase& sel)
 {
-    if( sel.rangeCount() != rangeCount() ) return false;
-    for( int i=rangeCount()-1; i>=0; --i ) {
-        if( !range(i).equals( sel.range(i) ) ) return false;
+    if (sel.rangeCount() != rangeCount()) return false;
+    for (size_t i = rangeCount() - 1; i != std::string::npos; --i) {
+        if (!range(i).equals(sel.range(i))) return false;
     }
     return true;
 }
@@ -562,10 +611,9 @@ bool TextRangeSetBase::equals( TextRangeSetBase& sel)
 void TextRangeSetBase::replaceAll(const TextRangeSetBase& base)
 {
     clear();
-    for( int i=0,cnt=base.rangeCount(); i<cnt; ++i ) {
-        addRange( base.constRange(i) );
+    for (size_t i = 0, cnt = base.rangeCount(); i < cnt; ++i) {
+        addRange(base.constRange(i));
     }
-
 }
 
 
@@ -575,15 +623,15 @@ QString TextRangeSetBase::getSelectedText()
 {
     TextDocument* doc = textDocument();
     QString buffer;
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
+    for (size_t i=0, cnt = rangeCount(); i < cnt; ++i) {
         TextRange& range = this->range(i);
-        if( range.hasSelection() ) {
-            buffer.append( doc->textPart( range.min(), range.length() ) );
+        if (range.hasSelection()) {
+            buffer.append(doc->textPart(range.min(), range.length()));
             buffer.append("\n");
         }
     }
-    if( !buffer.isEmpty() ) {
-        buffer.remove( buffer.length()-1, 1);  // remove the last(newline character)
+    if (!buffer.isEmpty()) {
+        buffer.remove(buffer.length() - 1, 1);  // remove the last(newline character)
     }
     return buffer;
 }
@@ -596,7 +644,7 @@ QString TextRangeSetBase::getSelectedTextExpandedToFullLines()
     TextDocument* doc = textDocument();
     QString buffer;
     int lastLine = -1;
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
+    for (int i = 0, cnt = rangeCount(); i < cnt; ++i) {
         TextRange& range = this->range(i);
         int min = range.min();
         int max = range.max();
@@ -604,9 +652,9 @@ QString TextRangeSetBase::getSelectedTextExpandedToFullLines()
         int maxLine = doc->lineFromOffset(max);
 
         // skip the current line if it's the same as last one
-        if( line == lastLine ) { ++line; }
-        while( line <= maxLine ) {
-            buffer.append( doc->lineWithoutNewline(line) );
+        if (line == lastLine) { ++line; }
+        while (line <= maxLine) {
+            buffer.append(doc->lineWithoutNewline(line));
             buffer.append("\n");
             ++line;
         }
@@ -620,30 +668,29 @@ QString TextRangeSetBase::getSelectedTextExpandedToFullLines()
 QString TextRangeSetBase::rangesAsString() const
 {
     QString str;
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
+    for (int i = 0, cnt = rangeCount(); i < cnt; ++i) {
         const TextRange& range = constRange(i);
-        if( !str.isEmpty() ) str.append(",");
-        str.append( range.toString() );
-
+        if (!str.isEmpty()) str.append(",");
+        str.append(range.toString());
     }
     return str;
 }
 
 
-
 /// This method resets all anchors to the positions of the carets
 void TextRangeSetBase::resetAnchors()
 {
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
+    for (int i = 0, cnt = rangeCount(); i < cnt; ++i) {
         TextRange& range = this->range(i);
         range.reset();
     }
 }
 
+
 /// This method moves all carets to the anchor positions
 void TextRangeSetBase::clearSelection()
 {
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
+    for (int i=0, cnt = rangeCount(); i < cnt; ++i) {
         TextRange& range = this->range(i);
         range.clearSelection();
     }
@@ -653,7 +700,7 @@ void TextRangeSetBase::clearSelection()
 /// This method starts the changes
 void TextRangeSetBase::beginChanges()
 {
-    Q_ASSERT(changing_ < 10 );  // 10 times nesting is a LOT!!
+    Q_ASSERT(changing_ < 10);  // 10 times nesting is a LOT!!
     ++changing_;
 }
 
@@ -688,7 +735,7 @@ bool TextRangeSetBase::changing() const
 /// Merges all ranges
 void TextRangeSetBase::addTextRanges(const TextRangeSetBase& sel)
 {
-    for( int i=0,cnt=sel.rangeCount(); i<cnt; ++i ) {
+    for (int i = 0, cnt = sel.rangeCount(); i < cnt; ++i) {
         addRange( sel.constRange(i) );
     }
     processChangesIfRequired(true );
@@ -700,7 +747,7 @@ void TextRangeSetBase::addTextRanges(const TextRangeSetBase& sel)
 void TextRangeSetBase::substractTextRanges(const TextRangeSetBase& sel)
 {
     ++changing_;
-    for( int i=0,cnt=sel.rangeCount(); i<cnt; ++i ) {
+    for (int i = 0, cnt = sel.rangeCount(); i < cnt; ++i) {
         const TextRange& r = sel.constRange(i);
         substractRange(r.min(), r.max());
     }
@@ -710,18 +757,20 @@ void TextRangeSetBase::substractTextRanges(const TextRangeSetBase& sel)
 
 
 /// This method substracts a single range from the ranges list
-void TextRangeSetBase::substractRange(int minB, int maxB)
+void TextRangeSetBase::substractRange(size_t minB, size_t maxB)
 {
+    if (rangeCount() == 0) return;
+
     beginChanges();
-    for( int i=rangeCount()-1; i >=0; --i ) {
+    for (size_t i = rangeCount() -1; i != std::string::npos; --i) {
         TextRange& rangeItem = range(i);
-        int& minA = rangeItem.minVar();
-        int& maxA = rangeItem.maxVar();
+        size_t& minA = rangeItem.minVar();
+        size_t& maxA = rangeItem.maxVar();
 
         // A: [             ]
         // B:     [XXXXX]
         // =  [   ]     [   ]
-        if( ( minA < minB && minB < maxA ) && (minA<maxB && maxB < maxA ) )
+        if ((minA < minB && minB < maxA) && (minA<maxB && maxB < maxA))
         {
             /// TODO Add support for copyrange
             addRange( maxB, maxA );
@@ -730,22 +779,21 @@ void TextRangeSetBase::substractRange(int minB, int maxB)
         // A:     [    ]
         // B: [XXXXXXXXXXXXX]
         // =:    (leeg)
-        else if( ( minB <= minA && minA <= maxB ) && ( minB <= maxA && maxA <= maxB ) )
+        else if ((minB <= minA && minA <= maxB) && (minB <= maxA && maxA <= maxB))
         {
             removeRange(i);
         }
-
         // A: [     ]
         // B:    [XXXXXX]
         // =: [  ]
-        else if( minA < minB && minB < maxA )
+        else if (minA < minB && minB < maxA)
         {
             maxA = minB;
         }
         // A:     [     ]
         // B: [XXXXXX]
         // =:        [  ]
-        else if( minA < maxB && maxB < maxA )
+        else if (minA < maxB && maxB < maxA)
         {
             minA = maxB;
         }
@@ -755,21 +803,20 @@ void TextRangeSetBase::substractRange(int minB, int maxB)
 
 
 /// Expands the selection so it selects full lines
-void TextRangeSetBase::expandToFullLines( int amount )
+void TextRangeSetBase::expandToFullLines(int amount)
 {
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
-        range(i).expandToFullLine( textDocument(), amount );
+    for (int i = 0, cnt = rangeCount(); i < cnt; ++i) {
+        range(i).expandToFullLine(textDocument(), amount);
     }
     processChangesIfRequired();
-
 }
 
 
 /// Expands the selection to full words
 void TextRangeSetBase::expandToWords(const QString& whitespace, const QStringList& characterGroups)
 {
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
-        range(i).expandToWord( textDocument(), whitespace, characterGroups );
+    for (int i = 0, cnt = rangeCount(); i < cnt; ++i) {
+        range(i).expandToWord(textDocument(), whitespace, characterGroups);
     }
     processChangesIfRequired();
 }
@@ -777,7 +824,7 @@ void TextRangeSetBase::expandToWords(const QString& whitespace, const QStringLis
 
 /// Selects the word at the given offset
 /// @param offset the offset of the word to select
-void TextRangeSetBase::selectWordAt(int offset, const QString& whitespace, const QStringList& characterGroups )
+void TextRangeSetBase::selectWordAt(int offset, const QString& whitespace, const QStringList& characterGroups)
 {
     TextRange newRange(offset,offset);
     newRange.expandToWord( textDocument(), whitespace, characterGroups );
@@ -791,17 +838,17 @@ void TextRangeSetBase::selectWordAt(int offset, const QString& whitespace, const
 /// Double click an existing selection to remove the selection (and caret)
 void TextRangeSetBase::toggleWordSelectionAt(int offset, const QString& whitespace, const QStringList& characterGroups)
 {
-    int idx = rangeIndexAtOffset( offset );
+    int idx = rangeIndexAtOffset(offset);
 
     // range found
-    if( idx >= 0) {
+    if (idx >= 0) {
         TextRange& found = this->range(idx);
 
         // found a range with selection
-        if( found.hasSelection() ) {
+        if (found.hasSelection()) {
 
             // when multiple range, just remove the range
-            if( rangeCount() > 1 ) {
+            if (rangeCount() > 1) {
                 removeRange(idx);
                 return;
 
@@ -813,14 +860,15 @@ void TextRangeSetBase::toggleWordSelectionAt(int offset, const QString& whitespa
         }
     }
     // default operation is select word at
-    selectWordAt( offset, whitespace, characterGroups );
+    selectWordAt(offset, whitespace, characterGroups);
 }
 
+
 /// This method moves the carets by character
-void TextRangeSetBase::moveCarets( int amount )
+void TextRangeSetBase::moveCarets(int amount)
 {
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
-        range(i).moveCaret( textDocument(), amount);
+    for (int i = 0, cnt = rangeCount(); i < cnt; ++i) {
+        range(i).moveCaret(textDocument(), amount);
     }
     processChangesIfRequired();
 }
@@ -829,18 +877,18 @@ void TextRangeSetBase::moveCarets( int amount )
 /// This method moves the carets or deslects the given character
 void TextRangeSetBase::moveCaretsOrDeselect(int amount)
 {
-    for( int i=0, cnt=rangeCount(); i<cnt; ++i ) {
-        range(i).moveCaretOrDeselect( textDocument(), amount);
+    for (int i = 0, cnt = rangeCount(); i < cnt; ++i) {
+        range(i).moveCaretOrDeselect(textDocument(), amount);
     }
     processChangesIfRequired();
 }
 
 
 /// This method moves the carets
-void TextRangeSetBase::moveCaretsByCharGroup(int amount, const QString& whitespace, const QStringList& characterGroups )
+void TextRangeSetBase::moveCaretsByCharGroup(int amount, const QString& whitespace, const QStringList& characterGroups)
 {
-    for( int rangeIdx=rangeCount()-1; rangeIdx >= 0; --rangeIdx ) {
-        range(rangeIdx).moveCaretByCharGroup( textDocument(), amount, whitespace, characterGroups );
+    for (int rangeIdx=rangeCount() - 1; rangeIdx >= 0; --rangeIdx) {
+        range(rangeIdx).moveCaretByCharGroup(textDocument(), amount, whitespace, characterGroups);
     }
     processChangesIfRequired();
 }
@@ -852,8 +900,8 @@ void TextRangeSetBase::moveCaretsByCharGroup(int amount, const QString& whitespa
 void TextRangeSetBase::moveCaretsToLineBoundary(int direction , const QString& whitespace)
 {
     // process all carets
-    for( int rangeIdx=rangeCount()-1; rangeIdx >= 0; --rangeIdx ) {
-        range(rangeIdx).moveCaretToLineBoundary(textDocument(), direction, whitespace );
+    for (int rangeIdx = rangeCount() - 1; rangeIdx >= 0; --rangeIdx) {
+        range(rangeIdx).moveCaretToLineBoundary(textDocument(), direction, whitespace);
     }
     processChangesIfRequired();
 }
@@ -861,17 +909,17 @@ void TextRangeSetBase::moveCaretsToLineBoundary(int direction , const QString& w
 
 /// This method merges overlapping ranges
 /// @param joinBorders if joinborders is set, borders next to eachother are also interpretted as overlap. (inclusive/exclusive switch)
-void TextRangeSetBase::mergeOverlappingRanges( bool joinBorders )
+void TextRangeSetBase::mergeOverlappingRanges(bool joinBorders)
 {
     // check the ranges
     beginChanges();
-    for( int i=rangeCount()-1; i>=0; --i ) {
+    for (int i = rangeCount() - 1; i >= 0; --i) {
         TextRange& range1 = range(i);
         int min1 = range1.min();
         int max1 = range1.max();
 
         // check overlap with all other ranges
-        for( int j=i-1; j>=0; --j ) {
+        for (int j = i - 1; j >= 0; --j) {
             TextRange& range2 = range(j);
             int min2 = range2.min();
             int max2 = range2.max();
@@ -880,7 +928,7 @@ void TextRangeSetBase::mergeOverlappingRanges( bool joinBorders )
             // 1: [        ]
             // 2    [XXX]
             // =  (delete 1)
-            if( min1 <= min2 && max2 <= max1 ) {
+            if (min1 <= min2 && max2 <= max1) {
                 removeRange(j);
                 --i;
                 continue;
@@ -890,7 +938,7 @@ void TextRangeSetBase::mergeOverlappingRanges( bool joinBorders )
             // 1:     [   ]
             // 2    [XXXXXXX]
             // =  (delete 1)
-            if( min2 <= min1 && max1 <= max2 ) {
+            if (min2 <= min1 && max1 <= max2) {
                 removeRange(i);
                 //selectionRanges_.remove(i);
                 break;
@@ -900,9 +948,9 @@ void TextRangeSetBase::mergeOverlappingRanges( bool joinBorders )
             // 1:       [        ]
             // 2    [XXXXXX]
             // =  [ min2, max1]     (update range 2, delete range 1 )
-            if(
-               ( min2 < min1 && min1 < max2 && max2 < max1 )
-               || ( joinBorders && min2 <= min1 && min1 <= max2 && max2 <= max1 )
+            if (
+               (min2 < min1 && min1 < max2 && max2 < max1)
+               || (joinBorders && min2 <= min1 && min1 <= max2 && max2 <= max1)
             )
             {
                 range2.maxVar() = max1;
@@ -915,9 +963,9 @@ void TextRangeSetBase::mergeOverlappingRanges( bool joinBorders )
             // 1:   [        ]
             // 2         [XXXXXXX]
             // =  [ min1, max2]     (update range 2, delete range 1 )
-            if(
-               ( min1 < min2 && min2 < max1 && max1 < max2 )
-               || ( joinBorders && min1 <= min2 && min2 <= max1 && max1 <= max2 )
+            if (
+               (min1 < min2 && min2 < max1 && max1 < max2)
+               || (joinBorders && min1 <= min2 && min2 <= max1 && max1 <= max2)
             )
             {
                 range2.minVar() = min1;
@@ -931,16 +979,13 @@ void TextRangeSetBase::mergeOverlappingRanges( bool joinBorders )
 }
 
 
-
-
-
 /// This method sets the first range item
 /// @param anchor the anchor of the selection
 /// @param caret the caret position
 /// @param index the default range index (default 0)
 void TextRangeSetBase::setRange(int anchor, int caret, int index)
 {
-    range(index).set( anchor, caret );
+    range(index).set(anchor, caret);
 }
 
 
@@ -948,17 +993,16 @@ void TextRangeSetBase::setRange(int anchor, int caret, int index)
 /// Make sure the given index exists!!
 /// @param the range to use
 /// @param index the index of the range to change (when not given index 0 is assumed)
-void TextRangeSetBase::setRange(const TextRange& range, int index )
+void TextRangeSetBase::setRange(const TextRange& range, int index)
 {
-    setRange( range.anchor(), range.caret(), index );
+    setRange(range.anchor(), range.caret(), index);
 }
 
 
-
 /// This method process the changes if required
-void TextRangeSetBase::processChangesIfRequired(bool joinBorders )
+void TextRangeSetBase::processChangesIfRequired(bool joinBorders)
 {
-    if( !changing_ ) {
+    if (!changing_) {
         ++changing_; // prevent changing by functions below:
         mergeOverlappingRanges(joinBorders);
         sortRanges();
@@ -984,52 +1028,58 @@ TextDocument*TextRangeSetBase::textDocument() const
 /// @param length the length of the text that's changed
 /// @param newLength the new length of the text
 /// @param sticky, when sticky the caret/anchor is sticky and isn't moved if the change happens at the same location
-void TextRangeSetBase::changeSpatial(int pos, int length, int newLength, bool sticky , bool performDelete)
+void TextRangeSetBase::changeSpatial(size_t pos, size_t length, size_t newLength, bool sticky , bool performDelete)
 {
+    if (rangeCount() == 0) return;
+
     int stickyDelta = sticky ? 0 : -1;
 
     // change the ranges
-    int endPos = pos + length;
-    int delta = newLength - length;
-    int newEndPos = endPos + delta;
-    beginChanges();
-    for( int i=rangeCount()-1; i>=0; --i ) {
+    ptrdiff_t endPos = static_cast<ptrdiff_t>(pos + length);
+    ptrdiff_t delta = static_cast<ptrdiff_t>(newLength) - static_cast<ptrdiff_t>(length);
+    ptrdiff_t newEndPos = static_cast<ptrdiff_t>(endPos) + delta;
+    ptrdiff_t spos = static_cast<ptrdiff_t>(pos);
 
+    beginChanges();
+    size_t i = rangeCount();
+    for (size_t i = rangeCount() - 1; i != std::string::npos; --i) {
         TextRange& range = this->range(i);
 
-        int& min = range.minVar();
-        int& max = range.maxVar();
+        ptrdiff_t min = static_cast<ptrdiff_t>(range.min());
+        ptrdiff_t max = static_cast<ptrdiff_t>(range.max());
 
         // cut 'off' the endpos
-        if( pos <= min && min < endPos ) {
+        if (spos <= min && min < endPos) {
             min = endPos;
             // when the range becomes invalid simply remove it
-            if( min > max ) {
-                if( performDelete ) {
+            if (min > max) {
+                if (performDelete) {
                     removeRange(i);
                     continue;
                 } else {
-                    range.set(pos,pos);
+                    range.set(pos, pos);
                     continue;
                 }
             }
         }
 
         // anchor
-        if( pos < min && min < endPos ) {
+        if (spos < min && min < endPos) {
             min = newEndPos;
-        } else if( min > (pos+stickyDelta) ) {
-            min  += delta;
+        } else if (min > (spos + stickyDelta)) {
+            min += delta;
         }
 
         // caret
-        if( pos < max && max < endPos ) {
+        if (spos < max && max < endPos) {
             max  = newEndPos;
-        } else if( max > (pos+stickyDelta) ) {
-            max  += delta;
+        } else if (max > (spos + stickyDelta)) {
+            max += delta;
         }
 
-        range.set( min, max );
+        Q_ASSERT(min >= 0);
+        Q_ASSERT(max >= 0);
+        range.set(static_cast<size_t>(min), static_cast<size_t>(max));
     }
     endChanges();
 }
@@ -1041,23 +1091,23 @@ void TextRangeSetBase::changeSpatial(int pos, int length, int newLength, bool st
 /// Constructs a textrange set
 /// @param doc the document for this rangeset
 TextRangeSet::TextRangeSet(TextDocument* doc)
-    : TextRangeSetBase( doc )
+    : TextRangeSetBase(doc)
 {
 }
 
 
 /// the copy constructor for copying a selection
 /// @param sel the ranges to copy
-TextRangeSet::TextRangeSet( const TextRangeSet& sel )
-    : TextRangeSetBase( sel.textDocument() )
+TextRangeSet::TextRangeSet(const TextRangeSet& sel)
+    : TextRangeSetBase(sel.textDocument())
 {
     selectionRanges_ = sel.selectionRanges_;
 }
 
 
 // An operation to copy the selection with a pointer
-TextRangeSet::TextRangeSet( const TextRangeSet* sel )
-    : TextRangeSetBase( sel->textDocument() )
+TextRangeSet::TextRangeSet(const TextRangeSet* sel)
+    : TextRangeSetBase(sel->textDocument())
 {
     selectionRanges_ = sel->selectionRanges_;
 }
@@ -1075,49 +1125,47 @@ TextRangeSet& TextRangeSet::operator=(const TextRangeSet& sel)
 ///// This method clones the text selection
 TextRangeSet *TextRangeSet::clone() const
 {
-    return new TextRangeSet( *this );
+    return new TextRangeSet(*this);
 }
 
 
 /// returns the selection range
-TextRange& TextRangeSet::range(int idx)
+TextRange& TextRangeSet::range(size_t idx)
 {
-    Q_ASSERT( idx >= 0 );
-    Q_ASSERT( idx < selectionRanges_.size() );
-    return selectionRanges_[idx];
+    Q_ASSERT(idx >= 0);
+    Q_ASSERT(idx < static_cast<size_t>(selectionRanges_.size()));
+    return selectionRanges_[static_cast<size_t>(idx)];
 }
 
 
 /// Returns a const reference from the
-const TextRange &TextRangeSet::constRange(int idx) const
+const TextRange &TextRangeSet::constRange(size_t idx) const
 {
-    Q_ASSERT( idx >= 0 );
-    Q_ASSERT( idx < selectionRanges_.size() );
-    return selectionRanges_.at(idx);
+    Q_ASSERT(idx >= 0);
+    Q_ASSERT(idx < static_cast<qsizetype>(selectionRanges_.size()));
+    return selectionRanges_.at(static_cast<qsizetype>(idx));
 }
 
 
 /// Adds a text range
-void TextRangeSet::addRange(int anchor, int caret)
+void TextRangeSet::addRange(size_t anchor, size_t caret)
 {
-    selectionRanges_.append( TextRange( anchor, caret ) );
+    selectionRanges_.append(TextRange(anchor, caret));
     processChangesIfRequired();
 }
-
 
 
 /// adds a range
 void TextRangeSet::addRange(const TextRange& range)
 {
-    addRange( range.anchor(), range.caret() );
+    addRange(range.anchor(), range.caret());
 }
 
 
-
 /// this method removes the range
-void TextRangeSet::removeRange(int idx)
+void TextRangeSet::removeRange(size_t idx)
 {
-    selectionRanges_.remove(idx);
+    selectionRanges_.remove(static_cast<qsizetype>(idx));
     processChangesIfRequired();
 }
 
@@ -1125,8 +1173,6 @@ void TextRangeSet::removeRange(int idx)
 /// This method removes ALL carets except the 'global' selection
 void TextRangeSet::clear()
 {
-//    selectionRanges_.remove(1,selectionRanges_.size()-1);
-//    selectionRanges_[0].reset();
     selectionRanges_.clear();
 }
 
@@ -1134,7 +1180,7 @@ void TextRangeSet::clear()
 /// Converts the range to a single range selection
 void TextRangeSet::toSingleRange()
 {
-    selectionRanges_.remove(1,selectionRanges_.size()-1);
+    selectionRanges_.remove(1, selectionRanges_.size() - 1);
 }
 
 
@@ -1142,6 +1188,15 @@ void TextRangeSet::toSingleRange()
 void TextRangeSet::sortRanges()
 {
     std::sort(selectionRanges_.begin(), selectionRanges_.end(), TextRange::lessThan);
+}
+
+/// asserts all range site items are valied
+void TextRangeSet::assertValid() const
+{
+    for (size_t i = 0, cnt = selectionRanges_.size(); i < cnt; i++) {
+        selectionRanges_.at(i).assertValid();
+    }
+
 }
 
 
@@ -1156,10 +1211,10 @@ void TextRangeSet::sortRanges()
 DynamicTextRangeSet::DynamicTextRangeSet(TextDocument* doc, bool stickyMode, bool deleteMode, QObject* parent)
     : QObject(parent)
     , TextRangeSet(doc)
-    , stickyMode_( stickyMode )
-    , deleteMode_( deleteMode )
+    , stickyMode_(stickyMode)
+    , deleteMode_(deleteMode)
 {
-    connect( textDocument(), &TextDocument::textChanged, this, &DynamicTextRangeSet::textChanged );
+    connect(textDocument(), &TextDocument::textChanged, this, &DynamicTextRangeSet::textChanged);
 }
 
 
@@ -1170,10 +1225,10 @@ DynamicTextRangeSet::DynamicTextRangeSet(TextDocument* doc, bool stickyMode, boo
 DynamicTextRangeSet::DynamicTextRangeSet(const TextRangeSet& sel, bool stickyMode, bool deleteMode, QObject* parent)
     : QObject(parent)
     , TextRangeSet(sel)
-    , stickyMode_( stickyMode )
-    , deleteMode_( deleteMode )
+    , stickyMode_(stickyMode)
+    , deleteMode_(deleteMode)
 {
-    connect( textDocument(), &TextDocument::textChanged, this, &DynamicTextRangeSet::textChanged );
+    connect(textDocument(), &TextDocument::textChanged, this, &DynamicTextRangeSet::textChanged);
 }
 
 
@@ -1184,10 +1239,10 @@ DynamicTextRangeSet::DynamicTextRangeSet(const TextRangeSet& sel, bool stickyMod
 DynamicTextRangeSet::DynamicTextRangeSet(const TextRangeSet* sel, bool stickyMode, bool deleteMode, QObject* parent)
     : QObject(parent)
     , TextRangeSet(sel)
-    , stickyMode_( stickyMode )
-    , deleteMode_( deleteMode )
+    , stickyMode_(stickyMode)
+    , deleteMode_(deleteMode)
 {
-    connect( textDocument(), &TextDocument::textChanged, this, &DynamicTextRangeSet::textChanged );
+    connect(textDocument(), &TextDocument::textChanged, this, &DynamicTextRangeSet::textChanged);
 }
 
 
@@ -1231,9 +1286,8 @@ bool DynamicTextRangeSet::deleteMode() const
 void DynamicTextRangeSet::textChanged(edbee::TextBufferChange change, QString oldText)
 {
     Q_UNUSED(oldText)
-    changeSpatial( change.offset(), change.length(), change.newTextLength(), stickyMode_, deleteMode_ );
+    changeSpatial(change.offset(), change.length(), change.newTextLength(), stickyMode_, deleteMode_);
 }
-
 
 
 } // edbee

--- a/edbee-lib/edbee/models/textrange.h
+++ b/edbee-lib/edbee/models/textrange.h
@@ -28,33 +28,32 @@ class TextDocument;
 ///
 class EDBEE_EXPORT TextRange {
 public:
-    TextRange( int anchor=0, int caret=0 ) : anchor_(anchor), caret_(caret) {}
+    TextRange(size_t anchor = 0, size_t caret = 0) : anchor_(anchor), caret_(caret) {}
 
-    inline int anchor() const { return anchor_; }
-    inline int caret() const { return caret_; }
+    inline size_t anchor() const { return anchor_; }
+    inline size_t caret() const { return caret_; }
 
     /// returns the minimal value
-    inline int min() const { return qMin( caret_, anchor_ ); }
-    inline int max() const { return qMax( caret_, anchor_ ); }
+    inline size_t min() const { return qMin(caret_, anchor_); }
+    inline size_t max() const { return qMax(caret_, anchor_); }
 
     /// returns the minimal variable reference
-    inline int& minVar() { return caret_ < anchor_ ? caret_ : anchor_; }
-    inline int& maxVar() { return caret_ < anchor_ ? anchor_: caret_; }
+    inline size_t& minVar() { return caret_ < anchor_ ? caret_ : anchor_; }
+    inline size_t& maxVar() { return caret_ < anchor_ ? anchor_: caret_; }
 
-    inline int length() const { return qAbs(caret_ - anchor_ ); }
+    inline size_t length() const { return (caret_ > anchor_) ? caret_ - anchor_ : anchor_ - caret_; }
 
-    void fixCaretForUnicode(TextDocument* doc, int direction );
+    void fixCaretForUnicode(TextDocument* doc, int direction);
 
+    void setAnchor(size_t anchor) { anchor_ = anchor; }
+    void setAnchorBounded(TextDocument* doc, size_t anchor);
+    void setAnchorBounded(TextDocument* doc, ptrdiff_t anchor);
+    void setCaret(size_t caret) { caret_ = caret; }
+    void setCaretBounded(TextDocument* doc, size_t caret);
+    void setCaretBounded(TextDocument* doc, ptrdiff_t caret);
+    void setLength(size_t newLength);
 
-    void setAnchor( int anchor ) { anchor_ = anchor; }
-    void setAnchorBounded( TextDocument* doc, int anchor );
-    void setCaret( int caret ) { caret_ = caret; }
-    void setCaretBounded( TextDocument* doc, int caret );
-    void setLength( int newLength );
-
-
-    void set( int anchor, int caret ) { anchor_ = anchor; caret_ = caret; }
-
+    void set(size_t anchor, size_t caret) { anchor_ = anchor; caret_ = caret; }
     void reset() { anchor_ = caret_; }
     bool hasSelection() const  { return anchor_ != caret_; }
     bool isEmpty() const { return anchor_==caret_; }
@@ -62,41 +61,41 @@ public:
 
     QString toString() const;
 
-    void moveCaret( TextDocument* doc, int amount );
-    void moveCaretOrDeselect( TextDocument* doc, int amount );
-    int moveWhileChar( TextDocument* doc, int pos, int amount, const QString& chars );
-    int moveUntilChar( TextDocument* doc, int pos, int amount, const QString& chars );
-    void moveCaretWhileChar( TextDocument* doc, int amount, const QString& chars );
-    void moveCaretUntilChar( TextDocument* doc, int amount, const QString& chars );
-    void moveAnchortWhileChar( TextDocument* doc, int amount, const QString& chars );
-    void moveAnchorUntilChar( TextDocument* doc, int amount, const QString& chars );
-    void moveCaretByCharGroup( TextDocument* doc, int amount, const QString& whitespace, const QStringList& characterGroups );
-    void moveCaretToLineBoundary( TextDocument* doc, int amount, const QString& whitespace );
-    void moveCaretToWordBoundaryAtOffset( TextDocument* doc, int offset );
-    void moveCaretToLineBoundaryAtOffset( TextDocument* doc, int offset );
+    void moveCaret(TextDocument* doc, int amount);
+    void moveCaretOrDeselect( TextDocument* doc, int amount);
+    size_t moveWhileChar(TextDocument* doc, size_t pos, int amount, const QString& chars);
+    size_t moveUntilChar(TextDocument* doc, size_t pos, int amount, const QString& chars);
+    void moveCaretWhileChar(TextDocument* doc, int amount, const QString& chars);
+    void moveCaretUntilChar(TextDocument* doc, int amount, const QString& chars);
+    void moveAnchortWhileChar(TextDocument* doc, int amount, const QString& chars);
+    void moveAnchorUntilChar(TextDocument* doc, int amount, const QString& chars);
+    void moveCaretByCharGroup(TextDocument* doc, int amount, const QString& whitespace, const QStringList& characterGroups);
+    void moveCaretToLineBoundary(TextDocument* doc, int amount, const QString& whitespace);
+    void moveCaretToWordBoundaryAtOffset(TextDocument* doc, size_t offset);
+    void moveCaretToLineBoundaryAtOffset(TextDocument* doc, size_t offset);
 
+    void expandToFullLine(TextDocument* doc, int amount);
+    void deselectTrailingNewLine(TextDocument* doc);
+    void expandToWord(TextDocument* doc, const QString& whitespace, const QStringList& characterGroups);
+    void expandToIncludeRange(TextRange& range);
 
-    void expandToFullLine( TextDocument* doc, int amount );
-    void deselectTrailingNewLine( TextDocument* doc );
-    void expandToWord( TextDocument* doc, const QString& whitespace, const QStringList& characterGroups );
-    void expandToIncludeRange( TextRange& range );
+    void forceBounds(TextDocument* doc);
 
-    void forceBounds( TextDocument* doc );
+    bool equals(const TextRange &range);
+    bool touches(TextRange& range);
+    bool contains(size_t pos);
 
-    bool equals(const TextRange &range );
-    bool touches( TextRange& range );
-    bool contains( int pos );
+    void assertValid() const;
 
-    static bool lessThan( TextRange& r1, TextRange& r2 );
+    static bool lessThan(TextRange& r1, TextRange& r2);
 
 private:
-    int anchor_;        ///< The position of the anchor
-    int caret_;         ///< The position of the caret
+    size_t anchor_;        ///< The position of the anchor
+    size_t caret_;         ///< The position of the caret
 };
 
 
 //======================================================================
-
 
 /// This abstract class represents a set of textranges
 /// The ranges are kept ordered and will not contain overlapping regions.
@@ -109,18 +108,13 @@ class EDBEE_EXPORT TextRangeSetBase {
 public:
     TextRangeSetBase(TextDocument* doc);
     virtual ~TextRangeSetBase() {}
-    //    TextRangeSet(const TextRangeSet& sel);
 
-  // pure virtual methods
-//    virtual TextRangeSetBase* clone() const = 0;
-    //    TextRangeSet & operator=( const TextRangeSet& sel );
-
-    virtual int rangeCount() const  = 0;
-    virtual TextRange& range(int idx) = 0;
-    virtual const TextRange& constRange(int idx) const = 0;
-    virtual void addRange( int anchor, int caret ) = 0;
-    virtual void addRange( const TextRange& range ) = 0;
-    virtual void removeRange( int idx ) = 0;
+    virtual size_t rangeCount() const  = 0;
+    virtual TextRange& range(size_t idx) = 0;
+    virtual const TextRange& constRange(size_t idx) const = 0;
+    virtual void addRange(size_t anchor, size_t caret) = 0;
+    virtual void addRange(const TextRange& range) = 0;
+    virtual void removeRange(size_t idx) = 0;
     virtual void clear() = 0;
     virtual void toSingleRange() = 0;
     virtual void sortRanges() = 0;
@@ -128,22 +122,21 @@ public:
     TextRange& lastRange();
     TextRange& firstRange();
 
-    int rangeIndexAtOffset( int offset );
-    bool rangesBetweenOffsets( int offsetBegin, int offsetEnd, int& firstIndex, int& lastIndex );
-    bool rangesBetweenOffsetsExlusiveEnd( int offsetBegin, int offsetEnd, int& firstIndex, int& lastIndex );
-    bool rangesAtLine( int line, int& firstIndex, int& lastIndex );
-    bool rangesAtLineExclusiveEnd( int line, int& firstIndex, int& lastIndex );
+    size_t rangeIndexAtOffset(size_t offset);
+    bool rangesBetweenOffsets(size_t offsetBegin, size_t offsetEnd, size_t& firstIndex, size_t& lastIndex);
+    bool rangesBetweenOffsetsExlusiveEnd(size_t offsetBegin, size_t offsetEnd, size_t& firstIndex, size_t& lastIndex);
+    bool rangesAtLine(size_t line, size_t& firstIndex, size_t& lastIndex);
+    bool rangesAtLineExclusiveEnd(size_t line, size_t& firstIndex, size_t& lastIndex);
     bool hasSelection();
-    bool equals( TextRangeSetBase& sel );
-    void replaceAll( const TextRangeSetBase& base );
-
+    bool equals(TextRangeSetBase& sel);
+    void replaceAll(const TextRangeSetBase& base);
 
     QString getSelectedText();
     QString getSelectedTextExpandedToFullLines();
 
     QString rangesAsString() const;
 
-  // changing
+    // changing
     void beginChanges();
     void endChanges();
     void endChangesWithoutProcessing();
@@ -152,31 +145,29 @@ public:
     void resetAnchors();
     void clearSelection();
 
-    void addTextRanges( const TextRangeSetBase& sel);
-    void substractTextRanges( const TextRangeSetBase& sel );
-    void substractRange( int min, int max );
+    void addTextRanges(const TextRangeSetBase& sel);
+    void substractTextRanges(const TextRangeSetBase& sel);
+    void substractRange(size_t min, size_t max);
 
-
-  // selection
+    // selection
     void expandToFullLines(int amount);
-    void expandToWords( const QString& whitespace, const QStringList& characterGroups);
+    void expandToWords(const QString& whitespace, const QStringList& characterGroups);
     void selectWordAt(int offset , const QString& whitespace, const QStringList& characterGroups);
     void toggleWordSelectionAt( int offset, const QString& whitespace, const QStringList& characterGroups);
 
-  // movement
-    void moveCarets( int amount );
-    void moveCaretsOrDeselect( int amount );
-    void moveCaretsByCharGroup( int amount, const QString& whitespace, const QStringList& charGroups );
-    void moveCaretsToLineBoundary(int direction, const QString& whitespace  );
+    // movement
+    void moveCarets(int amount);
+    void moveCaretsOrDeselect(int amount);
+    void moveCaretsByCharGroup(int amount, const QString& whitespace, const QStringList& charGroups);
+    void moveCaretsToLineBoundary(int direction, const QString& whitespace);
     //    void moveCaretsByLine( int amount );  //< Impossible to do without view when having a flexible font, guess that's why it wasn't implemented
 
+    // changing
+    // void growSelectionAtBegin( int amount );
+    void changeSpatial(size_t pos, size_t length, size_t newLength, bool sticky = false, bool performDelete = false);
 
-  // changing
-    //    void growSelectionAtBegin( int amount );
-    void changeSpatial(int pos, int length, int newLength, bool sticky=false, bool performDelete=false);
-
-    void setRange( int anchor, int caret, int index = 0 );
-    void setRange( const TextRange& range , int index = 0 );
+    void setRange(int anchor, int caret, int index = 0);
+    void setRange(const TextRange& range , int index = 0);
 
     virtual void processChangesIfRequired(bool joinBorders=false);
 
@@ -184,8 +175,7 @@ public:
     TextDocument* textDocument() const;
     //TextBuffer* textBuffer() const { return textBufferRef_; }
 
-
-    void mergeOverlappingRanges( bool joinBorders );
+    void mergeOverlappingRanges(bool joinBorders);
 
 protected:
 
@@ -201,23 +191,25 @@ protected:
 class EDBEE_EXPORT TextRangeSet : public TextRangeSetBase
 {
 public:
-    TextRangeSet( TextDocument* doc );
-    TextRangeSet( const TextRangeSet& sel );
-    TextRangeSet( const TextRangeSet* sel );
+    TextRangeSet(TextDocument* doc);
+    TextRangeSet(const TextRangeSet& sel);
+    TextRangeSet(const TextRangeSet* sel);
     virtual ~TextRangeSet() {}
 
     TextRangeSet& operator=(const TextRangeSet& sel);
     TextRangeSet* clone() const;
 
-    virtual int rangeCount() const { return selectionRanges_.size(); }
-    virtual TextRange& range(int idx);
-    virtual const TextRange& constRange(int idx ) const;
-    virtual void addRange(int anchor, int caret);
-    virtual void addRange( const TextRange& range );
-    virtual void removeRange(int idx);
+    virtual size_t rangeCount() const { return static_cast<size_t>(selectionRanges_.size()); }
+    virtual TextRange& range(size_t idx);
+    virtual const TextRange& constRange(size_t idx) const;
+    virtual void addRange(size_t anchor, size_t caret);
+    virtual void addRange(const TextRange& range);
+    virtual void removeRange(size_t idx);
     virtual void clear();
     virtual void toSingleRange();
     virtual void sortRanges();
+
+    virtual void assertValid() const;
 
 private:
 
@@ -242,19 +234,19 @@ class EDBEE_EXPORT DynamicTextRangeSet : public QObject, public TextRangeSet
 Q_OBJECT
 
 public:
-    DynamicTextRangeSet( TextDocument* doc, bool stickyMode=false, bool deleteMode=false, QObject* parent=0 );
-    DynamicTextRangeSet( const TextRangeSet& sel, bool stickyMode=false, bool deleteMode=false, QObject* parent=0 );
-    DynamicTextRangeSet( const TextRangeSet* sel, bool stickyMode=false, bool deleteMode=false, QObject* parent=0 );
+    DynamicTextRangeSet(TextDocument* doc, bool stickyMode=false, bool deleteMode=false, QObject* parent=nullptr);
+    DynamicTextRangeSet(const TextRangeSet& sel, bool stickyMode=false, bool deleteMode=false, QObject* parent=nullptr);
+    DynamicTextRangeSet(const TextRangeSet* sel, bool stickyMode=false, bool deleteMode=false, QObject* parent=nullptr);
     virtual ~DynamicTextRangeSet();
 
-    void setStickyMode( bool mode );
+    void setStickyMode(bool mode);
     bool stickyMode() const;
 
-    void setDeleteMode( bool mode );
+    void setDeleteMode(bool mode);
     bool deleteMode() const;
 
 public slots:
-    void textChanged( edbee::TextBufferChange change, QString oldText = QString() );
+    void textChanged(edbee::TextBufferChange change, QString oldText = QString());
 
 private:
     bool stickyMode_;                       ///< Sticky mode means if this rangeset is the current selection (This requires a different approach)

--- a/edbee-lib/edbee/models/textrange.h
+++ b/edbee-lib/edbee/models/textrange.h
@@ -43,7 +43,7 @@ public:
 
     inline size_t length() const { return (caret_ > anchor_) ? caret_ - anchor_ : anchor_ - caret_; }
 
-    void fixCaretForUnicode(TextDocument* doc, int direction);
+    void fixCaretForUnicode(TextDocument* doc, ptrdiff_t direction);
 
     void setAnchor(size_t anchor) { anchor_ = anchor; }
     void setAnchorBounded(TextDocument* doc, size_t anchor);
@@ -61,20 +61,20 @@ public:
 
     QString toString() const;
 
-    void moveCaret(TextDocument* doc, int amount);
-    void moveCaretOrDeselect( TextDocument* doc, int amount);
-    size_t moveWhileChar(TextDocument* doc, size_t pos, int amount, const QString& chars);
-    size_t moveUntilChar(TextDocument* doc, size_t pos, int amount, const QString& chars);
-    void moveCaretWhileChar(TextDocument* doc, int amount, const QString& chars);
-    void moveCaretUntilChar(TextDocument* doc, int amount, const QString& chars);
-    void moveAnchortWhileChar(TextDocument* doc, int amount, const QString& chars);
-    void moveAnchorUntilChar(TextDocument* doc, int amount, const QString& chars);
-    void moveCaretByCharGroup(TextDocument* doc, int amount, const QString& whitespace, const QStringList& characterGroups);
-    void moveCaretToLineBoundary(TextDocument* doc, int amount, const QString& whitespace);
+    void moveCaret(TextDocument* doc, ptrdiff_t amount);
+    void moveCaretOrDeselect( TextDocument* doc, ptrdiff_t amount);
+    size_t moveWhileChar(TextDocument* doc, size_t pos, ptrdiff_t amount, const QString& chars);
+    size_t moveUntilChar(TextDocument* doc, size_t pos, ptrdiff_t amount, const QString& chars);
+    void moveCaretWhileChar(TextDocument* doc, ptrdiff_t amount, const QString& chars);
+    void moveCaretUntilChar(TextDocument* doc, ptrdiff_t amount, const QString& chars);
+    void moveAnchortWhileChar(TextDocument* doc, ptrdiff_t amount, const QString& chars);
+    void moveAnchorUntilChar(TextDocument* doc, ptrdiff_t amount, const QString& chars);
+    void moveCaretByCharGroup(TextDocument* doc, ptrdiff_t amount, const QString& whitespace, const QStringList& characterGroups);
+    void moveCaretToLineBoundary(TextDocument* doc, ptrdiff_t amount, const QString& whitespace);
     void moveCaretToWordBoundaryAtOffset(TextDocument* doc, size_t offset);
     void moveCaretToLineBoundaryAtOffset(TextDocument* doc, size_t offset);
 
-    void expandToFullLine(TextDocument* doc, int amount);
+    void expandToFullLine(TextDocument* doc, ptrdiff_t amount);
     void deselectTrailingNewLine(TextDocument* doc);
     void expandToWord(TextDocument* doc, const QString& whitespace, const QStringList& characterGroups);
     void expandToIncludeRange(TextRange& range);
@@ -150,16 +150,16 @@ public:
     void substractRange(size_t min, size_t max);
 
     // selection
-    void expandToFullLines(int amount);
+    void expandToFullLines(ptrdiff_t amount);
     void expandToWords(const QString& whitespace, const QStringList& characterGroups);
     void selectWordAt(size_t offset , const QString& whitespace, const QStringList& characterGroups);
     void toggleWordSelectionAt(size_t offset, const QString& whitespace, const QStringList& characterGroups);
 
     // movement
-    void moveCarets(int amount);
-    void moveCaretsOrDeselect(int amount);
-    void moveCaretsByCharGroup(int amount, const QString& whitespace, const QStringList& charGroups);
-    void moveCaretsToLineBoundary(int direction, const QString& whitespace);
+    void moveCarets(ptrdiff_t amount);
+    void moveCaretsOrDeselect(ptrdiff_t amount);
+    void moveCaretsByCharGroup(ptrdiff_t amount, const QString& whitespace, const QStringList& charGroups);
+    void moveCaretsToLineBoundary(ptrdiff_t direction, const QString& whitespace);
     //    void moveCaretsByLine( int amount );  //< Impossible to do without view when having a flexible font, guess that's why it wasn't implemented
 
     // changing
@@ -171,7 +171,7 @@ public:
 
     virtual void processChangesIfRequired(bool joinBorders=false);
 
-  // getters
+      // getters
     TextDocument* textDocument() const;
     //TextBuffer* textBuffer() const { return textBufferRef_; }
 

--- a/edbee-lib/edbee/models/textrange.h
+++ b/edbee-lib/edbee/models/textrange.h
@@ -152,8 +152,8 @@ public:
     // selection
     void expandToFullLines(int amount);
     void expandToWords(const QString& whitespace, const QStringList& characterGroups);
-    void selectWordAt(int offset , const QString& whitespace, const QStringList& characterGroups);
-    void toggleWordSelectionAt( int offset, const QString& whitespace, const QStringList& characterGroups);
+    void selectWordAt(size_t offset , const QString& whitespace, const QStringList& characterGroups);
+    void toggleWordSelectionAt(size_t offset, const QString& whitespace, const QStringList& characterGroups);
 
     // movement
     void moveCarets(int amount);
@@ -166,8 +166,8 @@ public:
     // void growSelectionAtBegin( int amount );
     void changeSpatial(size_t pos, size_t length, size_t newLength, bool sticky = false, bool performDelete = false);
 
-    void setRange(int anchor, int caret, int index = 0);
-    void setRange(const TextRange& range , int index = 0);
+    void setRange(size_t anchor, size_t caret, size_t index = 0);
+    void setRange(const TextRange& range, size_t index = 0);
 
     virtual void processChangesIfRequired(bool joinBorders=false);
 

--- a/edbee-lib/edbee/models/textundostack.cpp
+++ b/edbee-lib/edbee/models/textundostack.cpp
@@ -458,8 +458,8 @@ bool TextUndoStack::isPersisted()
     if (persistedIndex_ < 0 ){ return false;}
 
     // check if all changes are non-persistable
-    qsizetype startIdx = qMax(0, qMin(curIdx, persistedIndex_));
-    qsizetype endIdx   = qMin(qMax(curIdx, persistedIndex_), changeList_.size());
+    qsizetype startIdx = qMax(static_cast<qsizetype>(0), qMin(curIdx, persistedIndex_));
+    qsizetype endIdx   = qMin(qMax(curIdx, persistedIndex_), static_cast<qsizetype>(changeList_.size()));
 
     for (qsizetype idx = startIdx; idx < endIdx; ++idx) {
         Change* change = changeList_.at(idx);

--- a/edbee-lib/edbee/models/textundostack.cpp
+++ b/edbee-lib/edbee/models/textundostack.cpp
@@ -15,7 +15,7 @@ namespace edbee {
 
 
 /// Constructs the main undostack
-TextUndoStack::TextUndoStack( TextDocument* doc, QObject *parent)
+TextUndoStack::TextUndoStack(TextDocument* doc, QObject *parent)
     : QObject(parent)
     , documentRef_(doc)
     , changeList_()
@@ -46,7 +46,7 @@ void TextUndoStack::clearHistoryLists()
 {
     qDeleteAll(changeList_);
     changeList_.clear();
-    qDeleteAll( undoGroupStack_ );
+    qDeleteAll(undoGroupStack_);
     undoGroupStack_.clear();
     lastCoalesceIdStack_.clear();
 }
@@ -61,10 +61,10 @@ void TextUndoStack::clear()
     // point all the indices to BLANK
     changeIndex_ = 0;
     setPersistedIndex(-1); // clearing the undo-stack must result in a non-saved state
-    QMapIterator<TextEditorController*, int> itr(controllerIndexMap_);
+    QMapIterator<TextEditorController*, qsizetype> itr(controllerIndexMap_);
     while (itr.hasNext()) {
         itr.next();
-        controllerIndexMap_.insert( itr.key(), 0 );
+        controllerIndexMap_.insert(itr.key(), 0);
     }
 }
 
@@ -72,7 +72,7 @@ void TextUndoStack::clear()
 /// Registers acontroller for it's own view pointer
 void TextUndoStack::registerContoller(TextEditorController* controller)
 {
-    controllerIndexMap_.insert(controller,changeIndex_);
+    controllerIndexMap_.insert(controller, changeIndex_);
 }
 
 
@@ -84,19 +84,19 @@ void TextUndoStack::unregisterController(TextEditorController* controller)
 
 
 /// Checks if the given controller is registered
-bool TextUndoStack::isControllerRegistered(TextEditorController *controller)
+bool TextUndoStack::isControllerRegistered(TextEditorController* controller)
 {
     return controllerIndexMap_.contains(controller);
 }
 
 
 /// Starts an undo group (or increase nest-level-counter)
-void TextUndoStack::beginUndoGroup( ChangeGroup* group )
+void TextUndoStack::beginUndoGroup(ChangeGroup* group)
 {
 //    if( !group ) { group = new TextChangeGroup(controller); }
-    undoGroupStack_.append( group );
+    undoGroupStack_.append(group);
     lastCoalesceIdStack_.append(0);
-    emit undoGroupStarted( group );
+    emit undoGroupStarted(group);
 }
 
 
@@ -104,7 +104,7 @@ void TextUndoStack::beginUndoGroup( ChangeGroup* group )
 /// @return the current undo stack item or 0
 ChangeGroup* TextUndoStack::currentGroup()
 {
-    if( undoGroupStack_.isEmpty() ) { return 0; }
+    if (undoGroupStack_.isEmpty()) { return nullptr; }
     return undoGroupStack_.last();
 }
 
@@ -112,37 +112,41 @@ ChangeGroup* TextUndoStack::currentGroup()
 /// Ends the undogroup
 /// @param coalesceId the coalesceId to use
 /// @param flatten should the textchange groups be flattened
-void TextUndoStack::endUndoGroup(int coalesceId, bool flatten )
+void TextUndoStack::endUndoGroup(int coalesceId, bool flatten)
 {
     Q_ASSERT(!undoGroupStack_.isEmpty());
-    if( undoGroupStack_.isEmpty() ) return;
+
+    if ( undoGroupStack_.isEmpty()) return;
     ChangeGroup* group = undoGroupStack_.pop();
     lastCoalesceIdStack_.pop();
 
-    if( group ) {
+    if (group) {
         group->groupClosed();   // close the group
 
         // flatten the group?
-        if( flatten ) {
+        if (flatten) {
             group->flatten();
         }
+
         // multiple-changes or not discardable
-        if( !group->isDiscardable() || group->size() > 1 ) {
-            Change* newChange = giveChange( group , coalesceId );
+        if (!group->isDiscardable() || group->size() > 1) {
+            Change* newChange = giveChange(group , coalesceId);
             bool merged = newChange && newChange != group;
-            emit undoGroupEnded( coalesceId, merged, ActionEnd );
+            emit undoGroupEnded(coalesceId, merged, ActionEnd);
 
         // a single change (don't give the group, just the single change)
-        } else if( group->size() == 1 ) {
+        } else if (group->size() == 1) {
             Change* change = group->takeLast();
-            Change* newChange = giveChange( change, coalesceId );
+            Change* newChange = giveChange(change, coalesceId);
             bool merged = newChange && newChange != change;
             delete group;
-            emit undoGroupEnded( coalesceId, merged, ActionUngrouped );
+
+            emit undoGroupEnded(coalesceId, merged, ActionUngrouped);
         // empty group, can be optimized away
         } else {
             delete group;
-            emit undoGroupEnded( coalesceId, false, ActionFullDiscard );
+
+            emit undoGroupEnded(coalesceId, false, ActionFullDiscard);
         }
     }
 }
@@ -152,44 +156,45 @@ void TextUndoStack::endUndoGroup(int coalesceId, bool flatten )
 void TextUndoStack::endUndoGroupAndDiscard()
 {
     Q_ASSERT(!undoGroupStack_.isEmpty());
-    if( undoGroupStack_.isEmpty() ) return;
+
+    if (undoGroupStack_.isEmpty()) return;
     ChangeGroup* group = undoGroupStack_.pop();
     lastCoalesceIdStack_.pop();
 
-    if( group ) {
+    if (group) {
         group->groupClosed();   // close the group
         delete group;
-        emit undoGroupEnded( 0, false, ActionFullDiscard );
+        emit undoGroupEnded(0, false, ActionFullDiscard);
     }
 }
 
 
 /// returns the number of stacked undo-groups
-int TextUndoStack::undoGroupLevel()
+size_t TextUndoStack::undoGroupLevel()
 {
-    return undoGroupStack_.size();
+    return static_cast<size_t>(undoGroupStack_.size());
 }
 
 
 /// returns the last coalesceId at the given level
 int TextUndoStack::lastCoalesceIdAtCurrentLevel()
 {
-    return lastCoalesceIdStack_[ lastCoalesceIdStack_.size()-1 ];
+    return lastCoalesceIdStack_[lastCoalesceIdStack_.size() - 1];
 }
 
 
 /// Sets the last coalesceId at the current level
 void TextUndoStack::setLastCoalesceIdAtCurrentLevel(int id)
 {
-    lastCoalesceIdStack_[ lastCoalesceIdStack_.size()-1 ] = id;
+    lastCoalesceIdStack_[lastCoalesceIdStack_.size() - 1] = id;
 }
 
 
 /// Resets all coalsceIds
 void TextUndoStack::resetAllLastCoalesceIds()
 {
-    for( int i=0, cnt=lastCoalesceIdStack_.size(); i<cnt; ++i ) {
-        lastCoalesceIdStack_[i]=0;
+    for (qsizetype i = 0, cnt = lastCoalesceIdStack_.size(); i < cnt; ++i) {
+        lastCoalesceIdStack_[i] = 0;
     }
 }
 
@@ -204,35 +209,35 @@ void TextUndoStack::resetAllLastCoalesceIds()
 ///        The return value is 0, if the change was discared
 ///        The return value == change if the change was appended to the stack
 ///        The return value != change if the change was merged  (previous stack item is returned)
-Change* TextUndoStack::giveChange(Change* change, int coalesceId )
+Change* TextUndoStack::giveChange(Change* change, int coalesceId)
 {
     // when undo-collection is disabled. don't record the change
-    if( !collectionEnabled_ ) {
+    if (!collectionEnabled_) {
         delete change;
-        return 0;
+        return nullptr;
     }
 
-    ChangeGroup* group = undoGroupStack_.isEmpty() ? 0 : undoGroupStack_.top();
+    ChangeGroup* group = undoGroupStack_.isEmpty() ? nullptr : undoGroupStack_.top();
 
     int lastCoalesceId = lastCoalesceIdAtCurrentLevel();
     bool merge = lastCoalesceId && lastCoalesceIdStack_.top() == coalesceId && coalesceId != CoalesceId_None;
 
     setLastCoalesceIdAtCurrentLevel(coalesceId);
-    if( coalesceId == CoalesceId_ForceMerge ) { merge = true; }
+    if (coalesceId == CoalesceId_ForceMerge) { merge = true; }
 
     // still an undogroup active ?
     //----------------------------
-    if( group ) {
+    if (group) {
         //TextEditorController* controller = change->controllerContext();
         // try to merge the operation
-        if( merge ) {
+        if (merge) {
             Change* lastChange = group->last();
-            if( lastChange && lastChange->giveAndMerge( documentRef_, change ) ) {
+            if(lastChange && lastChange->giveAndMerge(documentRef_, change)) {
                 return lastChange;
             }
         }
 
-        group->giveChange( document(), change);
+        group->giveChange(document(), change);
         // TODO: giveChange to a group can also merge a change. This can have implications
         //   on the change. At the moment I simply return the group. I doubt this is correct
         //   for the moment it's the best solution for this problem
@@ -243,12 +248,12 @@ Change* TextUndoStack::giveChange(Change* change, int coalesceId )
     } else {
         // get the optional controller context
         TextEditorController* controller = change->controllerContext();
-        clearRedo( controller );
+        clearRedo(controller);
 
         // try to merge the operation
-        if( merge ) {
-            Change* lastChange = this->findUndoChange(controller);
-            if( lastChange && lastChange->giveAndMerge( documentRef_, change ) ) {
+        if (merge) {
+            Change* lastChange = findUndoChange(controller);
+            if (lastChange && lastChange->giveAndMerge( documentRef_, change)) {
                 //emit changeMerged( lastChange, change );
                 dumpStackInternal();
                 return lastChange;
@@ -260,18 +265,18 @@ Change* TextUndoStack::giveChange(Change* change, int coalesceId )
 
         // increase the pointers
         // controller-only change, only update the controller pointer
-        if( controller ) {
+        if (controller) {
             controllerIndexMap_[controller] = changeList_.size();
 
         // model-change update the model-pointer and ALL controller pointers
         } else {
-            setChangeIndex( changeList_.size() );
-            QMap<TextEditorController*, int>::iterator i;
+            setChangeIndex(changeList_.size());
+            QMap<TextEditorController*, qsizetype>::iterator i;
             for (i = controllerIndexMap_.begin(); i != controllerIndexMap_.end(); ++i) {
                 i.value() = changeIndex_;
             }
         }
-        emit changeAdded( change );
+        emit changeAdded(change);
 
     }
     dumpStackInternal();
@@ -279,7 +284,7 @@ Change* TextUndoStack::giveChange(Change* change, int coalesceId )
 }
 
 
-/// Should check if a undo operation can be performed.
+/// Checks if a undo operation can be performed.
 /// When no controller is given a document-undo is checkd
 /// else a view specific soft undo is tested
 bool TextUndoStack::canUndo(TextEditorController* controller)
@@ -288,7 +293,7 @@ bool TextUndoStack::canUndo(TextEditorController* controller)
 }
 
 
-/// Should check if a redo operation can be performed.
+/// Checks if a redo operation can be performed.
 /// When no controller is given a document-redo is checkd
 /// else a view specific soft redo is tested
 bool TextUndoStack::canRedo(TextEditorController* controller)
@@ -297,23 +302,23 @@ bool TextUndoStack::canRedo(TextEditorController* controller)
 }
 
 
-/// performs an undo operation
+/// Performs an undo operation
 /// @param controller this method is called
-void TextUndoStack::undo(TextEditorController* controller, bool controllerOnly )
+void TextUndoStack::undo(TextEditorController* controller, bool controllerOnly)
 {
     Q_ASSERT(!undoRunning_);
     undoRunning_ = true;
     resetAllLastCoalesceIds();
 
-    Change* changeToUndo = this->findUndoChange( controller );
+    Change* changeToUndo = this->findUndoChange(controller);
     // only for the current controller
-    if( changeToUndo && changeToUndo->controllerContext() ) {
-        Q_ASSERT(changeToUndo->controllerContext() == controller );
-        undoControllerChange( controller );
+    if (changeToUndo && changeToUndo->controllerContext()) {
+        Q_ASSERT(changeToUndo->controllerContext() == controller);
+        undoControllerChange(controller);
 
     // else we need to undo ALL other controller changes
-    } else if( !controllerOnly ) {
-        undoDocumentChange( );
+    } else if(!controllerOnly) {
+        undoDocumentChange();
     }
     dumpStackInternal();
 
@@ -321,21 +326,21 @@ void TextUndoStack::undo(TextEditorController* controller, bool controllerOnly )
 }
 
 
-/// performs the redo operation for the given controller
+/// Performs the redo operation for the given controller
 /// @param controller the controller to execute the redo for
 /// @param controllerOnly undo controller undo's only?
-void TextUndoStack::redo(TextEditorController* controller, bool controllerOnly )
+void TextUndoStack::redo(TextEditorController* controller, bool controllerOnly)
 {
     Q_ASSERT(!redoRunning_);
     redoRunning_ = true;
     resetAllLastCoalesceIds();
 
-    Change* changeToRedo = findRedoChange( controller );
-    if( changeToRedo && changeToRedo->controllerContext() ) {
-        Q_ASSERT(changeToRedo->controllerContext() == controller );
-        redoControllerChange( controller );
+    Change* changeToRedo = findRedoChange(controller);
+    if (changeToRedo && changeToRedo->controllerContext()) {
+        Q_ASSERT(changeToRedo->controllerContext() == controller);
+        redoControllerChange(controller);
 
-    } else if( !controllerOnly ){
+    } else if (!controllerOnly){
         redoDocumentChange();
 
     }
@@ -344,54 +349,53 @@ void TextUndoStack::redo(TextEditorController* controller, bool controllerOnly )
 }
 
 
-/// returns the number of changes on the stack
-int TextUndoStack::size()
+/// Returns the number of changes on the stack
+qsizetype TextUndoStack::size()
 {
     return changeList_.size();
 }
 
 
-/// returns the change at the given index
-Change* TextUndoStack::at(int idx)
+/// Returns the change at the given index
+Change* TextUndoStack::at(qsizetype idx)
 {
     return changeList_.at(idx);
 }
 
 
-/// This method return the index that's active for the given controller
+/// Returns the index that's active for the given controller
 /// The currentIndex points directly AFTER the last placed item on the stack
-int TextUndoStack::currentIndex(TextEditorController* controller)
+qsizetype TextUndoStack::currentIndex(TextEditorController* controller)
 {
-    if( controller ) {
-        Q_ASSERT( controllerIndexMap_.contains(controller) );
+    if (controller) {
+        Q_ASSERT(controllerIndexMap_.contains(controller));
         return controllerIndexMap_.value(controller);
     } else {
         return changeIndex_;
     }
-
 }
 
 
-/// This method returns the current redo change. This maybe the change for the given context or the document change
+/// Returns the current redo change. This maybe the change for the given context or the document change
 /// depending on what comes first
 /// @param controller the controller this change is for
 /// @return the new text change (0 if there aren't any redo items availabe for the given context). When a controller is given the document change is ALSO returned
 Change* TextUndoStack::findRedoChange(TextEditorController* controller)
 {
-    int redoIndex = findRedoIndex( currentIndex(controller), controller );
-    if( redoIndex < changeList_.size() ) {
-        return at( redoIndex );
+    qsizetype redoIndex = findRedoIndex(currentIndex(controller), controller);
+    if (redoIndex < changeList_.size()) {
+        return at(redoIndex);
     }
-    return 0;
+    return nullptr;
 }
 
 
-/// This method returns the last index for a given controller
+/// Returns the last index for a given controller
 /// The lastIndex points to the index on the stack
 /// @return the index on the stack or -1 if the item isn't on the undo-stack
-int TextUndoStack::lastIndex(TextEditorController *controller)
+qsizetype TextUndoStack::lastIndex(TextEditorController* controller)
 {
-    return currentIndex( controller ) - 1;
+    return currentIndex(controller) - 1;
 }
 
 
@@ -400,29 +404,29 @@ int TextUndoStack::lastIndex(TextEditorController *controller)
 /// @return the last change (with optional the controller context) 0 if no last change
 Change* TextUndoStack::last(TextEditorController* controller)
 {
-    int idx = lastIndex(controller);
-    if( idx < 0 ) { return  0; }
+    qsizetype idx = lastIndex(controller);
+    if (idx < 0) { return  nullptr; }
     return at(idx);
 }
 
 
 /// The number of doc-'undo' items on the stack
-int TextUndoStack::sizeInDocChanges()
+qsizetype TextUndoStack::sizeInDocChanges()
 {
-    int count = 0;
-    foreach( Change* change, changeList_ ) {
-        if( change->isDocumentChange() ) { ++count;}
+    qsizetype count = 0;
+    foreach (Change* change, changeList_) {
+        if (change->isDocumentChange()) { ++count;}
     }
     return count;
 }
 
 
 /// This method returns the current doc change index
-int TextUndoStack::currentIndexInDocChanges()
+qsizetype TextUndoStack::currentIndexInDocChanges()
 {
-    int index = 0;
-    for( int i=0; i < changeIndex_; ++i ) {
-        if( changeList_.at(i)->isDocumentChange() ) { ++index; }
+    qsizetype index = 0;
+    for (int i = 0; i < changeIndex_; ++i) {
+        if(changeList_.at(i)->isDocumentChange()) { ++index; }
     }
     return index;
 }
@@ -431,38 +435,38 @@ int TextUndoStack::currentIndexInDocChanges()
 /// This method returns the last change (TOS) for the given controller
 Change* TextUndoStack::findUndoChange(TextEditorController* controller)
 {
-    int undoIndex = this->findUndoIndex( currentIndex(controller), controller );
-    if( undoIndex >= 0 ) {
+    qsizetype undoIndex = findUndoIndex(currentIndex(controller), controller);
+    if (undoIndex >= 0) {
         return changeList_.at(undoIndex);
     }
-    return 0;
+    return nullptr;
 }
 
 
 /// Marks the current documentIndex as persisted
 void TextUndoStack::setPersisted(bool enabled)
 {
-    setPersistedIndex( enabled ? currentIndex() : -1);
+    setPersistedIndex(enabled ? currentIndex() : -1);
 }
 
 
 /// returns true if the undo-stack is on a persisted index
 bool TextUndoStack::isPersisted()
 {
-    int curIdx = currentIndex();
-    if( persistedIndex_ == curIdx ) { return true; }
-    if( persistedIndex_ < 0 ) { return false;}
+    qsizetype curIdx = currentIndex();
+    if (persistedIndex_ == curIdx) { return true; }
+    if (persistedIndex_ < 0 ){ return false;}
 
     // check if all changes are non-persistable
-    int startIdx = qMax( 0, qMin( curIdx, persistedIndex_ ));
-    int endIdx   = qMin( qMax( curIdx, persistedIndex_ ), changeList_.size());
+    qsizetype startIdx = qMax(0, qMin(curIdx, persistedIndex_));
+    qsizetype endIdx   = qMin(qMax(curIdx, persistedIndex_), changeList_.size());
 
-    for( int idx=startIdx; idx<endIdx; ++idx ) {
+    for (qsizetype idx = startIdx; idx < endIdx; ++idx) {
         Change* change = changeList_.at(idx);
 
         // only check document changes
-        if( change->isDocumentChange() ) {
-            if( change->isPersistenceRequired() ) {
+        if (change->isDocumentChange()) {
+            if (change->isPersistenceRequired()) {
                 return false;
             }
         }
@@ -472,7 +476,7 @@ bool TextUndoStack::isPersisted()
 
 
 /// This method returns the current persisted index
-int TextUndoStack::persistedIndex()
+qsizetype TextUndoStack::persistedIndex()
 {
     return persistedIndex_;
 }
@@ -483,43 +487,42 @@ QString TextUndoStack::dumpStack()
 {
     QString result;
     result += "\n";
-    result +="UndoStack\n";
+    result += "UndoStack\n";
     result += "=====================\n";
 
-    bool end=true;
-    for( int i=changeList_.size(); i >=0 ; --i ) {
-        QString str;
+    bool end = true;
+    for (qsizetype i = changeList_.size(); i >=0 ; --i) {
         QString changeName;
         QString controllerName;
         QString pointers;
 
         /// build the stack overview
-        if( end ) {
+        if (end) {
             changeName= "^^^^^^^^^^^^^^^^^";
         } else {
             Change* change= at(i);
             TextEditorController* controller = change->controllerContext();
             changeName = change->toString();
-            if( controller ) {
-                controllerName = QString::number((quintptr)controller,16);
+            if (controller) {
+                controllerName = QString::number((quintptr)controller, 16);
             }
         }
 
         // next append the pointers
-        QMap<TextEditorController*, int>::iterator itr;
-        for( itr = controllerIndexMap_.begin(); itr != controllerIndexMap_.end(); ++itr ) {
-            if( itr.value() == i ) {
-                pointers.append( QStringLiteral("<=(%1) ").arg( QString::number((quintptr)itr.key(),16) ) );
+        QMap<TextEditorController*, qsizetype>::iterator itr;
+        for (itr = controllerIndexMap_.begin(); itr != controllerIndexMap_.end(); ++itr) {
+            if (itr.value() == i) {
+                pointers.append(QStringLiteral("<=(%1) ").arg(QString::number((quintptr)itr.key(), 16)));
             }
         }
-        if( changeIndex_ == i ) {
-            pointers.append( QStringLiteral("<=(DOC) " ));
+        if (changeIndex_ == i) {
+            pointers.append(QStringLiteral("<=(DOC) "));
         }
-        if( persistedIndex_ == i ){
-            pointers.append( QStringLiteral("<=(P) " ));
+        if (persistedIndex_ == i) {
+            pointers.append( QStringLiteral("<=(P) "));
         }
 
-        result += QStringLiteral("-|%1:%2| %3\n").arg(changeName,-30).arg(controllerName,10).arg(pointers);
+        result += QStringLiteral("-|%1:%2| %3\n").arg(changeName, -30).arg(controllerName, 10).arg(pointers);
         end=false;
     }
     return result;
@@ -535,35 +538,35 @@ void TextUndoStack::dumpStackInternal()
 }
 
 
-/// This method finds the next redo-item
+/// Finds the next redo-item
 /// @param index the index to search it from
 /// @param controller the controller context
 /// @return the next change index. Or changeList_.size() if there's no next change
-int TextUndoStack::findRedoIndex(int index, TextEditorController* controller)
+qsizetype TextUndoStack::findRedoIndex(qsizetype index, TextEditorController* controller)
 {
-    if( index < changeList_.size() ) {
-        int size = changeList_.size();
-        for( ; index < size; ++index ) {
+    if (index < changeList_.size()) {
+        qsizetype size = changeList_.size();
+        for (; index < size; ++index) {
             Change* change = at(index);
             TextEditorController* context = change->controllerContext();
-            if( context == 0 || context == controller ) { return index; }
+            if (context == nullptr || context == controller) { return index; }
         }
     }
     return changeList_.size();
 }
 
 
-/// This method finds the index of the given stackitem from the given index
+/// Finds the index of the given stackitem from the given index
 /// @param  index the previous index
 /// @param controller the controller context
 /// @return the previous index -1, if there's no previous index
-int TextUndoStack::findUndoIndex( int index, TextEditorController* controller)
+qsizetype TextUndoStack::findUndoIndex(qsizetype index, TextEditorController* controller)
 {
-    if( index > 0 ) {
-        for( --index; index >= 0; --index ) {
+    if (index > 0) {
+        for (--index; index >= 0; --index) {
             Change* change = at(index);
             TextEditorController* context = change->controllerContext();
-            if( context == 0 || context == controller ) { return index; }
+            if (context == nullptr || context == controller) { return index; }
         }
     }
     return -1;
@@ -574,54 +577,50 @@ int TextUndoStack::findUndoIndex( int index, TextEditorController* controller)
 void TextUndoStack::clearRedo(TextEditorController* controller)
 {
     // view specific undo
-    if( controller ) {
-        int idx = changeIndex_;
-        if( controllerIndexMap_.contains(controller) ) {
+    if (controller) {
+        qsizetype idx = changeIndex_;
+        if (controllerIndexMap_.contains(controller)) {
             idx = this->controllerIndexMap_.value(controller);
         } else {
-            Q_ASSERT(false && "The current controller isn't registered with the undostack!");    // warning view isn't registered!
+            Q_ASSERT(false && "The current controller isn't registered with the undostack!");
         }
 
         // remove all items from the stack AFTER the given index
-        for( int i=changeList_.size()-1; i >= idx; --i ) {
-            if( changeList_.at(i)->controllerContext() == controller ) {
+        for (qsizetype i = changeList_.size() - 1; i >= idx; --i) {
+            if (changeList_.at(i)->controllerContext() == controller) {
                 delete changeList_.takeAt(i);
             }
         }
 
     } else {
-        if( currentIndex(0) < persistedIndex() ) {
+        if (currentIndex() < persistedIndex()) {
             setPersistedIndex(-1);
         }
 
         // find the next redo-document operation
-        int redoIndex = findRedoIndex( currentIndex(0), 0);
-        for( int i=changeList_.size()-1; i >= redoIndex; --i ) {
+        qsizetype redoIndex = findRedoIndex(currentIndex());
+        for (qsizetype i = changeList_.size()-1; i >= redoIndex; --i) {
             delete changeList_.takeAt(i);
         }
-
-        // remove all items from the stack AFTER the given index
-//        for( int i=changeList_.size()-1; i >= changeIndex_; --i ) {
-//            delete changeList_.takeAt(i);
-//        }
     }
 }
 
 
-/// This method undos the given controller change. This method does NOT undo document changes
+/// Undos the given controller change. This method does NOT undo document changes
 /// @param controller the controller to undo the change form
 /// @return true if a change has been undone.
 bool TextUndoStack::undoControllerChange(TextEditorController* controller)
 {
     Q_ASSERT(controller);
-    int changeIdx = controllerIndexMap_.value(controller)-1;    // -1, because the index is directly AFTER the item
-    Change* changeToUndo = findUndoChange( controller );
 
-    if( changeToUndo && changeToUndo->controllerContext() ) {
-        Q_ASSERT( changeToUndo->controllerContext() == controller );
-        changeToUndo->revert( documentRef_ );
-        controllerIndexMap_[controller] = findUndoIndex( changeIdx, controller )+1;
-        emit undoExecuted( changeToUndo );
+    qsizetype changeIdx = controllerIndexMap_.value(controller) - 1; // -1, because the index is directly AFTER the item
+    Change* changeToUndo = findUndoChange(controller);
+
+    if (changeToUndo && changeToUndo->controllerContext()) {
+        Q_ASSERT(changeToUndo->controllerContext() == controller);
+        changeToUndo->revert(documentRef_);
+        controllerIndexMap_[controller] = findUndoIndex(changeIdx, controller) + 1;
+        emit undoExecuted(changeToUndo);
         return true;
     }
     return false;
@@ -632,29 +631,28 @@ bool TextUndoStack::undoControllerChange(TextEditorController* controller)
 void TextUndoStack::undoDocumentChange()
 {
     // first make sure ALL controller-changes are back to the document change-level
-    QMap<TextEditorController*, int>::iterator itr;
-    for( itr = controllerIndexMap_.begin(); itr != controllerIndexMap_.end(); ++itr) {
+    QMap<TextEditorController*, qsizetype>::iterator itr;
+    for (itr = controllerIndexMap_.begin(); itr != controllerIndexMap_.end(); ++itr) {
         TextEditorController* controller = itr.key();
-        while( undoControllerChange(controller) ) {};  // undo all controller operations
+        while (undoControllerChange(controller)) {};  // undo all controller operations
     }
 
     // next perform an undo of the document operations
     Change* change = findUndoChange();
-    if( change ) {
-        Q_ASSERT( change->controllerContext() == 0 );
-        change->revert( documentRef_ );
+    if (change) {
+        Q_ASSERT(change->controllerContext() == 0);
+        change->revert(documentRef_);
 
         // next move the pointers to first 'related' change
-        for( itr = controllerIndexMap_.begin(); itr != controllerIndexMap_.end(); ++itr) {
+        for (itr = controllerIndexMap_.begin(); itr != controllerIndexMap_.end(); ++itr) {
             TextEditorController* controller = itr.key();
-            controllerIndexMap_[controller] = findUndoIndex( changeIndex_-1, controller ) + 1; // +1 because the pointer points AFTER the found index
+            controllerIndexMap_[controller] = findUndoIndex(changeIndex_ - 1, controller) + 1; // +1 because the pointer points AFTER the found index
         }
 
         // and finally move the document pointer
-        setChangeIndex( findUndoIndex( changeIndex_-1 ) + 1 );  // +1 because the pointer points AFTER the found index
-        emit undoExecuted( change);
+        setChangeIndex(findUndoIndex(changeIndex_ - 1) + 1);  // +1 because the pointer points AFTER the found index
+        emit undoExecuted(change);
     }
-
 }
 
 
@@ -662,15 +660,15 @@ void TextUndoStack::undoDocumentChange()
 bool TextUndoStack::redoControllerChange(TextEditorController *controller)
 {
     Q_ASSERT(controller);
-    int changeIdx = findRedoIndex( currentIndex(controller), controller);
-    Change* changeToRedo = findRedoChange( controller );
-    if( changeToRedo && changeToRedo->controllerContext() ) {
-        Q_ASSERT( changeToRedo->controllerContext() == controller );
-        changeToRedo->execute( documentRef_ );
+    qsizetype changeIdx = findRedoIndex(currentIndex(controller), controller);
+    Change* changeToRedo = findRedoChange(controller);
+    if (changeToRedo && changeToRedo->controllerContext()) {
+        Q_ASSERT(changeToRedo->controllerContext() == controller);
+        changeToRedo->execute(documentRef_);
 
         // move the pointer to the next
-        controllerIndexMap_[controller] = changeIdx+1;
-        emit redoExecuted( changeToRedo );
+        controllerIndexMap_[controller] = changeIdx + 1;
+        emit redoExecuted(changeToRedo);
     }
     return false;
 }
@@ -680,50 +678,50 @@ bool TextUndoStack::redoControllerChange(TextEditorController *controller)
 void TextUndoStack::redoDocumentChange()
 {
     // first find the redo operation
-    int redoIndex = findRedoIndex( currentIndex(0), 0 );
-    Change* redo = findRedoChange(0);
-    if( redo ) { ++redoIndex; }
+    qsizetype redoIndex = findRedoIndex(currentIndex());
+    Change* redo = findRedoChange();
+    if (redo) { ++redoIndex; }
 
     // first move all controller redo-operation to the given redo found redo location
-    QMap<TextEditorController*, int>::iterator itr;
-    for( itr = controllerIndexMap_.begin(); itr != controllerIndexMap_.end(); ++itr) {
+    QMap<TextEditorController*, qsizetype>::iterator itr;
+    for (itr = controllerIndexMap_.begin(); itr != controllerIndexMap_.end(); ++itr) {
         TextEditorController* controller = itr.key();
-        while( redoControllerChange(controller) ) {};  // undo all controller operations
+        while (redoControllerChange(controller)) {};  // undo all controller operations
         itr.value() = redoIndex;    // move the position after the DOC operation
     }
 
     // is there a document redo? execute it
-    if( redo ) {
+    if (redo) {
         redo->execute(documentRef_);
         setChangeIndex(redoIndex);
-        emit redoExecuted( redo );
+        emit redoExecuted(redo);
     }
 }
 
 
 /// Sets the persisted in dex and fires a signal
-void TextUndoStack::setPersistedIndex(int index)
+void TextUndoStack::setPersistedIndex(qsizetype index)
 {
     bool oldPersisted = isPersisted();
     persistedIndex_ = index;
     bool persisted = isPersisted();
-    if( oldPersisted != persisted ) {
-        emit persistedChanged( persisted );
+
+    if (oldPersisted != persisted) {
+        emit persistedChanged(persisted);
     }
 }
 
 
 /// When setting the change-index we sometimes must emit a persisted change
-void TextUndoStack::setChangeIndex(int index)
+void TextUndoStack::setChangeIndex(qsizetype index)
 {
-    if( index != changeIndex_ ) {
+    if (index != changeIndex_) {
         bool oldPersisted= isPersisted();
         changeIndex_ = index;
         bool persisted = isPersisted();
-        if( oldPersisted != persisted ) {
-            emit persistedChanged( persisted );
+        if (oldPersisted != persisted) {
+            emit persistedChanged(persisted);
         }
-
     }
 }
 

--- a/edbee-lib/edbee/models/textundostack.h
+++ b/edbee-lib/edbee/models/textundostack.h
@@ -58,57 +58,56 @@ public:
         ActionUngrouped,        ///< The group has been ungrouped, the single change has been added to the stack
         ActionFullDiscard,      ///< The group contained nothing usefull, nothing is added to the stack
         ActionEnd               ///< A normal group end
-
     };
 
 public:
-    explicit TextUndoStack( TextDocument* doc, QObject* parent = 0);
+    explicit TextUndoStack(TextDocument* doc, QObject* parent = nullptr);
     virtual ~TextUndoStack();
     void clear();
 
-    void registerContoller( TextEditorController* controller );
-    void unregisterController( TextEditorController* controller );
-    bool isControllerRegistered( TextEditorController* controller );
+    void registerContoller(TextEditorController* controller);
+    void unregisterController(TextEditorController* controller);
+    bool isControllerRegistered(TextEditorController* controller);
 
-    void beginUndoGroup( ChangeGroup* group );
+    void beginUndoGroup(ChangeGroup* group);
     ChangeGroup* currentGroup();
     void endUndoGroup(int coalesceId , bool flatten);
     void endUndoGroupAndDiscard();
-    int undoGroupLevel();
+    size_t undoGroupLevel();
 
     int lastCoalesceIdAtCurrentLevel();
     void setLastCoalesceIdAtCurrentLevel(int id);
     void resetAllLastCoalesceIds();
 
-    Change* giveChange( Change* change, int coalesceId );
+    Change* giveChange(Change* change, int coalesceId);
 
-    bool canUndo( TextEditorController* controller=0 );
-    bool canRedo( TextEditorController* controller=0 );
+    bool canUndo(TextEditorController* controller = nullptr);
+    bool canRedo(TextEditorController* controller = nullptr);
 
-    void undo( TextEditorController* controller=0, bool controllerOnly=false );
-    void redo( TextEditorController* controller=0, bool controllerOnly=false );
+    void undo(TextEditorController* controller = nullptr, bool controllerOnly = false);
+    void redo(TextEditorController* controller = nullptr, bool controllerOnly = false);
 
     bool isCollectionEnabled() { return collectionEnabled_; }
-    void setCollectionEnabled( bool enabled ) { collectionEnabled_ = enabled; }
+    void setCollectionEnabled(bool enabled) { collectionEnabled_ = enabled; }
 
     bool isUndoRunning() { return undoRunning_; }
     bool isRedoRunning() { return redoRunning_; }
 
-    int size();
-    Change* at(int idx);
-    int currentIndex( TextEditorController* controller=0 );
-    int lastIndex( TextEditorController* controller=0 );
-    Change* last(TextEditorController* controller=0 );
+    qsizetype size();
+    Change* at(qsizetype idx);
+    qsizetype currentIndex(TextEditorController* controller = nullptr);
+    qsizetype lastIndex(TextEditorController* controller = nullptr);
+    Change* last(TextEditorController* controller = nullptr);
 
-    int sizeInDocChanges();
-    int currentIndexInDocChanges();
+    qsizetype sizeInDocChanges();
+    qsizetype currentIndexInDocChanges();
 
-    Change* findRedoChange( TextEditorController* controller=0);
-    Change* findUndoChange( TextEditorController* controller=0 );
+    Change* findRedoChange(TextEditorController* controller = nullptr);
+    Change* findUndoChange(TextEditorController* controller = nullptr);
 
     void setPersisted(bool enabled);
     bool isPersisted();
-    int persistedIndex();
+    qsizetype persistedIndex();
 
     TextDocument* document() { return documentRef_; }
 
@@ -116,53 +115,49 @@ public:
     void dumpStackInternal();
 
 protected:
-    int findRedoIndex( int index, TextEditorController* controller=0 );
-    int findUndoIndex( int index, TextEditorController* controller=0 );
-    void clearRedo( TextEditorController* controller );
-    bool undoControllerChange( TextEditorController* controller );
+    qsizetype findRedoIndex(qsizetype index, TextEditorController* controller = nullptr);
+    qsizetype findUndoIndex(qsizetype index, TextEditorController* controller = nullptr);
+    void clearRedo(TextEditorController* controller );
+    bool undoControllerChange(TextEditorController* controller);
     void undoDocumentChange();
-    bool redoControllerChange( TextEditorController* controller );
+    bool redoControllerChange(TextEditorController* controller);
     void redoDocumentChange();
 
-    void setPersistedIndex( int index );
-    void setChangeIndex( int index );
+    void setPersistedIndex(qsizetype index);
+    void setChangeIndex(qsizetype index);
 
 signals:
 
-    void undoGroupStarted( edbee::ChangeGroup* group );
+    void undoGroupStarted(edbee::ChangeGroup* group);
 
     /// This signal is fired when the group is ended. Warning, when the group is merged
     /// the group pointer will be 0!!
-    void undoGroupEnded( int coalesceId, bool merged, int action );
-    void changeAdded( edbee::Change* change );
+    void undoGroupEnded(int coalesceId, bool merged, int action);
+    void changeAdded(edbee::Change* change);
 //    void changeMerged( edbee::TextChange* oldChange, edbee::TextChange* change );
-    void undoExecuted( edbee::Change* change );
-    void redoExecuted( edbee::Change* change );
+    void undoExecuted(edbee::Change* change);
+    void redoExecuted(edbee::Change* change);
 
     /// This signal is emitted if the persisted state is changed
     void persistedChanged(bool persisted);
 
-
 private:
     void clearHistoryLists();
 
+    TextDocument* documentRef_;                                 ///< A reference to the textdocument
 
-    TextDocument* documentRef_;                           ///< A reference to the textdocument
+    QList<Change*> changeList_;                                 ///< The list of stack commands
+    qsizetype changeIndex_;                                     ///< The current command index (TextDocument/Global)
+    QMap<TextEditorController*, qsizetype> controllerIndexMap_; ///< The current controller pointers (View specific)
+    qsizetype persistedIndex_;                                  ///< The current persisted index. A persisted-index of -1, means it never is persisted
 
-    QList<Change*> changeList_;                       ///< The list of stack commands
-    int changeIndex_;                                     ///< The current command index (TextDocument/Global)
-    QMap<TextEditorController*,int> controllerIndexMap_;  ///< The current controller pointers (View specific)
-    int persistedIndex_;                                  ///< The current persisted index. A persisted-index of -1, means it never is persisted
+    QStack<ChangeGroup*> undoGroupStack_;                       ///< A stack of all undo items
+    QStack<int> lastCoalesceIdStack_;                           ///< The last coalesceId
 
-    QStack<ChangeGroup*> undoGroupStack_;             ///< A stack of all undo items
-    QStack<int> lastCoalesceIdStack_;                     ///< The last coalesceId
+    bool collectionEnabled_;                                    ///< Is the undo-stack enabled?
 
-//    int undoGroupLevel_;                                 ///< The undo group level
-//    TextChangeGroup* undoGroup_;                         ///< The current undo group
-    bool collectionEnabled_;                               ///< Is the undo-stack enabled?
-
-    bool undoRunning_;                                    ///< This flag is set if undo is running
-    bool redoRunning_;                                    ///< This flag is set if a redo is running
+    bool undoRunning_;                                          ///< This flag is set if undo is running
+    bool redoRunning_;                                          ///< This flag is set if a redo is running
 };
 
 } // edbee

--- a/edbee-lib/edbee/texteditorcontroller.cpp
+++ b/edbee-lib/edbee/texteditorcontroller.cpp
@@ -656,7 +656,9 @@ void TextEditorController::moveCaretTo(ptrdiff_t line, ptrdiff_t col, bool keepA
     }
 
     ptrdiff_t minusNewLineChar = textDocument()->lineCount() - 1 == uline ? 0 : 1;
-    offset += static_cast<size_t>(qBound(0, col, qMax(static_cast<ptrdiff_t>(lineLength) - minusNewLineChar, 0)));
+
+    ptrdiff_t max = qMax(static_cast<ptrdiff_t>(lineLength) - minusNewLineChar, static_cast<ptrdiff_t>(0));
+    offset += static_cast<size_t>(qBound(static_cast<ptrdiff_t>(0), col, max));
     return moveCaretToOffset(offset, keepAnchors, rangeIndex);
 }
 

--- a/edbee-lib/edbee/texteditorcontroller.cpp
+++ b/edbee-lib/edbee/texteditorcontroller.cpp
@@ -135,8 +135,8 @@ void TextEditorController::setTextDocument(TextDocument* doc)
         TextDocument* oldDocumentRef = textDocument();
         if( oldDocumentRef ) {
             oldDocumentRef->textUndoStack()->unregisterController(this);
-            disconnect( oldDocumentRef, SIGNAL(textChanged(edbee::TextBufferChange, QString)), this, SLOT(onTextChanged(edbee::TextBufferChange, QString)) );
-            disconnect( textDocumentRef_->lineDataManager(), SIGNAL(lineDataChanged(int,int,int)), this, SLOT(onLineDataChanged(int,int,int)));
+            disconnect(oldDocumentRef, SIGNAL(textChanged(edbee::TextBufferChange, QString)), this, SLOT(onTextChanged(edbee::TextBufferChange, QString)) );
+            disconnect(textDocumentRef_->lineDataManager(), SIGNAL(lineDataChanged(size_t,size_t,size_t)), this, SLOT(onLineDataChanged(size_t,size_t,size_t)));
         }
 
         // delete some old and dependent objects
@@ -155,8 +155,8 @@ void TextEditorController::setTextDocument(TextDocument* doc)
 
         textDocumentRef_->textUndoStack()->registerContoller(this);
 
-        connect( textDocumentRef_, SIGNAL(textChanged(edbee::TextBufferChange, QString)), this, SLOT(onTextChanged(edbee::TextBufferChange, QString)));
-        connect( textDocumentRef_->lineDataManager(), SIGNAL(lineDataChanged(int,int,int)), this, SLOT(onLineDataChanged(int,int,int)) );
+        connect(textDocumentRef_, SIGNAL(textChanged(edbee::TextBufferChange,QString)), this, SLOT(onTextChanged(edbee::TextBufferChange, QString)));
+        connect(textDocumentRef_->lineDataManager(), SIGNAL(lineDataChanged(size_t,size_t,size_t)), this, SLOT(onLineDataChanged(size_t,size_t,size_t)));
 
         // force an repaint when the grammar is changed
         connect( textDocumentRef_, &TextDocument::languageGrammarChanged, this, &TextEditorController::update );
@@ -402,10 +402,10 @@ void TextEditorController::onSelectionChanged(TextRangeSet* oldRangeSet)
 /// @param line the line number that had a data change
 /// @param length the number of lines changed
 /// @param newLength the new number of lines
-void TextEditorController::onLineDataChanged(int line, int length, int newLength)
+void TextEditorController::onLineDataChanged(size_t line, size_t length, size_t newLength)
 {
-    if( this->widgetRef_ ) {
-        widgetRef_->updateLine( line, qMax(length,newLength));
+    if (this->widgetRef_) {
+        widgetRef_->updateLine(line, qMax(length,newLength));
     }
 }
 

--- a/edbee-lib/edbee/texteditorcontroller.cpp
+++ b/edbee-lib/edbee/texteditorcontroller.cpp
@@ -43,7 +43,7 @@ namespace edbee {
 /// @param widget the widget this controller is associated with
 /// @paarm parent the QObject parent of the controller
 TextEditorController::TextEditorController(TextEditorWidget* widget, QObject *parent)
-    : TextEditorController( new CharTextDocument(), widget, parent )
+    : TextEditorController(new CharTextDocument(), widget, parent)
 {
 }
 
@@ -71,15 +71,14 @@ TextEditorController::TextEditorController(TextDocument *document, TextEditorWid
     commandMapRef_ = Edbee::instance()->defaultCommandMap();
 
     // create the text renderer
-    textRenderer_ = new TextRenderer( this );
+    textRenderer_ = new TextRenderer(this);
 
     // create a text document (this should happen AFTER the creation of the renderer)
-    giveTextDocument( document );
+    giveTextDocument(document);
 
     // Now all objects have been created we can init them
     textRenderer_->init();
     textRenderer_->setThemeByName( textDocument()->config()->themeName() );
-
 }
 
 
@@ -100,11 +99,11 @@ TextEditorController::~TextEditorController()
 /// This method is called to reset the caret timer and update the ui
 void TextEditorController::notifyStateChange()
 {
-    if( widgetRef_ ) {
+    if (widgetRef_) {
         widgetRef_->resetCaretTime();
 
         // scrolling is only required when focused (When scrolling without focus the sync-editor goes wacko :P )
-        if( autoScrollToCaret_ == AutoScrollAlways || (autoScrollToCaret_ == AutoScrollWhenFocus && hasFocus())   ) {
+        if (autoScrollToCaret_ == AutoScrollAlways || (autoScrollToCaret_ == AutoScrollWhenFocus && hasFocus())) {
             scrollOffsetVisible( textSelection()->range(0).caret() );
         }
 
@@ -117,8 +116,8 @@ void TextEditorController::notifyStateChange()
 /// @param doc the new document for this controller
 void TextEditorController::giveTextDocument(TextDocument* doc)
 {
-    if( doc != textDocument_ ) {
-        setTextDocument( doc );
+    if (doc != textDocument_) {
+        setTextDocument(doc);
         textDocument_ = doc;        // this is all that's required for getting the ownership
     }
 }
@@ -130,12 +129,12 @@ void TextEditorController::setTextDocument(TextDocument* doc)
 {
     Q_ASSERT_GUI_THREAD;
 
-    if( doc != textDocumentRef_ ) {
+    if (doc != textDocumentRef_) {
         // disconnect the old document
         TextDocument* oldDocumentRef = textDocument();
-        if( oldDocumentRef ) {
+        if (oldDocumentRef) {
             oldDocumentRef->textUndoStack()->unregisterController(this);
-            disconnect(oldDocumentRef, SIGNAL(textChanged(edbee::TextBufferChange, QString)), this, SLOT(onTextChanged(edbee::TextBufferChange, QString)) );
+            disconnect(oldDocumentRef, SIGNAL(textChanged(edbee::TextBufferChange, QString)), this, SLOT(onTextChanged(edbee::TextBufferChange, QString)));
             disconnect(textDocumentRef_->lineDataManager(), SIGNAL(lineDataChanged(size_t,size_t,size_t)), this, SLOT(onLineDataChanged(size_t,size_t,size_t)));
         }
 
@@ -145,17 +144,16 @@ void TextEditorController::setTextDocument(TextDocument* doc)
 
         // create the document
         textDocumentRef_ = doc;
-        textCaretCache_ = new TextCaretCache( textDocumentRef_, textRenderer_ ); // warning the cache needs to be created BEFORE the selection!!!
-        textSelection_ = new TextSelection( this );
+        textCaretCache_ = new TextCaretCache(textDocumentRef_, textRenderer_); // warning the cache needs to be created BEFORE the selection!!!
+        textSelection_ = new TextSelection(this);
         textSelection_->addRange(0,0);  // add at least one cursor :-)
 
         delete borderedTextRanges_;
         borderedTextRanges_ = new DynamicTextRangeSet(textDocument());
 
-
         textDocumentRef_->textUndoStack()->registerContoller(this);
 
-        connect(textDocumentRef_, SIGNAL(textChanged(edbee::TextBufferChange,QString)), this, SLOT(onTextChanged(edbee::TextBufferChange, QString)));
+        connect(textDocumentRef_, SIGNAL(textChanged(edbee::TextBufferChange,QString)), this, SLOT(onTextChanged(edbee::TextBufferChange,QString)));
         connect(textDocumentRef_->lineDataManager(), SIGNAL(lineDataChanged(size_t,size_t,size_t)), this, SLOT(onLineDataChanged(size_t,size_t,size_t)));
 
         // force an repaint when the grammar is changed
@@ -165,7 +163,7 @@ void TextEditorController::setTextDocument(TextDocument* doc)
         connect( textDocumentRef_->config(), &TextEditorConfig::configChanged, this, &TextEditorController::updateAfterConfigChange );
 
         // create the new document
-        emit textDocumentChanged( oldDocumentRef, textDocumentRef_ );
+        emit textDocumentChanged(oldDocumentRef, textDocumentRef_);
 
         // delete the old stuff
         delete textDocument_;
@@ -181,14 +179,14 @@ void TextEditorController::setTextDocument(TextDocument* doc)
 //   - AutoScrollNever => Never perform automatic scrolling
 void TextEditorController::setAutoScrollToCaret(TextEditorController::AutoScrollToCaret autoScroll)
 {
-     autoScrollToCaret_ = autoScroll;
+    autoScrollToCaret_ = autoScroll;
 }
 
 
 /// Returns the autoScrollToCaret setting
 TextEditorController::AutoScrollToCaret TextEditorController::autoScrollToCaret() const
 {
-     return autoScrollToCaret_;
+    return autoScrollToCaret_;
 }
 
 
@@ -199,25 +197,23 @@ bool TextEditorController::hasFocus()
 }
 
 
-/// This method creates an editor action that is
+/// Creates an editor action that is unconnected
 /// @param command the command that needs to be executed.
 /// @param text description of the command
 /// @param icon the optional icon of the command
 /// @param owner the QObject owner of this action
 /// @return the newly created QAction
-QAction* TextEditorController::createUnconnectedAction(const QString& command, const QString& text, const QIcon& icon, QObject* owner )
+QAction* TextEditorController::createUnconnectedAction(const QString& command, const QString& text, const QIcon& icon, QObject* owner)
 {
-    // create the action
-    QAction* action = new QAction( icon, text, owner );
+    QAction* action = new QAction(icon, text, owner);
 
     // set the key if there's an assigned keyboard command
     TextEditorKey* key = keyMap()->get(command);
-    if( keyMap()->get( command ) ) {
+    if (keyMap()->get(command)) {
         action->setShortcut( key->sequence() );
     }
 
-    // set the data
-    action->setData( command );
+    action->setData(command);
     return action;
 }
 
@@ -231,10 +227,8 @@ QAction* TextEditorController::createUnconnectedAction(const QString& command, c
 /// @return the newly created QAction
 QAction* TextEditorController::createAction(const QString& command, const QString& text, const QIcon& icon , QObject* owner)
 {
-    // create the action
     QAction* action = createUnconnectedAction( command, text, icon, owner );
-    /// connect the signal to executeCommand
-    connect( action, SIGNAL(triggered()), SLOT(executeCommand()) );
+    connect( action, SIGNAL(triggered()), SLOT(executeCommand()));
     return action;
 }
 
@@ -370,11 +364,8 @@ DynamicVariables* TextEditorController::dynamicVariables() const
 
 
 /// This slot is placed if a piece of text is replaced
-void TextEditorController::onTextChanged( edbee::TextBufferChange change, QString oldText )
+void TextEditorController::onTextChanged(edbee::TextBufferChange change, QString oldText)
 {
-    /// update the selection
-//    textSelection()->changeSpatial( change.offset(), change.length(), change.newTextLength() );
-
     /// TODO: improve this:
     if( widgetRef_) {
         widget()->updateGeometryComponents();
@@ -415,7 +406,7 @@ void TextEditorController::onLineDataChanged(size_t line, size_t length, size_t 
 /// A lot of changes don't require an updates, but some do
 void TextEditorController::updateAfterConfigChange()
 {
-    textRenderer()->setThemeByName( textDocument()->config()->themeName() );
+    textRenderer()->setThemeByName(textDocument()->config()->themeName());
 
     // we need to figure out a better way to do this
     QFont font = textDocument()->config()->font();
@@ -428,115 +419,112 @@ void TextEditorController::updateAfterConfigChange()
 
 /// This method updates the status text. This is the text as displayed in the lower status bar
 /// @param extraText the extra text to show in the status bar
-void TextEditorController::updateStatusText( const QString& extraText )
+void TextEditorController::updateStatusText(const QString& extraText)
 {
     QString text;
     TextDocument* doc = textDocument();
 
-    if( !doc->textUndoStack()->isPersisted() ) {
+    if (!doc->textUndoStack()->isPersisted()) {
         text.append("[*] ");
     }
 
     // add the ranges
-    if( textSelection_->rangeCount() > 1 ) {
-        text.append( QObject::tr("%1 ranges").arg(textSelection_->rangeCount() ) );
+    if (textSelection_->rangeCount() > 1) {
+        text.append(QObject::tr("%1 ranges").arg(textSelection_->rangeCount()));
     } else {
         TextRange& range = textSelection_->range(0);
-        int caret = range.caret();
-        int line = doc->lineFromOffset( caret ) ;
-        int col  = doc->columnFromOffsetAndLine( caret, line ) + 1;
+        size_t caret = range.caret();
+        size_t line = doc->lineFromOffset(caret) ;
+        size_t col  = doc->columnFromOffsetAndLine(caret, line) + 1;
         text.append( QObject::tr("Line %1, Column %2").arg(line+1).arg(col) );
 
-        if( textDocument()->config()->showCaretOffset() ) {
-            text.append( QObject::tr(", Offset %1").arg(caret) );
+        if (textDocument()->config()->showCaretOffset()) {
+            text.append(QObject::tr(", Offset %1").arg(caret));
         }
 
-        if( range.length() > 0 ) {
-            text.append( QObject::tr(" | %1 chars selected").arg(range.length()) );
+        if (range.length() > 0) {
+            text.append(QObject::tr(" | %1 chars selected").arg(range.length()));
 
         // add the current scopes
         } else {
             text.append( QObject::tr(" | scope: ") );
 
             QString str;
-            QVector<TextScope*> scopes = textDocument()->scopes()->scopesAtOffset( caret ) ;
-            for( int i=0,cnt=scopes.size(); i<cnt; ++i ) {
+            QVector<TextScope*> scopes = textDocument()->scopes()->scopesAtOffset(caret) ;
+            for (qsizetype i = 0, cnt = scopes.size(); i < cnt; ++i) {
                 TextScope* scope = scopes[i];
-                str.append( scope->name() );
+                str.append(scope->name());
                 str.append(" ");
             }
-            text.append( str );
-            text.append( QObject::tr(" (%1)").arg( textDocument()->scopes()->lastScopedOffset() ) );
+            text.append(str);
+            text.append(QObject::tr(" (%1)").arg( textDocument()->scopes()->lastScopedOffset()));
         }
     }
 
-    // add the extra text
-    if( !extraText.isEmpty() ) {
+    if(!extraText.isEmpty()) {
         text.append(" | " );
         text.append(extraText);
     }
-    emit updateStatusTextSignal( text );
+    emit updateStatusTextSignal(text);
 }
 
 
 /// updates the main widget
 void TextEditorController::update()
 {
-    if( widgetRef_ ) {
+    if (widgetRef_) {
         widgetRef_->fullUpdate();
     }
 }
 
 
 /// Asserts the view shows the given position
-void TextEditorController::scrollPositionVisible(int xPos, int yPos)
+void TextEditorController::scrollPositionVisible(size_t xPos, size_t yPos)
 {
-    emit widgetRef_->scrollPositionVisible( xPos, yPos );
+    emit widgetRef_->scrollPositionVisible(xPos, yPos);
 }
 
 
 /// Assets the view shows the given offset
-void TextEditorController::scrollOffsetVisible(int offset)
+void TextEditorController::scrollOffsetVisible(size_t offset)
 {
     TextRenderer* renderer = textRenderer();
-    int xPos = renderer->xPosForOffset(offset);
-    int yPos = renderer->yPosForOffset(offset);
-    scrollPositionVisible( xPos, yPos );
+    size_t xPos = renderer->xPosForOffset(offset);
+    size_t yPos = renderer->yPosForOffset(offset);
+    scrollPositionVisible(xPos, yPos);
 }
 
 
-/// This method makes sure caret 1 is visible
+/// Scrolls so the first caret is visible
 void TextEditorController::scrollCaretVisible()
 {
-    scrollOffsetVisible( textSelection()->range(0).caret() );
+    scrollOffsetVisible(textSelection()->range(0).caret());
 }
 
 
-/// This method adds a text change on the stack that simply stores the current text-selection
+/// Adds a text change on the stack that simply stores the current text-selection
 /// @param coalsceId the coalescing identifier for merging/coalescing undo operations
 void TextEditorController::storeSelection(int coalesceId)
 {
     SelectionChange* change = new SelectionChange(this);
-    change->giveTextRangeSet( new TextRangeSet( *textSelection() ) );
-    textDocument()->executeAndGiveChange( change, coalesceId );
+    change->giveTextRangeSet(new TextRangeSet(*textSelection()));
+    textDocument()->executeAndGiveChange(change, coalesceId);
 }
 
 
-/// This method executes the command
-void TextEditorController::executeCommand( edbee::TextEditorCommand* textCommand )
+void TextEditorController::executeCommand(edbee::TextEditorCommand* textCommand)
 {
     // Only readonly commands can be executed in readonly mode
-    if( readonly() && !textCommand->readonly() ) {
+    if (readonly() && !textCommand->readonly()) {
         updateStatusText( "Cannot edit a readonly document!" );
         return;
     }
 
-    emit commandToBeExecuted( textCommand  );
-    textCommand->execute( this );
-    emit commandExecuted( textCommand );
+    emit commandToBeExecuted(textCommand);
+    textCommand->execute(this);
+    emit commandExecuted(textCommand);
 
-    // TODO: move this to a nicer place!!
-    updateStatusText( textCommand->toString() );
+    updateStatusText(textCommand->toString());
 }
 
 
@@ -550,11 +538,11 @@ void TextEditorController::executeCommand(const QString& name)
 {
     // check if an empty command name has been supplied
     QString commandName = name;
-    if( commandName.isEmpty() ) {
+    if (commandName.isEmpty()) {
 
         // when the command name is blank  try to get the data of the QAction command
         QAction* action= qobject_cast<QAction*>(sender());
-        if( !action ) {
+        if (!action) {
             qlog_warn() << "executeCommand was triggered without argument and without QAction data attribute!";
             return;
         }
@@ -563,14 +551,16 @@ void TextEditorController::executeCommand(const QString& name)
 
     // try to retrieve the command
     TextEditorCommand* command = commandMap()->get(commandName);
-    if( command ) { executeCommand( command ); }
+    if (command) { executeCommand(command); }
 }
+
 
 /// Return the readonly state.
 bool TextEditorController::readonly() const
 {
     return widget()->readonly();
 }
+
 
 /// Sets the readonly state
 void TextEditorController::setReadonly(bool value)
@@ -579,47 +569,47 @@ void TextEditorController::setReadonly(bool value)
 }
 
 
-/// replaces the given text (single ranges)
+/// Replaces the given text (single ranges)
 /// @param offset the character offset in the document
 /// @param length the number of characters to replace
 /// @param text the text to replace
 /// @param coalesceId the identifier for grouping undo operations
-void TextEditorController::replace(int offset, int length, const QString& text, int coalesceId, bool stickySelection)
+void TextEditorController::replace(size_t offset, size_t length, const QString& text, int coalesceId, bool stickySelection)
 {
 //    SelectionTextChange* change = new SelectionTextChange(this);
     TextRangeSet ranges(textDocument());
-    ranges.addRange(offset, offset+length);
-    replaceRangeSet(ranges,text,coalesceId, stickySelection);
+    ranges.addRange(offset, offset + length);
+    replaceRangeSet(ranges, text, coalesceId, stickySelection);
 }
 
 
-/// This method replaces the selection with the given text
+/// Replaces the selection with the given text
 /// @param text the text to replace the selection with
 /// @param coalesceId the identifier for grouping undo operations
 void TextEditorController::replaceSelection(const QString& text, int coalesceId, bool stickySelection)
 {
-    replaceRangeSet( *dynamic_cast<TextRangeSet*>( textSelection() ), text, coalesceId, stickySelection);
+    replaceRangeSet(*dynamic_cast<TextRangeSet*>(textSelection()), text, coalesceId, stickySelection);
 }
 
 
-/// This method replaces the given selection with the given texts
+/// Replaces the given selection with the given texts
 /// @param texts the list of texts that need to be replaced
 /// @param coalesceID the identifier for grouping undo operation
 void TextEditorController::replaceSelection(const QStringList& texts, int coalesceId, bool stickySelection)
 {
-    replaceRangeSet(*dynamic_cast<TextRangeSet*>( textSelection() ), texts, coalesceId, stickySelection);
+    replaceRangeSet(*dynamic_cast<TextRangeSet*>(textSelection()), texts, coalesceId, stickySelection);
 }
 
 
-///  Replaces the given rangeset with the given text
+/// Replaces the given rangeset with the given text
 /// @param rangeset the ranges to replace
 /// @param text the text to replace the selection with
 /// @param coalesceId the identifier for grouping undo operations
 void TextEditorController::replaceRangeSet(edbee::TextRangeSet& rangeSet, const QString& text, int coalesceId, bool stickySelection)
 {
-    if(readonly()) return;
+    if (readonly()) return;
 
-    textDocument()->beginChanges( this );
+    textDocument()->beginChanges(this);
     textDocument()->replaceRangeSet(rangeSet, text, stickySelection);
     textDocument()->endChanges(coalesceId);
     notifyStateChange();
@@ -632,16 +622,16 @@ void TextEditorController::replaceRangeSet(edbee::TextRangeSet& rangeSet, const 
 /// @param coalesceId the identifier for grouping undo operations
 void TextEditorController::replaceRangeSet(edbee::TextRangeSet& rangeSet, const QStringList& texts, int coalesceId, bool stickySelection)
 {
-    if(readonly()) return;
+    if (readonly()) return;
 
-    textDocument()->beginChanges( this );
-    textDocument()->replaceRangeSet( rangeSet, texts, stickySelection);
-    textDocument()->endChanges( coalesceId );
+    textDocument()->beginChanges(this);
+    textDocument()->replaceRangeSet(rangeSet, texts, stickySelection);
+    textDocument()->endChanges(coalesceId);
     notifyStateChange();
 }
 
 
-/// This method creates a command that moves the caret to the given line/column position
+/// Creates a command that moves the caret to the given line/column position
 /// A negative number means that we're counting from the end
 /// This method assumes line 0 is the first line!
 ///
@@ -650,24 +640,24 @@ void TextEditorController::replaceRangeSet(edbee::TextRangeSet& rangeSet, const 
 ///     moveCaretTo( -1, -2 ) => Moves the caret to the character before the last character
 ///
 /// The rangeIndex is used to specify which range to move.. (Defaults to -1 which changes to a single range)
-void TextEditorController::moveCaretTo(int line, int col, bool keepAnchors, int rangeIndex )
+void TextEditorController::moveCaretTo(ptrdiff_t line, ptrdiff_t col, bool keepAnchors, size_t rangeIndex)
 {
-    if( line < 0) {
-        line = textDocument()->lineCount() + line;
-        if( line < 0 ) { line = 0; }
+    if (line < 0) {
+        line = static_cast<ptrdiff_t>(textDocument()->lineCount()) + line;
+        if (line < 0) { line = 0; }
     }
-    int offset = textDocument()->offsetFromLine(line);
-    int lineLength = textDocument()->lineLength(line);
-    if( col < 0 ){
-        col = lineLength + col;
+    Q_ASSERT(line >= 0);
+
+    size_t uline = static_cast<size_t>(line);
+    size_t offset = textDocument()->offsetFromLine(uline);
+    size_t lineLength = textDocument()->lineLength(uline);
+    if (col < 0){
+        col = static_cast<ptrdiff_t>(lineLength) + col;
     }
 
-    int minusNewLineChar = textDocument()->lineCount()-1 == line ? 0 : 1;
-    offset += qBound(0, col, qMax(lineLength-minusNewLineChar, 0));
-
-//textDocument()->offsetFromLineAndColumn(line,col)
-
-    return moveCaretToOffset( offset , keepAnchors, rangeIndex );
+    ptrdiff_t minusNewLineChar = textDocument()->lineCount() - 1 == uline ? 0 : 1;
+    offset += static_cast<size_t>(qBound(0, col, qMax(static_cast<ptrdiff_t>(lineLength) - minusNewLineChar, 0)));
+    return moveCaretToOffset(offset, keepAnchors, rangeIndex);
 }
 
 
@@ -675,49 +665,49 @@ void TextEditorController::moveCaretTo(int line, int col, bool keepAnchors, int 
 /// @param offset the offset to move the caret to
 /// @param keepAnchors should the anchors stay at the current position (extending the selection range)
 /// The rangeIndex is used to specify which range to move.. (Defaults to -1 which changes to a single range)
-void TextEditorController::moveCaretToOffset(int offset, bool keepAnchors, int rangeIndex)
+void TextEditorController::moveCaretToOffset(size_t offset, bool keepAnchors, size_t rangeIndex)
 {
 //    SelectionCommand* command = new SelectionCommand( SelectionCommand::MoveCaretToExactOffset, offset, keepAnchors );
-    SelectionCommand command( SelectionCommand::MoveCaretToExactOffset, offset, keepAnchors, rangeIndex );
-    return executeCommand( &command );
+    SelectionCommand command(SelectionCommand::MoveCaretToExactOffset, static_cast<ptrdiff_t>(offset), keepAnchors, rangeIndex);
+    return executeCommand(&command);
 }
 
 /// Move the caret and the anchor to the given offset
 /// @param caret the caret location
 /// @param anchor the anchor location
-/// The rangeIndex is used to specify which range to move.. (Defaults to -1 which changes to a single range)
-void TextEditorController::moveCaretAndAnchorToOffset(int caret, int anchor, int rangeIndex)
+/// The rangeIndex is used to specify which range to move.. (Defaults to std::string::npos which changes to a single range)
+void TextEditorController::moveCaretAndAnchorToOffset(size_t caret, size_t anchor, size_t rangeIndex)
 {
-    SelectionCommand command( SelectionCommand::MoveCaretToExactOffset, caret, true, rangeIndex);
+    SelectionCommand command(SelectionCommand::MoveCaretToExactOffset, static_cast<ptrdiff_t>(caret), true, rangeIndex);
     command.setAnchor(anchor);
-    return executeCommand( &command );
+    return executeCommand(&command);
 }
 
 
 /// Adds a new caret to the selection
 /// @param line the line number
 /// @param col the column
-void TextEditorController::addCaretAt(int line, int col)
+void TextEditorController::addCaretAt(size_t line, size_t col)
 {
-    return addCaretAtOffset( textDocument()->offsetFromLineAndColumn(line,col) );
+    return addCaretAtOffset(textDocument()->offsetFromLineAndColumn(line,col));
 }
 
 
 /// Adds a carert at the given offset
 /// @param offset the character offset to add the caret
-void TextEditorController::addCaretAtOffset(int offset)
+void TextEditorController::addCaretAtOffset(size_t offset)
 {
-    SelectionCommand command( SelectionCommand::AddCaretAtOffset, offset );
-    return executeCommand( &command );
+    SelectionCommand command(SelectionCommand::AddCaretAtOffset, static_cast<ptrdiff_t>(offset));
+    return executeCommand(&command);
 }
 
 
 /// This method changes the text selection
-void TextEditorController::changeAndGiveTextSelection(edbee::TextRangeSet* rangeSet, int coalesceId )
+void TextEditorController::changeAndGiveTextSelection(edbee::TextRangeSet* rangeSet, int coalesceId)
 {
     SelectionChange* change = new SelectionChange(this);
-    change->giveTextRangeSet( rangeSet );
-    textDocument()->executeAndGiveChange( change, coalesceId );
+    change->giveTextRangeSet(rangeSet);
+    textDocument()->executeAndGiveChange(change, coalesceId);
 }
 
 
@@ -725,7 +715,7 @@ void TextEditorController::changeAndGiveTextSelection(edbee::TextRangeSet* range
 /// controller based operations are undone. When supplying false a Document operation is being undone
 void TextEditorController::undo(bool soft)
 {
-    textDocument()->textUndoStack()->undo( soft ? this : nullptr, soft );
+    textDocument()->textUndoStack()->undo( soft ? this : nullptr, soft);
 }
 
 
@@ -734,17 +724,17 @@ void TextEditorController::undo(bool soft)
 /// @param soft perform a soft undo?
 void TextEditorController::redo(bool soft)
 {
-    textDocument()->textUndoStack()->redo( soft ? this : nullptr, soft );
+    textDocument()->textUndoStack()->redo(soft ? this : nullptr, soft);
 }
 
 
 
 /// Starts an undo group
 /// @param group the undogroup to use (defaults to a MergableChangeGroup)
-void TextEditorController::beginUndoGroup( edbee::ChangeGroup* group )
+void TextEditorController::beginUndoGroup(edbee::ChangeGroup* group)
 {
-    if( !group ) {
-        group = new ChangeGroup( this );
+    if (!group) {
+        group = new ChangeGroup(this);
     }
     textDocument()->beginUndoGroup(group);
 }

--- a/edbee-lib/edbee/texteditorcontroller.cpp
+++ b/edbee-lib/edbee/texteditorcontroller.cpp
@@ -18,6 +18,7 @@
 #include "edbee/models/texteditorcommandmap.h"
 #include "edbee/models/texteditorconfig.h"
 #include "edbee/models/texteditorkeymap.h"
+#include "edbee/models/textlinedata.h" // leave it!, it's used by the connect
 #include "edbee/models/textrange.h"
 #include "edbee/models/textsearcher.h"
 #include "edbee/models/textundostack.h"

--- a/edbee-lib/edbee/texteditorcontroller.cpp
+++ b/edbee-lib/edbee/texteditorcontroller.cpp
@@ -396,7 +396,7 @@ void TextEditorController::onSelectionChanged(TextRangeSet* oldRangeSet)
 void TextEditorController::onLineDataChanged(size_t line, size_t length, size_t newLength)
 {
     if (this->widgetRef_) {
-        widgetRef_->updateLine(line, qMax(length,newLength));
+        widgetRef_->updateLine(line, qMax(length, newLength));
     }
 }
 
@@ -479,7 +479,7 @@ void TextEditorController::update()
 
 
 /// Asserts the view shows the given position
-void TextEditorController::scrollPositionVisible(size_t xPos, size_t yPos)
+void TextEditorController::scrollPositionVisible(int xPos, int yPos)
 {
     emit widgetRef_->scrollPositionVisible(xPos, yPos);
 }
@@ -489,8 +489,8 @@ void TextEditorController::scrollPositionVisible(size_t xPos, size_t yPos)
 void TextEditorController::scrollOffsetVisible(size_t offset)
 {
     TextRenderer* renderer = textRenderer();
-    size_t xPos = renderer->xPosForOffset(offset);
-    size_t yPos = renderer->yPosForOffset(offset);
+    int xPos = renderer->xPosForOffset(offset);
+    int yPos = renderer->yPosForOffset(offset);
     scrollPositionVisible(xPos, yPos);
 }
 
@@ -639,7 +639,7 @@ void TextEditorController::replaceRangeSet(edbee::TextRangeSet& rangeSet, const 
 ///     moveCaretTo( 2, 1 ) => Moves the caret to the 3rd line and 2nd column
 ///     moveCaretTo( -1, -2 ) => Moves the caret to the character before the last character
 ///
-/// The rangeIndex is used to specify which range to move.. (Defaults to -1 which changes to a single range)
+/// The rangeIndex is used to specify which range to move.. (Defaults to std::string::npos which changes to a single range)
 void TextEditorController::moveCaretTo(ptrdiff_t line, ptrdiff_t col, bool keepAnchors, size_t rangeIndex)
 {
     if (line < 0) {
@@ -658,6 +658,19 @@ void TextEditorController::moveCaretTo(ptrdiff_t line, ptrdiff_t col, bool keepA
     ptrdiff_t minusNewLineChar = textDocument()->lineCount() - 1 == uline ? 0 : 1;
     offset += static_cast<size_t>(qBound(0, col, qMax(static_cast<ptrdiff_t>(lineLength) - minusNewLineChar, 0)));
     return moveCaretToOffset(offset, keepAnchors, rangeIndex);
+}
+
+/// Creates a command that moves the caret to the given line/column position
+/// A negative number means that we're counting from the end
+/// This method assumes line 0 is the first line!
+///
+/// For example:
+///     moveCaretTo( 2, 1 ) => Moves the caret to the 3rd line and 2nd column
+///
+/// The rangeIndex is used to specify which range to move.. (Defaults to std::string::npos which changes to a single range)
+void TextEditorController::moveCaretTo(size_t line, size_t col, bool keepAnchors, size_t rangeIndex)
+{
+    moveCaretTo(static_cast<ptrdiff_t>(line), static_cast<ptrdiff_t>(col), keepAnchors, rangeIndex);
 }
 
 

--- a/edbee-lib/edbee/texteditorcontroller.h
+++ b/edbee-lib/edbee/texteditorcontroller.h
@@ -100,9 +100,9 @@ signals:
 
 public slots:
 
-    void onTextChanged( edbee::TextBufferChange change, QString oldText = QString() );
-    void onSelectionChanged( edbee::TextRangeSet *oldRangeSet );
-    void onLineDataChanged( int line, int length, int newLength );
+    void onTextChanged(edbee::TextBufferChange change, QString oldText = QString());
+    void onSelectionChanged(edbee::TextRangeSet *oldRangeSet);
+    void onLineDataChanged(size_t line, size_t length, size_t newLength);
 
     void updateAfterConfigChange();
 

--- a/edbee-lib/edbee/texteditorcontroller.h
+++ b/edbee-lib/edbee/texteditorcontroller.h
@@ -113,7 +113,7 @@ public slots:
     virtual void update();
 
     // scrolling
-    virtual void scrollPositionVisible(size_t xPos, size_t yPos);
+    virtual void scrollPositionVisible(int xPos, int yPos);
     virtual void scrollOffsetVisible(size_t offset);
     virtual void scrollCaretVisible();
 
@@ -128,6 +128,7 @@ public slots:
 
     // caret movements
     virtual void moveCaretTo(ptrdiff_t line, ptrdiff_t col, bool keepAnchors, size_t rangeIndex = std::string::npos);
+    virtual void moveCaretTo(size_t line, size_t col, bool keepAnchors, size_t rangeIndex = std::string::npos);
     virtual void moveCaretToOffset(size_t offset, bool keepAnchors, size_t rangeIndex=std::string::npos);
     virtual void moveCaretAndAnchorToOffset(size_t caret, size_t anchor, size_t rangeIndex = std::string::npos);
     virtual void addCaretAt(size_t line, size_t col);

--- a/edbee-lib/edbee/texteditorcontroller.h
+++ b/edbee-lib/edbee/texteditorcontroller.h
@@ -46,23 +46,22 @@ public:
         AutoScrollNever
     };
 
-
-    explicit TextEditorController( TextEditorWidget* widget = nullptr, QObject *parent = nullptr );
-    explicit TextEditorController( TextDocument* document, TextEditorWidget* widget = nullptr, QObject *parent = nullptr );
+    explicit TextEditorController(TextEditorWidget* widget = nullptr, QObject *parent = nullptr);
+    explicit TextEditorController(TextDocument* document, TextEditorWidget* widget = nullptr, QObject *parent = nullptr);
     virtual ~TextEditorController();
 
 // public method
     void notifyStateChange();
 
-    void giveTextDocument( TextDocument* doc );
-    void setTextDocument( TextDocument* doc );
+    void giveTextDocument(TextDocument* doc);
+    void setTextDocument(TextDocument* doc);
 
-    void setAutoScrollToCaret( AutoScrollToCaret autoScroll );
+    void setAutoScrollToCaret(AutoScrollToCaret autoScroll);
     virtual AutoScrollToCaret autoScrollToCaret() const;
 
     bool hasFocus();
-    QAction* createUnconnectedAction(const QString& command, const QString& text, const QIcon& icon=QIcon(), QObject* owner=0 );
-    QAction* createAction(const QString& command, const QString& text , const QIcon& icon=QIcon(), QObject* owner=0 );
+    QAction* createUnconnectedAction(const QString& command, const QString& text, const QIcon& icon = QIcon(), QObject* owner = nullptr);
+    QAction* createAction(const QString& command, const QString& text , const QIcon& icon=QIcon(), QObject* owner = nullptr);
 
 
 // getters
@@ -72,29 +71,29 @@ public:
     TextRenderer* textRenderer() const;
     TextRangeSet* borderedTextRanges() const;
 
-    void setKeyMap( TextEditorKeyMap* keyMap );
-    void giveKeyMap( TextEditorKeyMap* keyMap );
+    void setKeyMap(TextEditorKeyMap* keyMap);
+    void giveKeyMap(TextEditorKeyMap* keyMap);
     TextEditorKeyMap* keyMap() const;
-    void setCommandMap( TextEditorCommandMap* commandMap );
-    void giveCommandMap( TextEditorCommandMap* commandMap );
+    void setCommandMap(TextEditorCommandMap* commandMap);
+    void giveCommandMap(TextEditorCommandMap* commandMap);
     TextEditorCommandMap* commandMap() const;
     TextEditorWidget* widget() const;
     TextCaretCache* textCaretCache() const;
-    void giveTextSearcher( TextSearcher* searcher );
+    void giveTextSearcher(TextSearcher* searcher);
     TextSearcher* textSearcher();
     DynamicVariables* dynamicVariables() const;
 
 signals:
 
     /// This signal is fired if the statusbar needs updating
-    void updateStatusTextSignal( const QString& text );
+    void updateStatusTextSignal(const QString& text);
 
     /// This signal is fired if the textdocument changes.
-    void textDocumentChanged( edbee::TextDocument* oldDocument, edbee::TextDocument* newDocument );
+    void textDocumentChanged(edbee::TextDocument* oldDocument, edbee::TextDocument* newDocument);
 
     /// this method is executed when a command is going to be executed
-    void commandToBeExecuted( edbee::TextEditorCommand* command );
-    void commandExecuted( edbee::TextEditorCommand* command );
+    void commandToBeExecuted(edbee::TextEditorCommand* command);
+    void commandExecuted(edbee::TextEditorCommand* command);
 
     void backspacePressed();
 
@@ -109,30 +108,30 @@ public slots:
 public slots:
 
     // updates the status text
-    virtual void updateStatusText( const QString& extraText=QString() );
+    virtual void updateStatusText(const QString& extraText=QString());
 
     virtual void update();
 
     // scrolling
-    virtual void scrollPositionVisible( int xPos, int yPos );
-    virtual void scrollOffsetVisible( int offset );
+    virtual void scrollPositionVisible(size_t xPos, size_t yPos);
+    virtual void scrollOffsetVisible(size_t offset);
     virtual void scrollCaretVisible();
 
-    virtual void storeSelection( int coalesceId=0 );
+    virtual void storeSelection(int coalesceId = 0);
 
     // replace the given selection
-    virtual void replace( int offset, int length, const QString& text, int coalesceId, bool stickySelection=false);
-    virtual void replaceSelection(const QString& text, int coalesceId=0, bool stickySelection=false);
+    virtual void replace(size_t offset, size_t length, const QString& text, int coalesceId, bool stickySelection = false);
+    virtual void replaceSelection(const QString& text, int coalesceId=0, bool stickySelection = false);
     virtual void replaceSelection(const QStringList& texts, int coalesceId=0, bool stickySelection=false);
     virtual void replaceRangeSet(edbee::TextRangeSet& rangeSet, const QString& text, int coalesceId=0, bool stickySelection=false);
     virtual void replaceRangeSet(edbee::TextRangeSet& rangeSet, const QStringList& texts, int coalesceId=0, bool stickySelection=false);
 
     // caret movements
-    virtual void moveCaretTo( int line, int col, bool keepAnchors, int rangeIndex=-1 );
-    virtual void moveCaretToOffset( int offset, bool keepAnchors, int rangeIndex=-1 );
-    virtual void moveCaretAndAnchorToOffset(int caret, int anchor, int rangeIndex= -1 );
-    virtual void addCaretAt( int line, int col);
-    virtual void addCaretAtOffset( int offset );
+    virtual void moveCaretTo(ptrdiff_t line, ptrdiff_t col, bool keepAnchors, size_t rangeIndex = std::string::npos);
+    virtual void moveCaretToOffset(size_t offset, bool keepAnchors, size_t rangeIndex=std::string::npos);
+    virtual void moveCaretAndAnchorToOffset(size_t caret, size_t anchor, size_t rangeIndex = std::string::npos);
+    virtual void addCaretAt(size_t line, size_t col);
+    virtual void addCaretAtOffset(size_t offset);
     virtual void changeAndGiveTextSelection(edbee::TextRangeSet* rangeSet , int coalesceId = 0);
 
     // perform an undo

--- a/edbee-lib/edbee/texteditorwidget.cpp
+++ b/edbee-lib/edbee/texteditorwidget.cpp
@@ -19,7 +19,7 @@
 #include <QTimer>
 #include <QVBoxLayout>
 
-#include "edbee/commands/selectioncommand.h"
+//#include "edbee/commands/selectioncommand.h"
 #include "edbee/edbee.h"
 #include "edbee/texteditorcontroller.h"
 #include "edbee/models/change.h"
@@ -60,55 +60,52 @@ TextEditorWidget::TextEditorWidget(TextEditorController *controller, QWidget* pa
     scrollAreaRef_ = new class TextEditorScrollArea(this);
     scrollAreaRef_->setWidgetResizable(true);
 
-    editCompRef_   = new TextEditorComponent( controller_, scrollAreaRef_);
-    marginCompRef_ = new TextMarginComponent( this, scrollAreaRef_ );
+    editCompRef_   = new TextEditorComponent(controller_, scrollAreaRef_);
+    marginCompRef_ = new TextMarginComponent(this, scrollAreaRef_);
 
-
-    scrollAreaRef_->setWidget( editCompRef_ );
-    scrollAreaRef_->setLeftWidget( marginCompRef_ );
-//    scrollAreaRef_->setLeftWidget( new QLabel("Left",this) );//marginCompRef_ );
-//    scrollAreaRef_->setTopWidget( new QLabel("Top",this));
-//    scrollAreaRef_->setRightWidget( new QLabel("Right",this));
-//    scrollAreaRef_->setBottomWidget( new QLabel("Bottom",this));
+    scrollAreaRef_->setWidget(editCompRef_);
+    scrollAreaRef_->setLeftWidget(marginCompRef_);
+    // scrollAreaRef_->setLeftWidget( new QLabel("Left",this) );//marginCompRef_ );
+    // scrollAreaRef_->setTopWidget( new QLabel("Top",this));
+    // scrollAreaRef_->setRightWidget( new QLabel("Right",this));
+    // scrollAreaRef_->setBottomWidget( new QLabel("Bottom",this));
 
     QVBoxLayout* layout = new QVBoxLayout(this);
-    layout->addWidget( scrollAreaRef_ );
+    layout->addWidget(scrollAreaRef_);
     layout->setContentsMargins(0, 0, 0, 0);
 
     setLayout(layout);
-    setFocusProxy( editCompRef_ );
+    setFocusProxy(editCompRef_);
 
     /// TODO: Check if this works.. It could be possible the layout screws this
     /// If I add this before the setLayout everything hangs :S ...
-    autoCompleteCompRef_ = new TextEditorAutoCompleteComponent( controller_, editCompRef_, marginCompRef_ );
-
+    autoCompleteCompRef_ = new TextEditorAutoCompleteComponent(controller_, editCompRef_, marginCompRef_);
 
     marginCompRef_->init();
     connectHorizontalScrollBar();
     connectVerticalScrollBar();
-    connect( this, SIGNAL(horizontalScrollBarChanged(QScrollBar*)), SLOT(connectHorizontalScrollBar()) );
-    connect( this, SIGNAL(verticalScrollBarChanged(QScrollBar*)), SLOT(connectVerticalScrollBar()) );
-    connect( editCompRef_, SIGNAL(textKeyPressed()), autoCompleteCompRef_, SLOT(textKeyPressed()));
-    connect( controller_, SIGNAL(backspacePressed()), autoCompleteCompRef_, SLOT(backspacePressed()));
+    connect(this, SIGNAL(horizontalScrollBarChanged(QScrollBar*)), SLOT(connectHorizontalScrollBar()));
+    connect(this, SIGNAL(verticalScrollBarChanged(QScrollBar*)), SLOT(connectVerticalScrollBar()));
+    connect(editCompRef_, SIGNAL(textKeyPressed()), autoCompleteCompRef_, SLOT(textKeyPressed()));
+    connect(controller_, SIGNAL(backspacePressed()), autoCompleteCompRef_, SLOT(backspacePressed()));
 
-
-    setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     editCompRef_->installEventFilter(this);     // receive events for the ability to emit focus events
-
 }
+
 
 TextEditorWidget::TextEditorWidget(TextDocument *document, QWidget *parent)
     : TextEditorWidget(new TextEditorController(document, this, nullptr), parent)
 {
-
 }
+
 
 TextEditorWidget::TextEditorWidget(TextEditorConfig *config, QWidget *parent)
     : TextEditorWidget(new TextEditorController(new CharTextDocument(config), this, nullptr), parent)
 {
-
 }
+
 
 TextEditorWidget::TextEditorWidget(QWidget* parent)
     : TextEditorWidget(new TextEditorController(this, nullptr), parent)
@@ -127,7 +124,7 @@ TextEditorWidget::~TextEditorWidget()
 }
 
 
-/// This method makes sure the given position is visible
+/// Asures the given position is visible
 /// @param xposIn the position in text-editor 'coordinates'
 /// @param yPosIn the position in text-editor 'coordinates'
 void TextEditorWidget::scrollPositionVisible(int xPosIn, int yPosIn)
@@ -146,10 +143,10 @@ TextEditorController* TextEditorWidget::controller() const
 
 /// this method scrolls the top position to the given line
 /// @param line the line to scroll to
-void TextEditorWidget::scrollTopToLine(int line)
+void TextEditorWidget::scrollTopToLine(size_t line)
 {
-    int yPos = line * textRenderer()->lineHeight();
-    scrollAreaRef_->verticalScrollBar()->setValue( qMax(0,yPos) );
+    int yPos = static_cast<int>(line * textRenderer()->lineHeight());
+    scrollAreaRef_->verticalScrollBar()->setValue(qMax(0, yPos));
 //    scrollAreaRef_->ensureVisible( 0,  qMax(0,yPos) );
 }
 
@@ -168,7 +165,7 @@ TextEditorCommandMap* TextEditorWidget::commandMap() const
 }
 
 
-/// return the associated keymap
+/// Returns the associated keymap
 TextEditorKeyMap* TextEditorWidget::keyMap() const
 {
     return controller_->keyMap();
@@ -222,14 +219,14 @@ TextEditorAutoCompleteComponent *TextEditorWidget::autoCompleteComponent() const
     return autoCompleteCompRef_;
 }
 
-/// This method resets the caret time
+/// Resets the caret time
 void TextEditorWidget::resetCaretTime()
 {
     editCompRef_->resetCaretTime();
 }
 
 
-/// This method performs a full update. Which means it calibrates the scrollbars
+/// Rerforms a full update. Which means it calibrates the scrollbars
 /// invalidates all caches, redraws the screen and updates the scrollbars
 void TextEditorWidget::fullUpdate()
 {
@@ -245,7 +242,7 @@ QScrollBar* TextEditorWidget::horizontalScrollBar() const
 }
 
 
-/// returns the vertical scrollbar
+/// Returns the vertical scrollbar
 QScrollBar* TextEditorWidget::verticalScrollBar() const
 {
     return scrollAreaRef_->verticalScrollBar();
@@ -271,11 +268,13 @@ void TextEditorWidget::setHorizontalScrollBar(QScrollBar* scrollBar)
     emit horizontalScrollBarChanged(scrollBar);
 }
 
+
 /// Returns the auto scroll margin
 int TextEditorWidget::autoScrollMargin() const
 {
     return autoScrollMargin_;
 }
+
 
 /// Sets the auto scrollmargin
 void TextEditorWidget::setAutoScrollMargin(int amount)
@@ -283,9 +282,11 @@ void TextEditorWidget::setAutoScrollMargin(int amount)
     autoScrollMargin_ = amount;
 }
 
+
+/// Sets the text for the placeholder text document
 void TextEditorWidget::setPlaceholderText(const QString &text)
 {
-    this->textRenderer()->placeholderTextDocument()->setText(text);
+    textRenderer()->placeholderTextDocument()->setText(text);
 }
 
 
@@ -294,6 +295,7 @@ bool TextEditorWidget::readonly() const
 {
     return readonly_;
 }
+
 
 /// Set the readonly status
 void TextEditorWidget::setReadonly(bool value)
@@ -310,16 +312,17 @@ void TextEditorWidget::resizeEvent(QResizeEvent* event)
     updateRendererViewport();
 }
 
+
 /// a basic event-filter for receiving focus-events of the editor
 /// @param obj the object to filter the events for
 /// @param event the event to filter
 bool TextEditorWidget::eventFilter(QObject* obj, QEvent* event)
 {
-    if( obj == editCompRef_) {
-        if ( event->type() == QEvent::FocusIn ) {
-            emit focusIn( this );
+    if (obj == editCompRef_) {
+        if (event->type() == QEvent::FocusIn) {
+            emit focusIn(this);
         }
-        if ( event->type() == QEvent::FocusOut ) {
+        if (event->type() == QEvent::FocusOut) {
             emit focusOut(this);
         }
     }
@@ -334,14 +337,14 @@ bool TextEditorWidget::eventFilter(QObject* obj, QEvent* event)
 /// Connects the vertical scrollbar so it updates the rendering viewport
 void TextEditorWidget::connectVerticalScrollBar()
 {
-    connect( verticalScrollBar(), SIGNAL(valueChanged(int)), SLOT(updateRendererViewport()) );
+    connect(verticalScrollBar(), SIGNAL(valueChanged(int)), SLOT(updateRendererViewport()));
 }
 
 
 /// Connects the horizontal scrollbar so it updates the rendering viewport
 void TextEditorWidget::connectHorizontalScrollBar()
 {
-    connect( horizontalScrollBar(), SIGNAL(valueChanged(int)), SLOT(updateRendererViewport()) );
+    connect(horizontalScrollBar(), SIGNAL(valueChanged(int)), SLOT(updateRendererViewport()));
 }
 
 
@@ -352,7 +355,7 @@ void TextEditorWidget::connectHorizontalScrollBar()
 
 /// updates the given line so it will be repainted
 /// @Param offset the offset of the line that needs repainting
-void TextEditorWidget::updateLineAtOffset(int offset)
+void TextEditorWidget::updateLineAtOffset(size_t offset)
 {
     editCompRef_->updateLineAtOffset(offset);
     marginCompRef_->updateLineAtOffset(offset);
@@ -362,20 +365,20 @@ void TextEditorWidget::updateLineAtOffset(int offset)
 /// updates the character before and at the given offset
 /// @param offset the offset of the area to repaint.
 /// @param width the width of the area to update (default is 8 pixels)
-void TextEditorWidget::updateAreaAroundOffset(int offset, int width )
+void TextEditorWidget::updateAreaAroundOffset(size_t offset, int width)
 {
-    editCompRef_->updateAreaAroundOffset(offset,width);
+    editCompRef_->updateAreaAroundOffset(offset, width);
     marginCompRef_->updateLineAtOffset(offset);
 }
 
 
-/// This method repaints the given lines
+/// Repaints the given lines
 /// @param line the line that updates the given line
 /// @param length the number of lines to update. (default is 1 line)
-void TextEditorWidget::updateLine(int line, int length)
+void TextEditorWidget::updateLine(size_t line, size_t length)
 {
-    editCompRef_->updateLine(line,length);
-    marginCompRef_->updateLine(line,length);
+    editCompRef_->updateLine(line, length);
+    marginCompRef_->updateLine(line, length);
 
 }
 

--- a/edbee-lib/edbee/texteditorwidget.cpp
+++ b/edbee-lib/edbee/texteditorwidget.cpp
@@ -145,7 +145,7 @@ TextEditorController* TextEditorWidget::controller() const
 /// @param line the line to scroll to
 void TextEditorWidget::scrollTopToLine(size_t line)
 {
-    int yPos = static_cast<int>(line * textRenderer()->lineHeight());
+    int yPos = static_cast<int>(line) * textRenderer()->lineHeight();
     scrollAreaRef_->verticalScrollBar()->setValue(qMax(0, yPos));
 //    scrollAreaRef_->ensureVisible( 0,  qMax(0,yPos) );
 }

--- a/edbee-lib/edbee/texteditorwidget.h
+++ b/edbee-lib/edbee/texteditorwidget.h
@@ -37,13 +37,13 @@ class EDBEE_EXPORT TextEditorWidget : public QWidget
     Q_OBJECT
 public:
 
-    explicit TextEditorWidget(TextEditorController *controller, QWidget *parent = 0);
-    explicit TextEditorWidget(TextDocument *document, QWidget *parent = 0);
-    explicit TextEditorWidget(TextEditorConfig *config, QWidget *parent = 0);
-    explicit TextEditorWidget(QWidget *parent = 0);
+    explicit TextEditorWidget(TextEditorController *controller, QWidget *parent = nullptr);
+    explicit TextEditorWidget(TextDocument *document, QWidget *parent = nullptr);
+    explicit TextEditorWidget(TextEditorConfig *config, QWidget *parent = nullptr);
+    explicit TextEditorWidget(QWidget *parent = nullptr);
     virtual ~TextEditorWidget();
-
-    void scrollPositionVisible( int xPosIn, int yPosIn );
+    
+    void scrollPositionVisible(int xPosIn, int yPosIn);
 
     // a whole bunch of getters
     TextEditorController* controller() const;
@@ -63,10 +63,10 @@ public:
 
     QScrollBar* horizontalScrollBar() const;
     QScrollBar* verticalScrollBar() const;
-    void setVerticalScrollBar( QScrollBar* scrollBar );
-    void setHorizontalScrollBar( QScrollBar* scrollBar );
+    void setVerticalScrollBar(QScrollBar* scrollBar);
+    void setHorizontalScrollBar(QScrollBar* scrollBar);
 	int autoScrollMargin() const;
-    void setAutoScrollMargin(int amount=50);
+    void setAutoScrollMargin(int amount = 50);
     void setPlaceholderText(const QString& text);
 
     virtual bool readonly() const;
@@ -76,14 +76,14 @@ public:
 protected:
 
     virtual void resizeEvent(QResizeEvent* event);
-    bool eventFilter(QObject *obj, QEvent *event );
+    bool eventFilter(QObject *obj, QEvent *event);
 
 signals:
     void focusIn(QWidget* event);
     void focusOut(QWidget* event);
 
-    void verticalScrollBarChanged( QScrollBar* newScrollBar );
-    void horizontalScrollBarChanged(  QScrollBar* newScrollBar );
+    void verticalScrollBarChanged(QScrollBar* newScrollBar);
+    void horizontalScrollBarChanged(QScrollBar* newScrollBar);
 
 protected slots:
 
@@ -92,10 +92,10 @@ protected slots:
 
 public slots:
 
-    void scrollTopToLine( int line );
-    virtual void updateLineAtOffset(int offset);
-    virtual void updateAreaAroundOffset(int offset, int width=8);
-    virtual void updateLine( int line, int length=1 );
+    void scrollTopToLine(size_t line);
+    virtual void updateLineAtOffset(size_t offset);
+    virtual void updateAreaAroundOffset(size_t offset, int width = 8);
+    virtual void updateLine(size_t line, size_t length = 1);
     virtual void updateComponents();
 
     virtual void updateGeometryComponents();
@@ -104,11 +104,10 @@ public slots:
 
 private:
 
-    TextEditorController* controller_;                    ///< This method returns the controller
-
-    TextEditorScrollArea* scrollAreaRef_;                 ///< The scrollarea of the widget
-    TextEditorComponent* editCompRef_;                    ///< The editor ref
-    TextMarginComponent* marginCompRef_;                  ///< The margin components
+    TextEditorController* controller_;                     ///< This controller of the widget
+    TextEditorScrollArea* scrollAreaRef_;                  ///< The scrollarea of the widget
+    TextEditorComponent* editCompRef_;                     ///< The editor ref
+    TextMarginComponent* marginCompRef_;                   ///< The margin components
     TextEditorAutoCompleteComponent* autoCompleteCompRef_; ///< The autocomplete list widget
 
     int autoScrollMargin_;                                 ///< Customize the autoscroll margin

--- a/edbee-lib/edbee/util/gapvector.h
+++ b/edbee-lib/edbee/util/gapvector.h
@@ -259,7 +259,7 @@ void copyRange(QChar* data, Tsize offset, size_t length) const {
 }
 
 
-/// This method returns a direct pointer to the 0-terminated buffer
+/// Returns a direct pointer to the 0-terminated buffer
 /// This pointer is only valid as long as the buffer doesn't change
 /// WARNING, this method MOVES the gap! Which means this method should NOT be used for a lot of operations
 T* data() {
@@ -495,7 +495,7 @@ public:
 }
 
 
-/// this method replaces the given items with a single data item
+/// Replaces the given items with a single data item
 /// @param offset the offset of the items to replace
 /// @param lenth the number of items to replace
 /// @param newLength the number of times to repeat data
@@ -506,13 +506,13 @@ void fill(Tsize offset, Tsize length, const T& data, Tsize newLength) {
   }
 }
 
-/// convenient append method
+/// Appends an item
 void append(T t) {
   items_.append(t);
 }
 
 
-/// another append method
+/// Appends a list of items
 void append(const T* t, Tsize length) {
   for (Tsize i = 0; i < length; i++) {
     items_.append(t[i]);
@@ -520,19 +520,19 @@ void append(const T* t, Tsize length) {
 }
 
 
-/// This method returns the item at the given index
+/// Returns the item at the given index
 T at(Tsize offset) const {
   return items_.at(offset);
 }
 
 
-/// This method sets an item at the given index
+/// Sets an item at the given index
 void set(Tsize offset, const T& value) {
   items_.replace(offset,value);
 }
 
 
-/// This method return an index
+/// Return an index
 T& operator[](Tsize offset) {
   return items_[offset];
 }

--- a/edbee-lib/edbee/util/gapvector.h
+++ b/edbee-lib/edbee/util/gapvector.h
@@ -212,7 +212,7 @@ public:
 
 
     /// This method return an index
-    T& operator[]( size_t offset ) {
+    T& operator[](size_t offset) const {
         Q_ASSERT( offset < length() );
         if( offset < gapBegin_ ) {
             return items_[offset];

--- a/edbee-lib/edbee/util/gapvector.h
+++ b/edbee-lib/edbee/util/gapvector.h
@@ -17,388 +17,388 @@ namespace edbee {
 template <typename T, typename Tsize = size_t>
 class EDBEE_EXPORT GapVector {
 public:
-  GapVector(Tsize capacity = 16) : items_(nullptr), capacity_(0), gapBegin_(0), gapEnd_(0)  {
-    items_    = new T[capacity];
-  capacity_ = capacity;
-  gapBegin_ = 0;
-  gapEnd_   = capacity;
-  growSize_ = 16;
-}
+    GapVector(Tsize capacity = 16) : items_(nullptr), capacity_(0), gapBegin_(0), gapEnd_(0)  {
+      items_    = new T[capacity];
+      capacity_ = capacity;
+      gapBegin_ = 0;
+      gapEnd_   = capacity;
+      growSize_ = 16;
+    }
 
 
-~GapVector() {
-  delete[] items_;
-}
+    ~GapVector() {
+        delete[] items_;
+    }
 
 
-/// returns the used length of the data
-inline Tsize length() const { return capacity_ - gapEnd_ + gapBegin_; }
-inline Tsize gapSize() const { return gapEnd_ - gapBegin_; }
-inline Tsize gapBegin() const { return gapBegin_; }
-inline Tsize gapEnd() const { return gapEnd_; }
-inline Tsize capacity() const { return capacity_; }
+    /// returns the used length of the data
+    inline Tsize length() const { return capacity_ - gapEnd_ + gapBegin_; }
+    inline Tsize gapSize() const { return gapEnd_ - gapBegin_; }
+    inline Tsize gapBegin() const { return gapBegin_; }
+    inline Tsize gapEnd() const { return gapEnd_; }
+    inline Tsize capacity() const { return capacity_; }
 
 
-/// clears the data
-void clear()
-{
-  delete[] items_;
-  capacity_ = 16;
-  items_    = new T[capacity_];
-  gapBegin_ = 0;
-  gapEnd_   = capacity_;
-  growSize_ = 16;
-}
+    /// clears the data
+    void clear()
+    {
+        delete[] items_;
+        capacity_ = 16;
+        items_    = new T[capacity_];
+        gapBegin_ = 0;
+        gapEnd_   = capacity_;
+        growSize_ = 16;
+    }
 
 
 protected:
 
-/// Replaces the given text with the given data.
-/// because the length of the source and target is the same in this method
-/// no gap-moving is required
-/// @param offset the target to move the data to
-/// @param length the number of items to replace
-/// @param data the data pointer with the source data
-void replace(Tsize offset, size_t length, const T* data) {
-  Q_ASSERT(offset <= this->length());
-Q_ASSERT(offset + length <= capacity_);
+    /// Replaces the given text with the given data.
+    /// because the length of the source and target is the same in this method
+    /// no gap-moving is required
+    /// @param offset the target to move the data to
+    /// @param length the number of items to replace
+    /// @param data the data pointer with the source data
+    void replace(Tsize offset, size_t length, const T* data) {
+        Q_ASSERT(offset <= this->length());
+        Q_ASSERT(offset + length <= capacity_);
 
-// copy the first part
-if (offset < gapBegin()) {
-  Tsize len = qMin(gapBegin_ - offset, length); // issue 141, added -offset
-  memcpy(items_ + offset, data, static_cast<Tsize>(sizeof(T)) * len);
-  data      += len;   // increase the pointer
-  offset    += len;
-  length    -= len;
-}
+        // copy the first part
+        if (offset < gapBegin()) {
+            Tsize len = qMin(gapBegin_ - offset, length); // issue 141, added -offset
+            memcpy(items_ + offset, data, static_cast<Tsize>(sizeof(T)) * len);
+            data      += len;   // increase the pointer
+            offset    += len;
+            length    -= len;
+        }
 
-if (0 < length) {
-  memcpy(items_ + offset + gapSize(), data, sizeof(T)*static_cast<Tsize>(length));
-}
+        if (0 < length) {
+            memcpy(items_ + offset + gapSize(), data, sizeof(T)*static_cast<Tsize>(length));
+        }
     }
 
 
-/// Replaces the given text with the given data.
-/// because the length of the source and target is the same in this method
-/// no gap-moving is required
-/// @param offset the target to move the data to
-/// @param length the number of items to replace
-/// @param data the data pointer with the source data
-void fill(Tsize offset, size_t length, const T& data) {
-  Q_ASSERT(offset <= this->length());
-  Q_ASSERT(offset + length <= capacity_);
+    /// Replaces the given text with the given data.
+    /// because the length of the source and target is the same in this method
+    /// no gap-moving is required
+    /// @param offset the target to move the data to
+    /// @param length the number of items to replace
+    /// @param data the data pointer with the source data
+    void fill(Tsize offset, size_t length, const T& data) {
+        Q_ASSERT(offset <= this->length());
+        Q_ASSERT(offset + length <= capacity_);
 
-  // copy the first part
-  if (offset < gapBegin()) {
-    Tsize len = qMin(gapBegin_ - offset, length);
-    for (Tsize i = 0; i < len; ++i) { items_ [offset + i] = data; }
-    offset    += len;
-    length    -= len;
-  }
+        // copy the first part
+        if (offset < gapBegin()) {
+            Tsize len = qMin(gapBegin_ - offset, length);
+            for (Tsize i = 0; i < len; ++i) { items_ [offset + i] = data; }
+            offset    += len;
+            length    -= len;
+        }
 
-  if (0 < length) {
-    offset += gapSize();
-    for (Tsize i = 0; i < length; ++i) { items_ [offset + i] = data; }
-  }
-}
+        if (0 < length) {
+            offset += gapSize();
+            for (Tsize i = 0; i < length; ++i) { items_ [offset + i] = data; }
+        }
+    }
 
 
 public:
 
-/// Replaces the given items
-/// @param offset the offset of the items to replace
-/// @param length the number of items to replace
-/// @param data an array with new items
-/// @param newLength the number of items in the new array
-void replace(Tsize offset, size_t length, const T* data, size_t newLength) {
-  Tsize currentLength=this->length();
-  Q_ASSERT((offset+length) <= currentLength);
-  Q_ASSERT(offset + length <= capacity_);
-  Q_UNUSED(currentLength);
+    /// Replaces the given items
+    /// @param offset the offset of the items to replace
+    /// @param length the number of items to replace
+    /// @param data an array with new items
+    /// @param newLength the number of items in the new array
+    void replace(Tsize offset, size_t length, const T* data, size_t newLength) {
+        Tsize currentLength=this->length();
+        Q_ASSERT((offset+length) <= currentLength);
+        Q_ASSERT(offset + length <= capacity_);
+        Q_UNUSED(currentLength);
 
-Tsize gapSize = this->gapSize();
+        Tsize gapSize = this->gapSize();
 
-// Is it a 'delete' or 'insert' or 'replace' operation
+        // Is it a 'delete' or 'insert' or 'replace' operation
 
-// a replace operation (do not perform gap moving)
-if (length == newLength) {
-  replace(offset, length, data);
+        // a replace operation (do not perform gap moving)
+        if (length == newLength) {
+            replace(offset, length, data);
 
-  // insert operation
-} else if (length < newLength) {
-  Tsize gapSizeRequired = newLength - length;
-  ensureGapSize(gapSizeRequired);
-  moveGapTo(offset + length);
-  memcpy(items_ + offset, data, sizeof(T) * static_cast<Tsize>(newLength));
-  gapBegin_ = offset + newLength;
+        // insert operation
+        } else if (length < newLength) {
+            Tsize gapSizeRequired = newLength - length;
+            ensureGapSize(gapSizeRequired);
+            moveGapTo(offset + length);
+            memcpy(items_ + offset, data, sizeof(T) * static_cast<Tsize>(newLength));
+            gapBegin_ = offset + newLength;
 
-  // delete operation
-} else {
-  moveGapTo(offset);
-  memcpy(items_ + offset, data, sizeof(T) * static_cast<Tsize>(newLength));
-  gapBegin_ = offset + newLength;
-  gapEnd_   = offset + gapSize + length;
-}
+        // delete operation
+        } else {
+            moveGapTo(offset);
+            memcpy(items_ + offset, data, sizeof(T) * static_cast<Tsize>(newLength));
+            gapBegin_ = offset + newLength;
+            gapEnd_   = offset + gapSize + length;
+        }
 
-Q_ASSERT(gapBegin_ <= gapEnd_);
-Q_ASSERT(this->gapSize() <= capacity_);
-Q_ASSERT(this->length() <= capacity_);
+        Q_ASSERT(gapBegin_ <= gapEnd_);
+        Q_ASSERT(this->gapSize() <= capacity_);
+        Q_ASSERT(this->length() <= capacity_);
     }
 
 
-/// Replaces the given items with a single data item
-/// @param offset the offset of the items to replace
-/// @param lenth the number of items to replace
-/// @param newLength the number of times to repeat data
-void fill(Tsize offset, size_t length, const T& data, size_t newLength) {
-  Tsize currentLength=this->length();
-  Q_ASSERT((offset+length) <= currentLength);
-  Q_ASSERT(offset + length <= capacity_);
-  Q_UNUSED(currentLength);
+    /// Replaces the given items with a single data item
+    /// @param offset the offset of the items to replace
+    /// @param lenth the number of items to replace
+    /// @param newLength the number of times to repeat data
+    void fill(Tsize offset, size_t length, const T& data, size_t newLength) {
+        Tsize currentLength=this->length();
+        Q_ASSERT((offset+length) <= currentLength);
+        Q_ASSERT(offset + length <= capacity_);
+        Q_UNUSED(currentLength);
 
-  Tsize gapSize = this->gapSize();
+        Tsize gapSize = this->gapSize();
 
-  // Is it a 'delete' or 'insert' or 'replace' operation
+        // Is it a 'delete' or 'insert' or 'replace' operation
 
-  // a replace operation (do not perform gap moving)
-  if (length == newLength) {
-    fill(offset, length, data);
+        // a replace operation (do not perform gap moving)
+        if (length == newLength) {
+            fill(offset, length, data);
 
-    // insert operation
-  } else if (length < newLength) {
-    Tsize gapSizeRequired = newLength - length;
-    ensureGapSize(gapSizeRequired);
-    moveGapTo( offset + length);
-    for (Tsize i = 0; i < newLength; ++i) { items_[offset+i] = data; }
-    gapBegin_ = offset + newLength;
+            // insert operation
+        } else if (length < newLength) {
+            Tsize gapSizeRequired = newLength - length;
+            ensureGapSize(gapSizeRequired);
+            moveGapTo( offset + length);
+            for (Tsize i = 0; i < newLength; ++i) { items_[offset+i] = data; }
+            gapBegin_ = offset + newLength;
 
-    // delete operation
-  } else {
-    moveGapTo(offset);
-    for (Tsize i = 0; i < newLength; ++i) { items_[offset+i] = data; }
-    gapBegin_ = offset + newLength;
-    gapEnd_   = offset + gapSize + length;
-  }
+            // delete operation
+        } else {
+            moveGapTo(offset);
+            for (Tsize i = 0; i < newLength; ++i) { items_[offset+i] = data; }
+            gapBegin_ = offset + newLength;
+            gapEnd_   = offset + gapSize + length;
+        }
 
-  Q_ASSERT(gapBegin_ <= gapEnd_);
-  Q_ASSERT(this->gapSize() <= capacity_);
-  Q_ASSERT(this->length() <= capacity_);
-}
-
-
-/// convenient append method
-void append(T t) {
-  replace(length(), 0, &t, 1);
-}
-
-
-/// another append method
-void append(const T* t, Tsize length) {
-  replace(this->length(), 0, t, length);
-}
-
-
-/// Returns the item at the given index
-T at(Tsize offset) const {
-  Q_ASSERT(offset < length());
-  if (offset < gapBegin_) {
-    return items_[offset];
-  } else {
-    return items_[gapEnd_ + offset - gapBegin_];
-  }
-}
-
-
-/// Sets an item at the given index
-void set(Tsize offset, const T& value) {
-  Q_ASSERT(offset < length());
-  if (offset < gapBegin_) {
-    items_[offset] = value;
-  } else {
-    items_[gapEnd_ + offset - gapBegin_] = value;
-  }
-}
-
-
-/// Returns an index
-T& operator[](Tsize offset) const {
-  Q_ASSERT(offset < length());
-  if (offset < gapBegin_) {
-    return items_[offset];
-  } else {
-    return items_[gapEnd_ + offset - gapBegin_];
-  }
-}
-
-
-/// Returns the 'raw' element at the given location
-/// This method does NOT take in account the gap
-T& rawAt(Tsize index) {
-  Q_ASSERT(index < capacity_);
-  return items_[index];
-}
-
-
-/// Copies the given range to the data pointer
-void copyRange(QChar* data, Tsize offset, size_t length) const {
-  Q_ASSERT(offset < this->length());
-  Q_ASSERT((offset + length) <= this->length());
-
-  // copy the first part
-  if (offset < gapBegin()) {
-    Tsize len = qMin(gapBegin_ - offset, length);
-    memcpy(data, items_ + offset, sizeof(T)*static_cast<Tsize>(len));
-    data      += len;   // increase the pointer
-    offset    += len;
-    length    -= len;
-  }
-
-  if (length > 0) {
-    memcpy(data, items_ + offset + gapSize(), sizeof(T)*static_cast<Tsize>(length));
-  }
-}
-
-
-/// Returns a direct pointer to the 0-terminated buffer
-/// This pointer is only valid as long as the buffer doesn't change
-/// WARNING, this method MOVES the gap! Which means this method should NOT be used for a lot of operations
-T* data() {
-  ensureGapSize(1);
-  moveGapTo(length());
-  items_[length()] = QChar(); // a \0 character
-  return items_;
-}
-
-
-//// moves the gap to the given position
-//// Warning when the gap is moved after the length the gap shrinks
-void moveGapTo(Tsize offset) {
-  Q_ASSERT(offset <= capacity_);
-  Q_ASSERT(offset <= length());
-  if (offset != gapBegin_) {
-    Tsize gapSize = this->gapSize();
-
-    // move the the data right after the gap
-    if (offset < gapBegin_) {
-      memmove(items_ + offset + gapSize, items_ + offset, sizeof(T) * (gapBegin_ - offset));   // memmove( target, source, size )
-    } else {
-      memmove(items_ + gapBegin_, items_ + gapEnd_, sizeof(T) * (offset - gapBegin_));  // memmove( target, source, size )
+        Q_ASSERT(gapBegin_ <= gapEnd_);
+        Q_ASSERT(this->gapSize() <= capacity_);
+        Q_ASSERT(this->length() <= capacity_);
     }
-    gapBegin_ = offset;
-    gapEnd_   = gapBegin_ + gapSize; // qMin( gapBegin_ + gapSize, capacity_ );
 
-  }
-  Q_ASSERT(gapBegin_ <= gapEnd_);
+
+    /// convenient append method
+    void append(T t) {
+        replace(length(), 0, &t, 1);
+    }
+
+
+    /// another append method
+    void append(const T* t, Tsize length) {
+        replace(this->length(), 0, t, length);
+    }
+
+
+    /// Returns the item at the given index
+    T at(Tsize offset) const {
+        Q_ASSERT(offset < length());
+        if (offset < gapBegin_) {
+            return items_[offset];
+        } else {
+            return items_[gapEnd_ + offset - gapBegin_];
+        }
+    }
+
+
+    /// Sets an item at the given index
+    void set(Tsize offset, const T& value) {
+        Q_ASSERT(offset < length());
+        if (offset < gapBegin_) {
+            items_[offset] = value;
+        } else {
+            items_[gapEnd_ + offset - gapBegin_] = value;
+        }
+    }
+
+
+    /// Returns an index
+    T& operator[](Tsize offset) const {
+        Q_ASSERT(offset < length());
+        if (offset < gapBegin_) {
+            return items_[offset];
+        } else {
+            return items_[gapEnd_ + offset - gapBegin_];
+        }
+    }
+
+
+    /// Returns the 'raw' element at the given location
+    /// This method does NOT take in account the gap
+    T& rawAt(Tsize index) {
+        Q_ASSERT(index < capacity_);
+        return items_[index];
+    }
+
+
+    /// Copies the given range to the data pointer
+    void copyRange(QChar* data, Tsize offset, size_t length) const {
+        Q_ASSERT(offset < this->length());
+        Q_ASSERT((offset + length) <= this->length());
+
+        // copy the first part
+        if (offset < gapBegin()) {
+            Tsize len = qMin(gapBegin_ - offset, length);
+            memcpy(data, items_ + offset, sizeof(T)*static_cast<Tsize>(len));
+            data      += len;   // increase the pointer
+            offset    += len;
+            length    -= len;
+        }
+
+        if (length > 0) {
+            memcpy(data, items_ + offset + gapSize(), sizeof(T)*static_cast<Tsize>(length));
+        }
+    }
+
+
+    /// Returns a direct pointer to the 0-terminated buffer
+    /// This pointer is only valid as long as the buffer doesn't change
+    /// WARNING, this method MOVES the gap! Which means this method should NOT be used for a lot of operations
+    T* data() {
+        ensureGapSize(1);
+        moveGapTo(length());
+        items_[length()] = QChar(); // a \0 character
+        return items_;
+    }
+
+
+    //// moves the gap to the given position
+    //// Warning when the gap is moved after the length the gap shrinks
+    void moveGapTo(Tsize offset) {
+        Q_ASSERT(offset <= capacity_);
+        Q_ASSERT(offset <= length());
+        if (offset != gapBegin_) {
+            Tsize gapSize = this->gapSize();
+
+            // move the the data right after the gap
+            if (offset < gapBegin_) {
+                memmove(items_ + offset + gapSize, items_ + offset, sizeof(T) * (gapBegin_ - offset));   // memmove( target, source, size )
+            } else {
+                memmove(items_ + gapBegin_, items_ + gapEnd_, sizeof(T) * (offset - gapBegin_));  // memmove( target, source, size )
+            }
+            gapBegin_ = offset;
+            gapEnd_   = gapBegin_ + gapSize; // qMin( gapBegin_ + gapSize, capacity_ );
+
+        }
+        Q_ASSERT(gapBegin_ <= gapEnd_);
 
 #ifdef GAP_VECTOR_CLEAR_GAP
-  memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
+        memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
 #endif
-}
+    }
 
 
-/// Mkes sure there's enough room for the insertation
-void ensureGapSize(Tsize requiredSize) {
-  if (gapSize() < requiredSize) {
-    while (growSize_ < capacity_ / 6) { growSize_ *= 2; }
-    resize(capacity_ + requiredSize + growSize_ - gapSize());
-  }
-}
+    /// Mkes sure there's enough room for the insertation
+    void ensureGapSize(Tsize requiredSize) {
+        if (gapSize() < requiredSize) {
+            while (growSize_ < capacity_ / 6) { growSize_ *= 2; }
+            resize(capacity_ + requiredSize + growSize_ - gapSize());
+        }
+    }
 
 
-/// resizes the array of data
-void resize(Tsize newSize)
-{
-  if (capacity_ >= newSize) return;
+    /// resizes the array of data
+    void resize(Tsize newSize)
+    {
+        if (capacity_ >= newSize) return;
 
-  Tsize lengte = length();
-  Q_ASSERT(lengte <= capacity_);
-  /// TODO: optimize, so data is moved only once
-  /// in other words, gap movement is not required over here!!
-  /// this can be done with 2 memcopies
-  //qlog_info() << "BEGIN resize: capacity =" << capacity_<< " => " << newSize;
+        Tsize lengte = length();
+        Q_ASSERT(lengte <= capacity_);
+        /// TODO: optimize, so data is moved only once
+        /// in other words, gap movement is not required over here!!
+        /// this can be done with 2 memcopies
+        //qlog_info() << "BEGIN resize: capacity =" << capacity_<< " => " << newSize;
 
-  moveGapTo(lengte);
-  T *newChars = new T[newSize];
+        moveGapTo(lengte);
+        T *newChars = new T[newSize];
 
-  if (capacity_ > 0) {
-    memmove(newChars, items_, sizeof(T) * lengte);
-    delete[] items_;
-  }
-  items_ = newChars;
-  capacity_ = newSize;
-  gapEnd_   = newSize;
+        if (capacity_ > 0) {
+            memmove(newChars, items_, sizeof(T) * lengte);
+            delete[] items_;
+        }
+        items_ = newChars;
+        capacity_ = newSize;
+        gapEnd_   = newSize;
 
-  // DEBUG gapsize
+// DEBUG gapsize
 #ifdef GAP_VECTOR_CLEAR_GAP
-  memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
+        memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
 #endif
-}
-
-
-/// sets the growsize. The growsize if the amount to reserve extra
-void setGrowSize(Tsize size) { growSize_ = size; }
-
-/// returns the growsize
-Tsize growSize() { return growSize_; }
-
-
-/// Converts the 'gap-buffer' to a unit-test debugging string
-QString getUnitTestString(QChar gapChar = '_') const {
-  QString s;
-  Tsize gapBegin = this->gapBegin();
-  Tsize gapEnd   = this->gapEnd();
-  Tsize capacity = this->capacity();
-
-  for (Tsize i = 0; i < gapBegin; ++i) {
-    if (items_[i].isNull()) {
-      s.append("@");
-    } else {
-      s.append(items_[i]);
     }
-  }
-  s.append( "[" );
-  for (Tsize i = gapBegin; i < gapEnd; ++i) {
-    s.append(gapChar);
-  }
-  s.append( ">" );
-  for (Tsize i=gapEnd; i<capacity; ++i) {
-    if (items_[i].isNull()) {
-      s.append("@");
-    } else {
-      s.append(items_[i]);
+
+
+    /// sets the growsize. The growsize if the amount to reserve extra
+    void setGrowSize(Tsize size) { growSize_ = size; }
+
+    /// returns the growsize
+    Tsize growSize() { return growSize_; }
+
+
+    /// Converts the 'gap-buffer' to a unit-test debugging string
+    QString getUnitTestString(QChar gapChar = '_') const {
+        QString s;
+        Tsize gapBegin = this->gapBegin();
+        Tsize gapEnd   = this->gapEnd();
+        Tsize capacity = this->capacity();
+
+        for (Tsize i = 0; i < gapBegin; ++i) {
+            if (items_[i].isNull()) {
+                s.append("@");
+            } else {
+                s.append(items_[i]);
+            }
+        }
+        s.append( "[" );
+        for (Tsize i = gapBegin; i < gapEnd; ++i) {
+            s.append(gapChar);
+        }
+        s.append( ">" );
+        for (Tsize i=gapEnd; i<capacity; ++i) {
+            if (items_[i].isNull()) {
+                s.append("@");
+            } else {
+                s.append(items_[i]);
+            }
+        }
+        return s;
     }
-  }
-  return s;
-}
 
 
-/// Converts the 'gap-buffer' to a unit-test debugging string
-QString getUnitTestString2() const {
-  QString s;
-  Tsize gapBegin = this->gapBegin();
-  Tsize gapEnd   = this->gapEnd();
-  Tsize capacity = this->capacity();
+    /// Converts the 'gap-buffer' to a unit-test debugging string
+    QString getUnitTestString2() const {
+        QString s;
+        Tsize gapBegin = this->gapBegin();
+        Tsize gapEnd   = this->gapEnd();
+        Tsize capacity = this->capacity();
 
-  for (Tsize i = 0; i < capacity; i++) {
-    if (i) { s.append(","); }
-    if (gapEnd == i) s.append(">");
-    s.append(QStringLiteral("%1").arg( "X" ));
-    if (gapBegin == i) s.append("[");
-  }
+        for (Tsize i = 0; i < capacity; i++) {
+            if (i) { s.append(","); }
+            if (gapEnd == i) s.append(">");
+            s.append(QStringLiteral("%1").arg( "X" ));
+            if (gapBegin == i) s.append("[");
+        }
 
-  s.append(" | ");
-  s.append(QStringLiteral("gapBegin: %1, gapEnd: %2, capacity: %3, length: %4").arg(gapBegin).arg(gapEnd).arg(capacity).arg(length()));
-  return s;
-}
+        s.append(" | ");
+        s.append(QStringLiteral("gapBegin: %1, gapEnd: %2, capacity: %3, length: %4").arg(gapBegin).arg(gapEnd).arg(capacity).arg(length()));
+        return s;
+    }
 
 
 protected:
 
-T *items_;           ///< The item data
-Tsize capacity_;    ///< The number of reserved bytes
-Tsize gapBegin_;    ///< The start of the gap
-Tsize gapEnd_;      ///< The end of the gap
-Tsize growSize_;    ///< The size to grow extra
+    T *items_;           ///< The item data
+    Tsize capacity_;    ///< The number of reserved bytes
+    Tsize gapBegin_;    ///< The start of the gap
+    Tsize gapEnd_;      ///< The end of the gap
+    Tsize growSize_;    ///< The size to grow extra
 };
 
 
@@ -407,48 +407,48 @@ class EDBEE_EXPORT QCharGapVector : public GapVector<QChar, size_t>
 {
 public:
 
-  QCharGapVector(size_t size = 16) : GapVector<QChar>(size){}
+    QCharGapVector(size_t size = 16) : GapVector<QChar>(size){}
 
-  /// initializes the vector with a given string
-  QCharGapVector(const QString& data, size_t gapSize) : GapVector<QChar>(static_cast<size_t>(data.length()) + gapSize)
-  {
-    memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
-    gapBegin_ = static_cast<size_t>(data.length());
-    gapEnd_ = capacity_;
-  }
-
-
-  /// Initializes the gapvector
-  void init(const QString& data, size_t gapSize)
-  {
-    delete items_;
-    capacity_ = static_cast<size_t>(data.length()) + gapSize;
-    items_ = new QChar[capacity_];
-    memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
-    gapBegin_ = static_cast<size_t>(data.length());
-    gapEnd_ = capacity_;
-    growSize_ = 16;
-  }
+    /// initializes the vector with a given string
+    QCharGapVector(const QString& data, size_t gapSize) : GapVector<QChar>(static_cast<size_t>(data.length()) + gapSize)
+    {
+        memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
+        gapBegin_ = static_cast<size_t>(data.length());
+        gapEnd_ = capacity_;
+    }
 
 
-  /// a string replace function
-  void replaceString(size_t offset, size_t length, const QString& data) {
-    replace(offset, length, data.constData(), static_cast<size_t>(data.length()));
-  }
+    /// Initializes the gapvector
+    void init(const QString& data, size_t gapSize)
+    {
+        delete items_;
+        capacity_ = static_cast<size_t>(data.length()) + gapSize;
+        items_ = new QChar[capacity_];
+        memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
+        gapBegin_ = static_cast<size_t>(data.length());
+        gapEnd_ = capacity_;
+        growSize_ = 16;
+    }
 
 
-  /// Retrieve a QString part
-  QString mid(size_t offset, size_t length) const
-  {
-    if (length == 0) return QString();
+    /// a string replace function
+    void replaceString(size_t offset, size_t length, const QString& data) {
+        replace(offset, length, data.constData(), static_cast<size_t>(data.length()));
+    }
 
-    QChar* data = new QChar[length];
-    copyRange(data, offset, length);
-    QString str(data, static_cast<qsizetype>(length));
-    delete[] data;
 
-    return str;
-  }
+    /// Retrieve a QString part
+    QString mid(size_t offset, size_t length) const
+    {
+        if (length == 0) return QString();
+
+        QChar* data = new QChar[length];
+        copyRange(data, offset, length);
+        QString str(data, static_cast<qsizetype>(length));
+        delete[] data;
+
+        return str;
+    }
 };
 
 
@@ -458,88 +458,88 @@ public:
 template <typename T, typename Tsize>
 class EDBEE_EXPORT NoGapVector {
 public:
-  NoGapVector(Tsize capacity = 16) {
-    Q_UNUSED(capacity);
-  }
+    NoGapVector(Tsize capacity = 16) {
+        Q_UNUSED(capacity);
+    }
 
-  ~NoGapVector() {
-  }
+    ~NoGapVector() {
+    }
 
-  /// returns the used length of the data
-  inline Tsize length() const { return items_.size(); }
-  inline Tsize gapSize() const { return 0; }
-  inline Tsize gapBegin() const { return 0; }
-  inline Tsize gapEnd() const { return 0; }
-  inline Tsize capacity() const { return items_.capacity(); }
+    /// returns the used length of the data
+    inline Tsize length() const { return items_.size(); }
+    inline Tsize gapSize() const { return 0; }
+    inline Tsize gapBegin() const { return 0; }
+    inline Tsize gapEnd() const { return 0; }
+    inline Tsize capacity() const { return items_.capacity(); }
 
 
-  /// clears the data
-  void clear()
-  {
-    items_.clear();
-  }
+    /// clears the data
+    void clear()
+    {
+        items_.clear();
+    }
 
 
 public:
 
-  /// Replaces the given items
-  /// @param offset the offset of the items to replace
-  /// @param lenth the number of items to replace
-  /// @param data an array with new items
-  /// @param newLength the number of items in the new array
-  void replace(Tsize offset, Tsize length, const T* data, Tsize newLength) {
-    items_.remove(offset, length);
-  for (Tsize i = 0; i < newLength; i++) {
-    items_.insert(offset+i,data[i]);
-  }
-}
+    /// Replaces the given items
+    /// @param offset the offset of the items to replace
+    /// @param lenth the number of items to replace
+    /// @param data an array with new items
+    /// @param newLength the number of items in the new array
+    void replace(Tsize offset, Tsize length, const T* data, Tsize newLength) {
+        items_.remove(offset, length);
+        for (Tsize i = 0; i < newLength; i++) {
+            items_.insert(offset+i,data[i]);
+        }
+    }
 
 
-/// Replaces the given items with a single data item
-/// @param offset the offset of the items to replace
-/// @param lenth the number of items to replace
-/// @param newLength the number of times to repeat data
-void fill(Tsize offset, Tsize length, const T& data, Tsize newLength) {
-  items_.remove(offset,length);
-  for (Tsize i = 0; i < newLength; i++) {
-    items_.insert(offset+i,data);
-  }
-}
+    /// Replaces the given items with a single data item
+    /// @param offset the offset of the items to replace
+    /// @param lenth the number of items to replace
+    /// @param newLength the number of times to repeat data
+    void fill(Tsize offset, Tsize length, const T& data, Tsize newLength) {
+        items_.remove(offset,length);
+        for (Tsize i = 0; i < newLength; i++) {
+            items_.insert(offset+i,data);
+        }
+    }
 
-/// Appends an item
-void append(T t) {
-  items_.append(t);
-}
-
-
-/// Appends a list of items
-void append(const T* t, Tsize length) {
-  for (Tsize i = 0; i < length; i++) {
-    items_.append(t[i]);
-  }
-}
+    /// Appends an item
+    void append(T t) {
+        items_.append(t);
+    }
 
 
-/// Returns the item at the given index
-T at(Tsize offset) const {
-  return items_.at(offset);
-}
+    /// Appends a list of items
+    void append(const T* t, Tsize length) {
+        for (Tsize i = 0; i < length; i++) {
+            items_.append(t[i]);
+        }
+    }
 
 
-/// Sets an item at the given index
-void set(Tsize offset, const T& value) {
-  items_.replace(offset,value);
-}
+    /// Returns the item at the given index
+    T at(Tsize offset) const {
+        return items_.at(offset);
+    }
 
 
-/// Return an index
-T& operator[](Tsize offset) {
-  return items_[offset];
-}
+    /// Sets an item at the given index
+    void set(Tsize offset, const T& value) {
+        items_.replace(offset,value);
+    }
+
+
+    /// Return an index
+    T& operator[](Tsize offset) {
+        return items_[offset];
+    }
 
 protected:
 
-QVector<T> items_;
+    QVector<T> items_;
 };
 
 

--- a/edbee-lib/edbee/util/gapvector.h
+++ b/edbee-lib/edbee/util/gapvector.h
@@ -14,532 +14,532 @@ namespace edbee {
 
 /// Is used to define a gap vector. A Gapvector is split in 2 parts. where the gap
 /// is moved to the insertation/changing point. So reducing the movement of fields
-template <typename T>
+template <typename T, typename Tsize = size_t>
 class EDBEE_EXPORT GapVector {
 public:
-    GapVector(size_t capacity = 16) : items_(nullptr), capacity_(0), gapBegin_(0), gapEnd_(0)  {
-        items_    = new T[capacity];
-        capacity_ = capacity;
-        gapBegin_ = 0;
-        gapEnd_   = capacity;
-        growSize_ = 16;
-    }
+  GapVector(Tsize capacity = 16) : items_(nullptr), capacity_(0), gapBegin_(0), gapEnd_(0)  {
+    items_    = new T[capacity];
+  capacity_ = capacity;
+  gapBegin_ = 0;
+  gapEnd_   = capacity;
+  growSize_ = 16;
+}
 
 
-    ~GapVector() {
-        delete[] items_;
-    }
+~GapVector() {
+  delete[] items_;
+}
 
 
-    /// returns the used length of the data
-    inline size_t length() const { return capacity_ - gapEnd_ + gapBegin_; }
-    inline size_t gapSize() const { return gapEnd_ - gapBegin_; }
-    inline size_t gapBegin() const { return gapBegin_; }
-    inline size_t gapEnd() const { return gapEnd_; }
-    inline size_t capacity() const { return capacity_; }
+/// returns the used length of the data
+inline Tsize length() const { return capacity_ - gapEnd_ + gapBegin_; }
+inline Tsize gapSize() const { return gapEnd_ - gapBegin_; }
+inline Tsize gapBegin() const { return gapBegin_; }
+inline Tsize gapEnd() const { return gapEnd_; }
+inline Tsize capacity() const { return capacity_; }
 
 
-    /// clears the data
-    void clear()
-    {
-        delete[] items_;
-        capacity_ = 16;
-        items_    = new T[capacity_];
-        gapBegin_ = 0;
-        gapEnd_   = capacity_;
-        growSize_ = 16;
-    }
+/// clears the data
+void clear()
+{
+  delete[] items_;
+  capacity_ = 16;
+  items_    = new T[capacity_];
+  gapBegin_ = 0;
+  gapEnd_   = capacity_;
+  growSize_ = 16;
+}
 
 
 protected:
 
-    /// Replaces the given text with the given data.
-    /// because the length of the source and target is the same in this method
-    /// no gap-moving is required
-    /// @param offset the target to move the data to
-    /// @param length the number of items to replace
-    /// @param data the data pointer with the source data
-    void replace(size_t offset, size_t length, const T* data) {
-        Q_ASSERT(offset <= this->length());
-        Q_ASSERT(offset + length <= capacity_);
+/// Replaces the given text with the given data.
+/// because the length of the source and target is the same in this method
+/// no gap-moving is required
+/// @param offset the target to move the data to
+/// @param length the number of items to replace
+/// @param data the data pointer with the source data
+void replace(Tsize offset, size_t length, const T* data) {
+  Q_ASSERT(offset <= this->length());
+Q_ASSERT(offset + length <= capacity_);
 
-        // copy the first part
-        if (offset < gapBegin()) {
-            size_t len = qMin(gapBegin_ - offset, length); // issue 141, added -offset
-            memcpy(items_ + offset, data, static_cast<size_t>(sizeof(T)) * len);
-            data      += len;   // increase the pointer
-            offset    += len;
-            length    -= len;
-        }
+// copy the first part
+if (offset < gapBegin()) {
+  Tsize len = qMin(gapBegin_ - offset, length); // issue 141, added -offset
+  memcpy(items_ + offset, data, static_cast<Tsize>(sizeof(T)) * len);
+  data      += len;   // increase the pointer
+  offset    += len;
+  length    -= len;
+}
 
-        if (0 < length) {
-            memcpy(items_ + offset + gapSize(), data, sizeof(T)*static_cast<size_t>(length));
-        }
+if (0 < length) {
+  memcpy(items_ + offset + gapSize(), data, sizeof(T)*static_cast<Tsize>(length));
+}
     }
 
 
-    /// Replaces the given text with the given data.
-    /// because the length of the source and target is the same in this method
-    /// no gap-moving is required
-    /// @param offset the target to move the data to
-    /// @param length the number of items to replace
-    /// @param data the data pointer with the source data
-    void fill(size_t offset, size_t length, const T& data) {
-        Q_ASSERT(offset <= this->length());
-        Q_ASSERT(offset + length <= capacity_);
+/// Replaces the given text with the given data.
+/// because the length of the source and target is the same in this method
+/// no gap-moving is required
+/// @param offset the target to move the data to
+/// @param length the number of items to replace
+/// @param data the data pointer with the source data
+void fill(Tsize offset, size_t length, const T& data) {
+  Q_ASSERT(offset <= this->length());
+  Q_ASSERT(offset + length <= capacity_);
 
-        // copy the first part
-        if (offset < gapBegin()) {
-            size_t len = qMin(gapBegin_ - offset, length);
-            for (size_t i = 0; i < len; ++i) { items_ [offset + i] = data; }
-            offset    += len;
-            length    -= len;
-        }
+  // copy the first part
+  if (offset < gapBegin()) {
+    Tsize len = qMin(gapBegin_ - offset, length);
+    for (Tsize i = 0; i < len; ++i) { items_ [offset + i] = data; }
+    offset    += len;
+    length    -= len;
+  }
 
-        if (0 < length) {
-            offset += gapSize();
-            for (size_t i = 0; i < length; ++i) { items_ [offset + i] = data; }
-        }
-    }
+  if (0 < length) {
+    offset += gapSize();
+    for (Tsize i = 0; i < length; ++i) { items_ [offset + i] = data; }
+  }
+}
 
 
 public:
 
-    /// Replaces the given items
-    /// @param offset the offset of the items to replace
-    /// @param length the number of items to replace
-    /// @param data an array with new items
-    /// @param newLength the number of items in the new array
-    void replace(size_t offset, size_t length, const T* data, size_t newLength) {
-        size_t currentLength=this->length();
-        Q_ASSERT((offset+length) <= currentLength);
-        Q_ASSERT(offset + length <= capacity_);
-        Q_UNUSED(currentLength);
+/// Replaces the given items
+/// @param offset the offset of the items to replace
+/// @param length the number of items to replace
+/// @param data an array with new items
+/// @param newLength the number of items in the new array
+void replace(Tsize offset, size_t length, const T* data, size_t newLength) {
+  Tsize currentLength=this->length();
+  Q_ASSERT((offset+length) <= currentLength);
+  Q_ASSERT(offset + length <= capacity_);
+  Q_UNUSED(currentLength);
 
-        size_t gapSize = this->gapSize();
+Tsize gapSize = this->gapSize();
 
-        // Is it a 'delete' or 'insert' or 'replace' operation
+// Is it a 'delete' or 'insert' or 'replace' operation
 
-        // a replace operation (do not perform gap moving)
-        if (length == newLength) {
-            replace(offset, length, data);
+// a replace operation (do not perform gap moving)
+if (length == newLength) {
+  replace(offset, length, data);
 
-        // insert operation
-        } else if (length < newLength) {
-            size_t gapSizeRequired = newLength - length;
-            ensureGapSize(gapSizeRequired);
-            moveGapTo(offset + length);
-            memcpy(items_ + offset, data, sizeof(T) * static_cast<size_t>(newLength));
-            gapBegin_ = offset + newLength;
+  // insert operation
+} else if (length < newLength) {
+  Tsize gapSizeRequired = newLength - length;
+  ensureGapSize(gapSizeRequired);
+  moveGapTo(offset + length);
+  memcpy(items_ + offset, data, sizeof(T) * static_cast<Tsize>(newLength));
+  gapBegin_ = offset + newLength;
 
-        // delete operation
-        } else {
-            moveGapTo(offset);
-            memcpy(items_ + offset, data, sizeof(T) * static_cast<size_t>(newLength));
-            gapBegin_ = offset + newLength;
-            gapEnd_   = offset + gapSize + length;
-        }
+  // delete operation
+} else {
+  moveGapTo(offset);
+  memcpy(items_ + offset, data, sizeof(T) * static_cast<Tsize>(newLength));
+  gapBegin_ = offset + newLength;
+  gapEnd_   = offset + gapSize + length;
+}
 
-        Q_ASSERT(gapBegin_ <= gapEnd_);
-        Q_ASSERT(this->gapSize() <= capacity_);
-        Q_ASSERT(this->length() <= capacity_);
+Q_ASSERT(gapBegin_ <= gapEnd_);
+Q_ASSERT(this->gapSize() <= capacity_);
+Q_ASSERT(this->length() <= capacity_);
     }
 
 
-    /// Replaces the given items with a single data item
-    /// @param offset the offset of the items to replace
-    /// @param lenth the number of items to replace
-    /// @param newLength the number of times to repeat data
-    void fill(size_t offset, size_t length, const T& data, size_t newLength) {
-        size_t currentLength=this->length();
-        Q_ASSERT((offset+length) <= currentLength);
-        Q_ASSERT(offset + length <= capacity_);
-        Q_UNUSED(currentLength);
+/// Replaces the given items with a single data item
+/// @param offset the offset of the items to replace
+/// @param lenth the number of items to replace
+/// @param newLength the number of times to repeat data
+void fill(Tsize offset, size_t length, const T& data, size_t newLength) {
+  Tsize currentLength=this->length();
+  Q_ASSERT((offset+length) <= currentLength);
+  Q_ASSERT(offset + length <= capacity_);
+  Q_UNUSED(currentLength);
 
-        size_t gapSize = this->gapSize();
+  Tsize gapSize = this->gapSize();
 
-        // Is it a 'delete' or 'insert' or 'replace' operation
+  // Is it a 'delete' or 'insert' or 'replace' operation
 
-        // a replace operation (do not perform gap moving)
-        if (length == newLength) {
-            fill(offset, length, data);
+  // a replace operation (do not perform gap moving)
+  if (length == newLength) {
+    fill(offset, length, data);
 
-        // insert operation
-        } else if (length < newLength) {
-            size_t gapSizeRequired = newLength - length;
-            ensureGapSize(gapSizeRequired);
-            moveGapTo( offset + length);
-            for (size_t i = 0; i < newLength; ++i) { items_[offset+i] = data; }
-            gapBegin_ = offset + newLength;
+    // insert operation
+  } else if (length < newLength) {
+    Tsize gapSizeRequired = newLength - length;
+    ensureGapSize(gapSizeRequired);
+    moveGapTo( offset + length);
+    for (Tsize i = 0; i < newLength; ++i) { items_[offset+i] = data; }
+    gapBegin_ = offset + newLength;
 
-        // delete operation
-        } else {
-            moveGapTo(offset);
-            for (size_t i = 0; i < newLength; ++i) { items_[offset+i] = data; }
-            gapBegin_ = offset + newLength;
-            gapEnd_   = offset + gapSize + length;
-        }
+    // delete operation
+  } else {
+    moveGapTo(offset);
+    for (Tsize i = 0; i < newLength; ++i) { items_[offset+i] = data; }
+    gapBegin_ = offset + newLength;
+    gapEnd_   = offset + gapSize + length;
+  }
 
-        Q_ASSERT(gapBegin_ <= gapEnd_);
-        Q_ASSERT(this->gapSize() <= capacity_);
-        Q_ASSERT(this->length() <= capacity_);
+  Q_ASSERT(gapBegin_ <= gapEnd_);
+  Q_ASSERT(this->gapSize() <= capacity_);
+  Q_ASSERT(this->length() <= capacity_);
+}
+
+
+/// convenient append method
+void append(T t) {
+  replace(length(), 0, &t, 1);
+}
+
+
+/// another append method
+void append(const T* t, Tsize length) {
+  replace(this->length(), 0, t, length);
+}
+
+
+/// Returns the item at the given index
+T at(Tsize offset) const {
+  Q_ASSERT(offset < length());
+  if (offset < gapBegin_) {
+    return items_[offset];
+  } else {
+    return items_[gapEnd_ + offset - gapBegin_];
+  }
+}
+
+
+/// Sets an item at the given index
+void set(Tsize offset, const T& value) {
+  Q_ASSERT(offset < length());
+  if (offset < gapBegin_) {
+    items_[offset] = value;
+  } else {
+    items_[gapEnd_ + offset - gapBegin_] = value;
+  }
+}
+
+
+/// Returns an index
+T& operator[](Tsize offset) const {
+  Q_ASSERT(offset < length());
+  if (offset < gapBegin_) {
+    return items_[offset];
+  } else {
+    return items_[gapEnd_ + offset - gapBegin_];
+  }
+}
+
+
+/// Returns the 'raw' element at the given location
+/// This method does NOT take in account the gap
+T& rawAt(Tsize index) {
+  Q_ASSERT(index < capacity_);
+  return items_[index];
+}
+
+
+/// Copies the given range to the data pointer
+void copyRange(QChar* data, Tsize offset, size_t length) const {
+  Q_ASSERT(offset < this->length());
+  Q_ASSERT((offset + length) <= this->length());
+
+  // copy the first part
+  if (offset < gapBegin()) {
+    Tsize len = qMin(gapBegin_ - offset, length);
+    memcpy(data, items_ + offset, sizeof(T)*static_cast<Tsize>(len));
+    data      += len;   // increase the pointer
+    offset    += len;
+    length    -= len;
+  }
+
+  if (length > 0) {
+    memcpy(data, items_ + offset + gapSize(), sizeof(T)*static_cast<Tsize>(length));
+  }
+}
+
+
+/// This method returns a direct pointer to the 0-terminated buffer
+/// This pointer is only valid as long as the buffer doesn't change
+/// WARNING, this method MOVES the gap! Which means this method should NOT be used for a lot of operations
+T* data() {
+  ensureGapSize(1);
+  moveGapTo(length());
+  items_[length()] = QChar(); // a \0 character
+  return items_;
+}
+
+
+//// moves the gap to the given position
+//// Warning when the gap is moved after the length the gap shrinks
+void moveGapTo(Tsize offset) {
+  Q_ASSERT(offset <= capacity_);
+  Q_ASSERT(offset <= length());
+  if (offset != gapBegin_) {
+    Tsize gapSize = this->gapSize();
+
+    // move the the data right after the gap
+    if (offset < gapBegin_) {
+      memmove(items_ + offset + gapSize, items_ + offset, sizeof(T) * (gapBegin_ - offset));   // memmove( target, source, size )
+    } else {
+      memmove(items_ + gapBegin_, items_ + gapEnd_, sizeof(T) * (offset - gapBegin_));  // memmove( target, source, size )
     }
+    gapBegin_ = offset;
+    gapEnd_   = gapBegin_ + gapSize; // qMin( gapBegin_ + gapSize, capacity_ );
 
-
-    /// convenient append method
-    void append(T t) {
-        replace(length(), 0, &t, 1);
-    }
-
-
-    /// another append method
-    void append(const T* t, size_t length) {
-        replace(this->length(), 0, t, length);
-    }
-
-
-    /// Returns the item at the given index
-    T at(size_t offset) const {
-        Q_ASSERT(offset < length());
-        if (offset < gapBegin_) {
-            return items_[offset];
-        } else {
-            return items_[gapEnd_ + offset - gapBegin_];
-        }
-    }
-
-
-    /// Sets an item at the given index
-    void set(size_t offset, const T& value) {
-        Q_ASSERT(offset < length());
-        if (offset < gapBegin_) {
-            items_[offset] = value;
-        } else {
-            items_[gapEnd_ + offset - gapBegin_] = value;
-        }
-    }
-
-
-    /// Returns an index
-    T& operator[](size_t offset) const {
-        Q_ASSERT(offset < length());
-        if (offset < gapBegin_) {
-            return items_[offset];
-        } else {
-            return items_[gapEnd_ + offset - gapBegin_];
-        }
-    }
-
-
-    /// Returns the 'raw' element at the given location
-    /// This method does NOT take in account the gap
-    T& rawAt(size_t index) {
-        Q_ASSERT(index < capacity_);
-        return items_[index];
-    }
-
-
-    /// Copies the given range to the data pointer
-    void copyRange(QChar* data, size_t offset, size_t length) const {
-        Q_ASSERT(offset < this->length());
-        Q_ASSERT((offset + length) <= this->length());
-
-        // copy the first part
-        if (offset < gapBegin()) {
-            size_t len = qMin(gapBegin_ - offset, length);
-            memcpy(data, items_ + offset, sizeof(T)*static_cast<size_t>(len));
-            data      += len;   // increase the pointer
-            offset    += len;
-            length    -= len;
-        }
-
-        if (length > 0) {
-            memcpy(data, items_ + offset + gapSize(), sizeof(T)*static_cast<size_t>(length));
-        }
-    }
-
-
-    /// This method returns a direct pointer to the 0-terminated buffer
-    /// This pointer is only valid as long as the buffer doesn't change
-    /// WARNING, this method MOVES the gap! Which means this method should NOT be used for a lot of operations
-    T* data() {
-        ensureGapSize(1);
-        moveGapTo(length());
-        items_[length()] = QChar(); // a \0 character
-        return items_;
-    }
-
-
-    //// moves the gap to the given position
-    //// Warning when the gap is moved after the length the gap shrinks
-    void moveGapTo(size_t offset) {
-        Q_ASSERT(offset <= capacity_);
-        Q_ASSERT(offset <= length());
-        if (offset != gapBegin_) {
-            size_t gapSize = this->gapSize();
-
-            // move the the data right after the gap
-            if (offset < gapBegin_) {
-                memmove(items_ + offset + gapSize, items_ + offset, sizeof(T) * (gapBegin_ - offset));   // memmove( target, source, size )
-            } else {
-                memmove(items_ + gapBegin_, items_ + gapEnd_, sizeof(T) * (offset - gapBegin_));  // memmove( target, source, size )
-            }
-            gapBegin_ = offset;
-            gapEnd_   = gapBegin_ + gapSize; // qMin( gapBegin_ + gapSize, capacity_ );
-
-        }
-        Q_ASSERT(gapBegin_ <= gapEnd_);
+  }
+  Q_ASSERT(gapBegin_ <= gapEnd_);
 
 #ifdef GAP_VECTOR_CLEAR_GAP
-        memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
+  memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
 #endif
-    }
+}
 
 
-    /// Mkes sure there's enough room for the insertation
-    void ensureGapSize(size_t requiredSize) {
-        if (gapSize() < requiredSize) {
-            while (growSize_ < capacity_ / 6) { growSize_ *= 2; }
-            resize(capacity_ + requiredSize + growSize_ - gapSize());
-        }
-    }
+/// Mkes sure there's enough room for the insertation
+void ensureGapSize(Tsize requiredSize) {
+  if (gapSize() < requiredSize) {
+    while (growSize_ < capacity_ / 6) { growSize_ *= 2; }
+    resize(capacity_ + requiredSize + growSize_ - gapSize());
+  }
+}
 
 
-    /// resizes the array of data
-    void resize(size_t newSize)
-    {
-        if (capacity_ >= newSize) return;
+/// resizes the array of data
+void resize(Tsize newSize)
+{
+  if (capacity_ >= newSize) return;
 
-        size_t lengte = length();
-        Q_ASSERT(lengte <= capacity_);
-/// TODO: optimize, so data is moved only once
-/// in other words, gap movement is not required over here!!
-/// this can be done with 2 memcopies
-//qlog_info() << "BEGIN resize: capacity =" << capacity_<< " => " << newSize;
+  Tsize lengte = length();
+  Q_ASSERT(lengte <= capacity_);
+  /// TODO: optimize, so data is moved only once
+  /// in other words, gap movement is not required over here!!
+  /// this can be done with 2 memcopies
+  //qlog_info() << "BEGIN resize: capacity =" << capacity_<< " => " << newSize;
 
-        moveGapTo(lengte);
-        T *newChars = new T[newSize];
+  moveGapTo(lengte);
+  T *newChars = new T[newSize];
 
-        if (capacity_ > 0) {
-            memmove(newChars, items_, sizeof(T) * lengte);
-            delete[] items_;
-        }
-        items_ = newChars;
-        capacity_ = newSize;
-        gapEnd_   = newSize;
+  if (capacity_ > 0) {
+    memmove(newChars, items_, sizeof(T) * lengte);
+    delete[] items_;
+  }
+  items_ = newChars;
+  capacity_ = newSize;
+  gapEnd_   = newSize;
 
-        // DEBUG gapsize
+  // DEBUG gapsize
 #ifdef GAP_VECTOR_CLEAR_GAP
-        memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
+  memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
 #endif
+}
+
+
+/// sets the growsize. The growsize if the amount to reserve extra
+void setGrowSize(Tsize size) { growSize_ = size; }
+
+/// returns the growsize
+Tsize growSize() { return growSize_; }
+
+
+/// Converts the 'gap-buffer' to a unit-test debugging string
+QString getUnitTestString(QChar gapChar = '_') const {
+  QString s;
+  Tsize gapBegin = this->gapBegin();
+  Tsize gapEnd   = this->gapEnd();
+  Tsize capacity = this->capacity();
+
+  for (Tsize i = 0; i < gapBegin; ++i) {
+    if (items_[i].isNull()) {
+      s.append("@");
+    } else {
+      s.append(items_[i]);
     }
-
-
-    /// sets the growsize. The growsize if the amount to reserve extra
-    void setGrowSize(size_t size) { growSize_ = size; }
-
-    /// returns the growsize
-    size_t growSize() { return growSize_; }
-
-
-    /// Converts the 'gap-buffer' to a unit-test debugging string
-    QString getUnitTestString(QChar gapChar = '_') const {
-        QString s;
-        size_t gapBegin = this->gapBegin();
-        size_t gapEnd   = this->gapEnd();
-        size_t capacity = this->capacity();
-
-        for (size_t i = 0; i < gapBegin; ++i) {
-            if (items_[i].isNull()) {
-                s.append("@");
-            } else {
-                s.append(items_[i]);
-            }
-        }
-        s.append( "[" );
-        for (size_t i = gapBegin; i < gapEnd; ++i) {
-            s.append(gapChar);
-        }
-        s.append( ">" );
-        for (size_t i=gapEnd; i<capacity; ++i) {
-            if (items_[i].isNull()) {
-                s.append("@");
-            } else {
-                s.append(items_[i]);
-            }
-        }
-        return s;
+  }
+  s.append( "[" );
+  for (Tsize i = gapBegin; i < gapEnd; ++i) {
+    s.append(gapChar);
+  }
+  s.append( ">" );
+  for (Tsize i=gapEnd; i<capacity; ++i) {
+    if (items_[i].isNull()) {
+      s.append("@");
+    } else {
+      s.append(items_[i]);
     }
+  }
+  return s;
+}
 
 
-    /// Converts the 'gap-buffer' to a unit-test debugging string
-    QString getUnitTestString2() const {
-        QString s;
-        size_t gapBegin = this->gapBegin();
-        size_t gapEnd   = this->gapEnd();
-        size_t capacity = this->capacity();
+/// Converts the 'gap-buffer' to a unit-test debugging string
+QString getUnitTestString2() const {
+  QString s;
+  Tsize gapBegin = this->gapBegin();
+  Tsize gapEnd   = this->gapEnd();
+  Tsize capacity = this->capacity();
 
-        for (size_t i = 0; i < capacity; i++) {
-            if (i) { s.append(","); }
-            if (gapEnd == i) s.append(">");
-            s.append(QStringLiteral("%1").arg( "X" ));
-            if (gapBegin == i) s.append("[");
-        }
+  for (Tsize i = 0; i < capacity; i++) {
+    if (i) { s.append(","); }
+    if (gapEnd == i) s.append(">");
+    s.append(QStringLiteral("%1").arg( "X" ));
+    if (gapBegin == i) s.append("[");
+  }
 
-        s.append(" | ");
-        s.append(QStringLiteral("gapBegin: %1, gapEnd: %2, capacity: %3, length: %4").arg(gapBegin).arg(gapEnd).arg(capacity).arg(length()));
-        return s;
-    }
+  s.append(" | ");
+  s.append(QStringLiteral("gapBegin: %1, gapEnd: %2, capacity: %3, length: %4").arg(gapBegin).arg(gapEnd).arg(capacity).arg(length()));
+  return s;
+}
 
 
 protected:
 
-    T *items_;           ///< The item data
-    size_t capacity_;    ///< The number of reserved bytes
-    size_t gapBegin_;    ///< The start of the gap
-    size_t gapEnd_;      ///< The end of the gap
-    size_t growSize_;    ///< The size to grow extra
+T *items_;           ///< The item data
+Tsize capacity_;    ///< The number of reserved bytes
+Tsize gapBegin_;    ///< The start of the gap
+Tsize gapEnd_;      ///< The end of the gap
+Tsize growSize_;    ///< The size to grow extra
 };
 
 
 /// The character vecor to use
-class EDBEE_EXPORT QCharGapVector : public GapVector<QChar>
+class EDBEE_EXPORT QCharGapVector : public GapVector<QChar, size_t>
 {
 public:
 
-    QCharGapVector(size_t size = 16) : GapVector<QChar>(size){}
+  QCharGapVector(size_t size = 16) : GapVector<QChar>(size){}
 
-    /// initializes the vector with a given string
-    QCharGapVector(const QString& data, size_t gapSize) : GapVector<QChar>(static_cast<size_t>(data.length()) + gapSize)
-    {
-        memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
-        gapBegin_ = static_cast<size_t>(data.length());
-        gapEnd_ = capacity_;
-    }
-
-
-    /// Initializes the gapvector
-    void init(const QString& data, size_t gapSize)
-    {
-        delete items_;
-        capacity_ = static_cast<size_t>(data.length()) + gapSize;
-        items_ = new QChar[capacity_];
-        memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
-        gapBegin_ = static_cast<size_t>(data.length());
-        gapEnd_ = capacity_;
-        growSize_ = 16;
-    }
+  /// initializes the vector with a given string
+  QCharGapVector(const QString& data, size_t gapSize) : GapVector<QChar>(static_cast<size_t>(data.length()) + gapSize)
+  {
+    memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
+    gapBegin_ = static_cast<size_t>(data.length());
+    gapEnd_ = capacity_;
+  }
 
 
-    /// a string replace function
-    void replaceString(size_t offset, size_t length, const QString& data) {
-        replace(offset, length, data.constData(), static_cast<size_t>(data.length()));
-    }
+  /// Initializes the gapvector
+  void init(const QString& data, size_t gapSize)
+  {
+    delete items_;
+    capacity_ = static_cast<size_t>(data.length()) + gapSize;
+    items_ = new QChar[capacity_];
+    memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
+    gapBegin_ = static_cast<size_t>(data.length());
+    gapEnd_ = capacity_;
+    growSize_ = 16;
+  }
 
 
-    /// Retrieve a QString part
-    QString mid(size_t offset, size_t length) const
-    {
-        if (length == 0) return QString();
+  /// a string replace function
+  void replaceString(size_t offset, size_t length, const QString& data) {
+    replace(offset, length, data.constData(), static_cast<size_t>(data.length()));
+  }
 
-        QChar* data = new QChar[length];
-        copyRange(data, offset, length);
-        QString str(data, static_cast<qsizetype>(length));
-        delete[] data;
 
-        return str;
-    }
+  /// Retrieve a QString part
+  QString mid(size_t offset, size_t length) const
+  {
+    if (length == 0) return QString();
+
+    QChar* data = new QChar[length];
+    copyRange(data, offset, length);
+    QString str(data, static_cast<qsizetype>(length));
+    delete[] data;
+
+    return str;
+  }
 };
 
 
 /// A special GapVector class that isn't a gapvector. It forwards it's request to a normal vector class
 /// (for debugging purposes) that isn't a gapv
 /// This class is only used for debugging issuess with the gapvector
-template <typename T>
+template <typename T, typename Tsize>
 class EDBEE_EXPORT NoGapVector {
 public:
-    NoGapVector(size_t capacity = 16) {
-        Q_UNUSED(capacity);
-    }
+  NoGapVector(Tsize capacity = 16) {
+    Q_UNUSED(capacity);
+  }
 
-    ~NoGapVector() {
-    }
+  ~NoGapVector() {
+  }
 
-    /// returns the used length of the data
-    inline size_t length() const { return items_.size(); }
-    inline size_t gapSize() const { return 0; }
-    inline size_t gapBegin() const { return 0; }
-    inline size_t gapEnd() const { return 0; }
-    inline size_t capacity() const { return items_.capacity(); }
+  /// returns the used length of the data
+  inline Tsize length() const { return items_.size(); }
+  inline Tsize gapSize() const { return 0; }
+  inline Tsize gapBegin() const { return 0; }
+  inline Tsize gapEnd() const { return 0; }
+  inline Tsize capacity() const { return items_.capacity(); }
 
 
-    /// clears the data
-    void clear()
-    {
-        items_.clear();
-    }
+  /// clears the data
+  void clear()
+  {
+    items_.clear();
+  }
 
 
 public:
 
-    /// Replaces the given items
-    /// @param offset the offset of the items to replace
-    /// @param lenth the number of items to replace
-    /// @param data an array with new items
-    /// @param newLength the number of items in the new array
-    void replace(size_t offset, size_t length, const T* data, size_t newLength) {
-        items_.remove(offset, length);
-        for (size_t i = 0; i < newLength; i++) {
-            items_.insert(offset+i,data[i]);
-        }
-    }
+  /// Replaces the given items
+  /// @param offset the offset of the items to replace
+  /// @param lenth the number of items to replace
+  /// @param data an array with new items
+  /// @param newLength the number of items in the new array
+  void replace(Tsize offset, Tsize length, const T* data, Tsize newLength) {
+    items_.remove(offset, length);
+  for (Tsize i = 0; i < newLength; i++) {
+    items_.insert(offset+i,data[i]);
+  }
+}
 
 
-    /// this method replaces the given items with a single data item
-    /// @param offset the offset of the items to replace
-    /// @param lenth the number of items to replace
-    /// @param newLength the number of times to repeat data
-    void fill(size_t offset, size_t length, const T& data, size_t newLength) {
-        items_.remove(offset,length);
-        for (size_t i = 0; i < newLength; i++) {
-            items_.insert(offset+i,data);
-        }
-    }
+/// this method replaces the given items with a single data item
+/// @param offset the offset of the items to replace
+/// @param lenth the number of items to replace
+/// @param newLength the number of times to repeat data
+void fill(Tsize offset, Tsize length, const T& data, Tsize newLength) {
+  items_.remove(offset,length);
+  for (Tsize i = 0; i < newLength; i++) {
+    items_.insert(offset+i,data);
+  }
+}
 
-    /// convenient append method
-    void append(T t) {
-        items_.append(t);
-    }
-
-
-    /// another append method
-    void append(const T* t, size_t length) {
-        for (size_t i = 0; i < length; i++) {
-            items_.append(t[i]);
-        }
-    }
+/// convenient append method
+void append(T t) {
+  items_.append(t);
+}
 
 
-    /// This method returns the item at the given index
-    T at(size_t offset) const {
-        return items_.at(offset);
-    }
+/// another append method
+void append(const T* t, Tsize length) {
+  for (Tsize i = 0; i < length; i++) {
+    items_.append(t[i]);
+  }
+}
 
 
-    /// This method sets an item at the given index
-    void set(size_t offset, const T& value) {
-        items_.replace(offset,value);
-    }
+/// This method returns the item at the given index
+T at(Tsize offset) const {
+  return items_.at(offset);
+}
 
 
-    /// This method return an index
-    T& operator[](size_t offset) {
-        return items_[offset];
-    }
+/// This method sets an item at the given index
+void set(Tsize offset, const T& value) {
+  items_.replace(offset,value);
+}
+
+
+/// This method return an index
+T& operator[](Tsize offset) {
+  return items_[offset];
+}
 
 protected:
 
-    QVector<T> items_;
+QVector<T> items_;
 };
 
 

--- a/edbee-lib/edbee/util/gapvector.h
+++ b/edbee-lib/edbee/util/gapvector.h
@@ -8,16 +8,16 @@
 #include <QChar>
 #include <QString>
 
-//#define GAP_VECTOR_CLEAR_GAP
+// #define GAP_VECTOR_CLEAR_GAP
 
 namespace edbee {
 
-/// This class is used to define a gap vector. A Gapvector is split in 2 parts. where the gap
+/// Is used to define a gap vector. A Gapvector is split in 2 parts. where the gap
 /// is moved to the insertation/changing point. So reducing the movement of fields
 template <typename T>
 class EDBEE_EXPORT GapVector {
 public:
-    GapVector( size_t capacity=16 ) : items_(nullptr), capacity_(0), gapBegin_(0), gapEnd_(0)  {
+    GapVector(size_t capacity = 16) : items_(nullptr), capacity_(0), gapBegin_(0), gapEnd_(0)  {
         items_    = new T[capacity];
         capacity_ = capacity;
         gapBegin_ = 0;
@@ -25,9 +25,11 @@ public:
         growSize_ = 16;
     }
 
+
     ~GapVector() {
         delete[] items_;
     }
+
 
     /// returns the used length of the data
     inline size_t length() const { return capacity_ - gapEnd_ + gapBegin_; }
@@ -35,6 +37,7 @@ public:
     inline size_t gapBegin() const { return gapBegin_; }
     inline size_t gapEnd() const { return gapEnd_; }
     inline size_t capacity() const { return capacity_; }
+
 
     /// clears the data
     void clear()
@@ -49,105 +52,68 @@ public:
 
 
 protected:
-    /// this method replaces the given text with the given data.
+
+    /// Replaces the given text with the given data.
     /// because the length of the source and target is the same in this method
     /// no gap-moving is required
     /// @param offset the target to move the data to
     /// @param length the number of items to replace
     /// @param data the data pointer with the source data
-    void replace( size_t offset, size_t length, const T* data ) {
-        Q_ASSERT( offset <= this->length() );
-        Q_ASSERT( offset + length <= capacity_ );
+    void replace(size_t offset, size_t length, const T* data) {
+        Q_ASSERT(offset <= this->length());
+        Q_ASSERT(offset + length <= capacity_);
 
         // copy the first part
-        if( offset < gapBegin() ) {
-            size_t len = qMin( gapBegin_-offset, length ); // issue 141, added -offset
-            memcpy( items_ + offset, data, static_cast<size_t>(sizeof(T))*len );
+        if (offset < gapBegin()) {
+            size_t len = qMin(gapBegin_ - offset, length); // issue 141, added -offset
+            memcpy(items_ + offset, data, static_cast<size_t>(sizeof(T)) * len);
             data      += len;   // increase the pointer
             offset    += len;
             length    -= len;
         }
 
-        if( 0 < length ) {
-            memcpy( items_ + offset + gapSize(), data, sizeof(T)*static_cast<size_t>(length) );
+        if (0 < length) {
+            memcpy(items_ + offset + gapSize(), data, sizeof(T)*static_cast<size_t>(length));
         }
     }
 
-    /// this method replaces the given text with the given data.
+
+    /// Replaces the given text with the given data.
     /// because the length of the source and target is the same in this method
     /// no gap-moving is required
     /// @param offset the target to move the data to
     /// @param length the number of items to replace
     /// @param data the data pointer with the source data
-    void fill( size_t offset, size_t length, const T& data ) {
-        Q_ASSERT( offset <= this->length() );
-        Q_ASSERT( offset + length <= capacity_ );
+    void fill(size_t offset, size_t length, const T& data) {
+        Q_ASSERT(offset <= this->length());
+        Q_ASSERT(offset + length <= capacity_);
 
         // copy the first part
-        if( offset < gapBegin() ) {
-            size_t len = qMin( gapBegin_-offset, length );
-            for( size_t i=0; i<len; ++i ) { items_ [offset + i] = data; }
+        if (offset < gapBegin()) {
+            size_t len = qMin(gapBegin_ - offset, length);
+            for (size_t i = 0; i < len; ++i) { items_ [offset + i] = data; }
             offset    += len;
             length    -= len;
         }
 
-        if( 0 < length ) {
+        if (0 < length) {
             offset += gapSize();
-            for( size_t i=0; i<length; ++i ) { items_ [offset + i] = data; }
+            for (size_t i = 0; i < length; ++i) { items_ [offset + i] = data; }
         }
     }
 
+
 public:
 
-
-    /// this method replaces the given items
+    /// Replaces the given items
     /// @param offset the offset of the items to replace
     /// @param length the number of items to replace
     /// @param data an array with new items
     /// @param newLength the number of items in the new array
-    void replace( size_t offset, size_t length, const T* data, size_t newLength ) {
+    void replace(size_t offset, size_t length, const T* data, size_t newLength) {
         size_t currentLength=this->length();
-        Q_ASSERT( (offset+length) <= currentLength );
-        Q_ASSERT( offset + length <= capacity_ );
-        Q_UNUSED( currentLength );
-
-        size_t gapSize = this->gapSize();
-
-        // Is it a 'delete' or 'insert' or 'replace' operation
-
-        // a replace operation (do not perform gap moving)
-        if( length == newLength ) {
-            replace( offset, length, data );
-
-        // insert operation
-        } else if( length < newLength ) {
-            size_t gapSizeRequired = newLength - length;
-            ensureGapSize( gapSizeRequired );
-            moveGapTo( offset + length );
-            memcpy( items_ + offset, data, sizeof(T) * static_cast<size_t>(newLength) );
-            gapBegin_ = offset + newLength;
-
-        // delete operation
-        } else {
-            moveGapTo( offset );
-            memcpy( items_ + offset, data, sizeof(T) * static_cast<size_t>(newLength) );
-            gapBegin_ = offset + newLength;
-            gapEnd_   = offset + gapSize + length;
-        }
-
-        Q_ASSERT( gapBegin_ <= gapEnd_ );
-        Q_ASSERT( this->gapSize() <= capacity_ );
-        Q_ASSERT( this->length() <= capacity_ );
-    }
-
-    /// this method replaces the given items with a single data item
-    /// @param offset the offset of the items to replace
-    /// @param lenth the number of items to replace
-    /// @param newLength the number of times to repeat data
-    void fill( size_t offset, size_t length, const T& data, size_t newLength ) {
-        size_t currentLength=this->length();
-        Q_ASSERT( (offset+length) <= currentLength );
-        Q_ASSERT( offset + length <= capacity_ );
+        Q_ASSERT((offset+length) <= currentLength);
+        Q_ASSERT(offset + length <= capacity_);
         Q_UNUSED(currentLength);
 
         size_t gapSize = this->gapSize();
@@ -155,55 +121,98 @@ public:
         // Is it a 'delete' or 'insert' or 'replace' operation
 
         // a replace operation (do not perform gap moving)
-        if( length == newLength ) {
-            fill( offset, length, data );
+        if (length == newLength) {
+            replace(offset, length, data);
 
         // insert operation
-        } else if( length < newLength ) {
+        } else if (length < newLength) {
             size_t gapSizeRequired = newLength - length;
-            ensureGapSize( gapSizeRequired );
-            moveGapTo( offset + length );
-            for( size_t i=0; i<newLength; ++i ) { items_[offset+i] = data; }
+            ensureGapSize(gapSizeRequired);
+            moveGapTo(offset + length);
+            memcpy(items_ + offset, data, sizeof(T) * static_cast<size_t>(newLength));
             gapBegin_ = offset + newLength;
 
         // delete operation
         } else {
-            moveGapTo( offset );
-            for( size_t i=0; i<newLength; ++i ) { items_[offset+i] = data; }
+            moveGapTo(offset);
+            memcpy(items_ + offset, data, sizeof(T) * static_cast<size_t>(newLength));
             gapBegin_ = offset + newLength;
             gapEnd_   = offset + gapSize + length;
         }
 
-        Q_ASSERT( gapBegin_ <= gapEnd_ );
-        Q_ASSERT( this->gapSize() <= capacity_ );
-        Q_ASSERT( this->length() <= capacity_ );
+        Q_ASSERT(gapBegin_ <= gapEnd_);
+        Q_ASSERT(this->gapSize() <= capacity_);
+        Q_ASSERT(this->length() <= capacity_);
     }
+
+
+    /// Replaces the given items with a single data item
+    /// @param offset the offset of the items to replace
+    /// @param lenth the number of items to replace
+    /// @param newLength the number of times to repeat data
+    void fill(size_t offset, size_t length, const T& data, size_t newLength) {
+        size_t currentLength=this->length();
+        Q_ASSERT((offset+length) <= currentLength);
+        Q_ASSERT(offset + length <= capacity_);
+        Q_UNUSED(currentLength);
+
+        size_t gapSize = this->gapSize();
+
+        // Is it a 'delete' or 'insert' or 'replace' operation
+
+        // a replace operation (do not perform gap moving)
+        if (length == newLength) {
+            fill(offset, length, data);
+
+        // insert operation
+        } else if (length < newLength) {
+            size_t gapSizeRequired = newLength - length;
+            ensureGapSize(gapSizeRequired);
+            moveGapTo( offset + length);
+            for (size_t i = 0; i < newLength; ++i) { items_[offset+i] = data; }
+            gapBegin_ = offset + newLength;
+
+        // delete operation
+        } else {
+            moveGapTo(offset);
+            for (size_t i = 0; i < newLength; ++i) { items_[offset+i] = data; }
+            gapBegin_ = offset + newLength;
+            gapEnd_   = offset + gapSize + length;
+        }
+
+        Q_ASSERT(gapBegin_ <= gapEnd_);
+        Q_ASSERT(this->gapSize() <= capacity_);
+        Q_ASSERT(this->length() <= capacity_);
+    }
+
 
     /// convenient append method
-    void append( T t ) {
-        replace( length(), 0, &t, 1 );
+    void append(T t) {
+        replace(length(), 0, &t, 1);
     }
+
 
     /// another append method
-    void append( const T* t, size_t length ) {
-        replace( this->length(), 0, t, length );
+    void append(const T* t, size_t length) {
+        replace(this->length(), 0, t, length);
     }
 
 
-    /// This method returns the item at the given index
-    T at( size_t offset ) const {
-        Q_ASSERT( offset < length() );
-        if( offset < gapBegin_ ) {
+    /// Returns the item at the given index
+    T at(size_t offset) const {
+        Q_ASSERT(offset < length());
+        if (offset < gapBegin_) {
             return items_[offset];
         } else {
             return items_[gapEnd_ + offset - gapBegin_];
         }
     }
 
-    /// This method sets an item at the given index
-    void set( size_t offset, const T& value ) {
-        Q_ASSERT( offset < length() );
-        if( offset < gapBegin_ ) {
+
+    /// Sets an item at the given index
+    void set(size_t offset, const T& value) {
+        Q_ASSERT(offset < length());
+        if (offset < gapBegin_) {
             items_[offset] = value;
         } else {
             items_[gapEnd_ + offset - gapBegin_] = value;
@@ -211,40 +220,41 @@ public:
     }
 
 
-    /// This method return an index
+    /// Returns an index
     T& operator[](size_t offset) const {
-        Q_ASSERT( offset < length() );
-        if( offset < gapBegin_ ) {
+        Q_ASSERT(offset < length());
+        if (offset < gapBegin_) {
             return items_[offset];
         } else {
             return items_[gapEnd_ + offset - gapBegin_];
         }
     }
 
-    /// This method returns the 'raw' element at the given location
+
+    /// Returns the 'raw' element at the given location
     /// This method does NOT take in account the gap
-    T& rawAt( size_t index ) {
-        Q_ASSERT( index < capacity_ );
+    T& rawAt(size_t index) {
+        Q_ASSERT(index < capacity_);
         return items_[index];
     }
 
 
-    /// This method copies the given range to the data pointer
-    void copyRange( QChar* data, size_t offset, size_t length ) const {
-        Q_ASSERT( offset < this->length() );
-        Q_ASSERT( (offset+length) <= this->length() );
+    /// Copies the given range to the data pointer
+    void copyRange(QChar* data, size_t offset, size_t length) const {
+        Q_ASSERT(offset < this->length());
+        Q_ASSERT((offset + length) <= this->length());
 
         // copy the first part
-        if( offset < gapBegin() ) {
-            size_t len = qMin( gapBegin_-offset, length );
-            memcpy( data, items_ + offset, sizeof(T)*static_cast<size_t>(len) );
+        if (offset < gapBegin()) {
+            size_t len = qMin(gapBegin_ - offset, length);
+            memcpy(data, items_ + offset, sizeof(T)*static_cast<size_t>(len));
             data      += len;   // increase the pointer
             offset    += len;
             length    -= len;
         }
 
-        if( length > 0 ) {
-            memcpy( data, items_ + offset + gapSize(), sizeof(T)*static_cast<size_t>(length) );
+        if (length > 0) {
+            memcpy(data, items_ + offset + gapSize(), sizeof(T)*static_cast<size_t>(length));
         }
     }
 
@@ -254,7 +264,7 @@ public:
     /// WARNING, this method MOVES the gap! Which means this method should NOT be used for a lot of operations
     T* data() {
         ensureGapSize(1);
-        moveGapTo( length() );
+        moveGapTo(length());
         items_[length()] = QChar(); // a \0 character
         return items_;
     }
@@ -262,35 +272,35 @@ public:
 
     //// moves the gap to the given position
     //// Warning when the gap is moved after the length the gap shrinks
-    void moveGapTo( size_t offset ) {
-        Q_ASSERT( offset <= capacity_);
-        Q_ASSERT( offset <= length() );
-        if( offset != gapBegin_ ) {
+    void moveGapTo(size_t offset) {
+        Q_ASSERT(offset <= capacity_);
+        Q_ASSERT(offset <= length());
+        if (offset != gapBegin_) {
             size_t gapSize = this->gapSize();
 
             // move the the data right after the gap
-            if (offset < gapBegin_ ) {
-                memmove( items_ + offset + gapSize, items_ + offset, sizeof(T) * (gapBegin_ - offset));   // memmove( target, source, size )
-
+            if (offset < gapBegin_) {
+                memmove(items_ + offset + gapSize, items_ + offset, sizeof(T) * (gapBegin_ - offset));   // memmove( target, source, size )
             } else {
-                memmove( items_ + gapBegin_, items_ + gapEnd_, sizeof(T) * (offset - gapBegin_ ));  // memmove( target, source, size )
+                memmove(items_ + gapBegin_, items_ + gapEnd_, sizeof(T) * (offset - gapBegin_));  // memmove( target, source, size )
             }
             gapBegin_ = offset;
-            gapEnd_   = gapBegin_ + gapSize; //qMin( gapBegin_ + gapSize, capacity_ );
+            gapEnd_   = gapBegin_ + gapSize; // qMin( gapBegin_ + gapSize, capacity_ );
 
         }
-        Q_ASSERT( gapBegin_ <= gapEnd_ );
+        Q_ASSERT(gapBegin_ <= gapEnd_);
 
 #ifdef GAP_VECTOR_CLEAR_GAP
         memset( items_+gapBegin_, 0, sizeof(T)*(gapEnd_-gapBegin_));
 #endif
     }
 
-    /// this method makes sure there's enough room for the insertation
-    void ensureGapSize( size_t requiredSize ) {
-        if( gapSize() < requiredSize ) {
-            while( growSize_ < capacity_ / 6) { growSize_ *= 2; }
-            resize(capacity_ + requiredSize + growSize_ - gapSize() );
+
+    /// Mkes sure there's enough room for the insertation
+    void ensureGapSize(size_t requiredSize) {
+        if (gapSize() < requiredSize) {
+            while (growSize_ < capacity_ / 6) { growSize_ *= 2; }
+            resize(capacity_ + requiredSize + growSize_ - gapSize());
         }
     }
 
@@ -298,20 +308,20 @@ public:
     /// resizes the array of data
     void resize(size_t newSize)
     {
-        if( capacity_ >= newSize) return;
+        if (capacity_ >= newSize) return;
 
         size_t lengte = length();
-        Q_ASSERT( lengte <= capacity_);
+        Q_ASSERT(lengte <= capacity_);
 /// TODO: optimize, so data is moved only once
 /// in other words, gap movement is not required over here!!
 /// this can be done with 2 memcopies
 //qlog_info() << "BEGIN resize: capacity =" << capacity_<< " => " << newSize;
 
-        moveGapTo( lengte );
-        T *newChars = new T[ newSize ];
+        moveGapTo(lengte);
+        T *newChars = new T[newSize];
 
-        if( capacity_ > 0 ) {
-            memmove( newChars, items_, sizeof(T)*lengte );
+        if (capacity_ > 0) {
+            memmove(newChars, items_, sizeof(T) * lengte);
             delete[] items_;
         }
         items_ = newChars;
@@ -326,69 +336,69 @@ public:
 
 
     /// sets the growsize. The growsize if the amount to reserve extra
-    void setGrowSize( size_t size ) { growSize_=size; }
+    void setGrowSize(size_t size) { growSize_ = size; }
 
     /// returns the growsize
     size_t growSize() { return growSize_; }
 
 
     /// Converts the 'gap-buffer' to a unit-test debugging string
-    QString getUnitTestString( QChar gapChar = '_' ) const {
+    QString getUnitTestString(QChar gapChar = '_') const {
         QString s;
         size_t gapBegin = this->gapBegin();
         size_t gapEnd   = this->gapEnd();
         size_t capacity = this->capacity();
 
-        for( size_t i=0; i<gapBegin; ++i ) {
-            if( items_[i].isNull() ) {
+        for (size_t i = 0; i < gapBegin; ++i) {
+            if (items_[i].isNull()) {
                 s.append("@");
             } else {
-                s.append( items_[i] );
+                s.append(items_[i]);
             }
         }
         s.append( "[" );
-        for( size_t i=gapBegin; i<gapEnd; ++i ) {
-            s.append( gapChar );
+        for (size_t i = gapBegin; i < gapEnd; ++i) {
+            s.append(gapChar);
         }
         s.append( ">" );
-        for( size_t i=gapEnd; i<capacity; ++i ) {
-            if( items_[i].isNull() ) {
+        for (size_t i=gapEnd; i<capacity; ++i) {
+            if (items_[i].isNull()) {
                 s.append("@");
             } else {
-                s.append( items_[i] );
+                s.append(items_[i]);
             }
         }
-
         return s;
     }
 
+
     /// Converts the 'gap-buffer' to a unit-test debugging string
-    QString getUnitTestString2( ) const {
+    QString getUnitTestString2() const {
         QString s;
         size_t gapBegin = this->gapBegin();
         size_t gapEnd   = this->gapEnd();
         size_t capacity = this->capacity();
 
-        for( size_t i=0; i<capacity;i++ ) {
-            if( i ) { s.append(","); }
-            if( gapEnd == i) s.append(">");
-            s.append( QStringLiteral("%1").arg( "X" ));
-            if( gapBegin==i ) s.append("[");
+        for (size_t i = 0; i < capacity; i++) {
+            if (i) { s.append(","); }
+            if (gapEnd == i) s.append(">");
+            s.append(QStringLiteral("%1").arg( "X" ));
+            if (gapBegin == i) s.append("[");
         }
 
         s.append(" | ");
-        s.append( QStringLiteral("gapBegin: %1, gapEnd: %2, capacity: %3, length: %4").arg(gapBegin).arg(gapEnd).arg(capacity).arg(length()) );
+        s.append(QStringLiteral("gapBegin: %1, gapEnd: %2, capacity: %3, length: %4").arg(gapBegin).arg(gapEnd).arg(capacity).arg(length()));
         return s;
     }
 
 
 protected:
 
-    T *items_;              ///< The item data
-    size_t capacity_;          ///< The number of reserved bytes
-    size_t gapBegin_;          ///< The start of the gap
-    size_t gapEnd_;            ///< The end of the gap
-    size_t growSize_;          ///< The size to grow extra
+    T *items_;           ///< The item data
+    size_t capacity_;    ///< The number of reserved bytes
+    size_t gapBegin_;    ///< The start of the gap
+    size_t gapEnd_;      ///< The end of the gap
+    size_t growSize_;    ///< The size to grow extra
 };
 
 
@@ -397,42 +407,44 @@ class EDBEE_EXPORT QCharGapVector : public GapVector<QChar>
 {
 public:
 
-    QCharGapVector( size_t size=16 ) : GapVector<QChar>(size){}
+    QCharGapVector(size_t size = 16) : GapVector<QChar>(size){}
 
     /// initializes the vector with a given string
-    QCharGapVector( const QString& data, size_t gapSize ) : GapVector<QChar>( static_cast<size_t>(data.length()) + gapSize )
+    QCharGapVector(const QString& data, size_t gapSize) : GapVector<QChar>(static_cast<size_t>(data.length()) + gapSize)
     {
-        memcpy( items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()) );
+        memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
         gapBegin_ = static_cast<size_t>(data.length());
         gapEnd_ = capacity_;
     }
 
 
     /// Initializes the gapvector
-    void init( const QString& data, size_t gapSize )
+    void init(const QString& data, size_t gapSize)
     {
         delete items_;
         capacity_ = static_cast<size_t>(data.length()) + gapSize;
         items_ = new QChar[capacity_];
-        memcpy( items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()) );
+        memcpy(items_, data.constData(), sizeof(QChar) * static_cast<size_t>(data.length()));
         gapBegin_ = static_cast<size_t>(data.length());
         gapEnd_ = capacity_;
         growSize_ = 16;
     }
 
-    /// a convenient string replace function
-    void replaceString( size_t offset, size_t length, const QString& data ) {
-        replace( offset, length, data.constData(), static_cast<size_t>(data.length()) );
+
+    /// a string replace function
+    void replaceString(size_t offset, size_t length, const QString& data) {
+        replace(offset, length, data.constData(), static_cast<size_t>(data.length()));
     }
 
-    /// a convenient method to retrieve a QString part
-    QString mid( size_t offset, size_t length ) const
+
+    /// Retrieve a QString part
+    QString mid(size_t offset, size_t length) const
     {
         if (length == 0) return QString();
 
         QChar* data = new QChar[length];
         copyRange(data, offset, length);
-        QString str( data, static_cast<qsizetype>(length) );
+        QString str(data, static_cast<qsizetype>(length));
         delete[] data;
 
         return str;
@@ -446,7 +458,7 @@ public:
 template <typename T>
 class EDBEE_EXPORT NoGapVector {
 public:
-    NoGapVector( size_t capacity=16 ) {
+    NoGapVector(size_t capacity = 16) {
         Q_UNUSED(capacity);
     }
 
@@ -470,56 +482,58 @@ public:
 
 public:
 
-    /// this method replaces the given items
+    /// Replaces the given items
     /// @param offset the offset of the items to replace
     /// @param lenth the number of items to replace
     /// @param data an array with new items
     /// @param newLength the number of items in the new array
-    void replace( size_t offset, size_t length, const T* data, size_t newLength ) {
-        items_.remove(offset,length);
-        for( size_t i=0; i < newLength; i++ ) {
+    void replace(size_t offset, size_t length, const T* data, size_t newLength) {
+        items_.remove(offset, length);
+        for (size_t i = 0; i < newLength; i++) {
             items_.insert(offset+i,data[i]);
         }
     }
+
 
     /// this method replaces the given items with a single data item
     /// @param offset the offset of the items to replace
     /// @param lenth the number of items to replace
     /// @param newLength the number of times to repeat data
-    void fill( size_t offset, size_t length, const T& data, size_t newLength ) {
+    void fill(size_t offset, size_t length, const T& data, size_t newLength) {
         items_.remove(offset,length);
-        for( size_t i=0; i < newLength; i++ ) {
+        for (size_t i = 0; i < newLength; i++) {
             items_.insert(offset+i,data);
         }
-
     }
 
     /// convenient append method
-    void append( T t ) {
+    void append(T t) {
         items_.append(t);
     }
 
+
     /// another append method
-    void append( const T* t, size_t length ) {
-        for( size_t i=0; i < length; i++ ) {
+    void append(const T* t, size_t length) {
+        for (size_t i = 0; i < length; i++) {
             items_.append(t[i]);
         }
     }
 
 
     /// This method returns the item at the given index
-    T at( size_t offset ) const {
+    T at(size_t offset) const {
         return items_.at(offset);
     }
 
+
     /// This method sets an item at the given index
-    void set( size_t offset, const T& value ) {
+    void set(size_t offset, const T& value) {
         items_.replace(offset,value);
     }
 
 
     /// This method return an index
-    T& operator[]( size_t offset ) {
+    T& operator[](size_t offset) {
         return items_[offset];
     }
 

--- a/edbee-lib/edbee/util/lineending.cpp
+++ b/edbee-lib/edbee/util/lineending.cpp
@@ -1,8 +1,9 @@
 // edbee - Copyright (c) 2012-2025 by Rick Blommers and contributors
 // SPDX-License-Identifier: MIT
 
-#include <QString>
 #include "lineending.h"
+
+#include <QString>
 
 #include "edbee/debug.h"
 
@@ -13,41 +14,41 @@ namespace edbee {
 LineEnding *LineEnding::types()
 {
     static LineEnding types[] = {
-        LineEnding( LineEnding::UnixType, "\n", "\\n", "Unix" ),
-        LineEnding( LineEnding::WindowsType, "\r\n", "\\r\\n", "Windows" ),
-        LineEnding( LineEnding::MacClassicType, "\r" , "\\r", "Mac Classic"),
+        LineEnding(LineEnding::UnixType, "\n", "\\n", "Unix"),
+        LineEnding(LineEnding::WindowsType, "\r\n", "\\r\\n", "Windows"),
+        LineEnding(LineEnding::MacClassicType, "\r" , "\\r", "Mac Classic"),
     };
     return types;
 }
 
 
 /// This methode returns the line ending from the given type
-LineEnding *LineEnding::get(int idx )
+LineEnding* LineEnding::get(size_t idx)
 {
-    Q_ASSERT( 0 <= idx && idx < TypeCount );
+    Q_ASSERT(idx < TypeCount);
     return types() + idx;
 }
 
 
 /// Returns the unix line ending type
-LineEnding*LineEnding::unixType()
+LineEnding* LineEnding::unixType()
 {
-    return get( UnixType );
+    return get(UnixType);
 }
 
 
 // returns the windows line ending type
-LineEnding*LineEnding::windowsType()
+LineEnding* LineEnding::windowsType()
 {
-    return get( WindowsType );
+    return get(WindowsType);
 
 }
 
 
 /// Returns the Mac class line ending type
-LineEnding*LineEnding::macClassicType()
+LineEnding* LineEnding::macClassicType()
 {
-    return get( MacClassicType );
+    return get(MacClassicType);
 }
 
 
@@ -56,11 +57,11 @@ LineEnding*LineEnding::macClassicType()
 /// @param chars the chars used for the line ending
 /// @param escaped an escaped variant of the characters
 /// @param name the name of the line ending
-LineEnding::LineEnding(LineEnding::Type type, const char* chars, const char* escaped, const char* name )
-    : type_( type )
-    , charsRef_( chars )
-    , escapedCharsRef_( escaped )
-    , nameRef_( name )
+LineEnding::LineEnding(LineEnding::Type type, const char* chars, const char* escaped, const char* name)
+    : type_(type)
+    , charsRef_(chars)
+    , escapedCharsRef_(escaped)
+    , nameRef_(name)
 {
 }
 
@@ -70,45 +71,44 @@ LineEnding::~LineEnding()
 }
 
 
-/// This method detects the, line endings of a QString.
+/// Detects the, line endings of a QString.
 /// A byte array is tricky because the encoding could be multi-byte
 ///
 /// @param str the string to find the line-endings.
 /// @param unknown the type to return when the ending is not nown. (defaults to 0)
 /// @return the found type or the unkown parameter if not found
 ///
-LineEnding *LineEnding::detect(const QString& str, LineEnding *unkown )
+LineEnding *LineEnding::detect(const QString& str, LineEnding *unkown)
 {
     const int endLoopWhenCountReaches = 3;
     int macClassicCount = 0;
     int unixCount = 0;
     int winCount = 0;
 
-    for( int i=0, cnt=str.length(); i<cnt; i++ ) {
-
+    for (qsizetype i = 0, cnt=str.length(); i < cnt; i++) {
         // retrieve the characters
         QChar c1 = str.at(i);
-        QChar c2 = (i+1<cnt) ? str.at(i+1) : QChar(0);
+        QChar c2 = (i + 1 < cnt) ? str.at(i + 1) : QChar(0);
 
         // detect the line-ending
-        if( c1 == '\r' ) {
-           if( c2 == '\n' ) {
+        if (c1 == '\r') {
+           if (c2 == '\n') {
                ++winCount;
                ++i;
-               if( winCount >= endLoopWhenCountReaches ) break;
+               if (winCount >= endLoopWhenCountReaches) break;
            } else  {
                ++macClassicCount;
-               if( macClassicCount >= endLoopWhenCountReaches ) break;
+               if (macClassicCount >= endLoopWhenCountReaches) break;
            }
         }
-        else if( c1 == '\n') {
+        else if (c1 == '\n') {
             ++unixCount;
-            if( unixCount >= endLoopWhenCountReaches ) break;
+            if (unixCount >= endLoopWhenCountReaches) break;
         }
     }
-    if( macClassicCount > unixCount && macClassicCount > winCount ) return get( LineEnding::MacClassicType );
-    if( winCount > unixCount ) return get( LineEnding::WindowsType );
-    if( unixCount > 0) return get( LineEnding::UnixType );
+    if (macClassicCount > unixCount && macClassicCount > winCount) return get(LineEnding::MacClassicType);
+    if (winCount > unixCount) return get(LineEnding::WindowsType );
+    if (unixCount > 0) return get(LineEnding::UnixType);
     return unkown;
 }
 

--- a/edbee-lib/edbee/util/lineending.h
+++ b/edbee-lib/edbee/util/lineending.h
@@ -19,40 +19,30 @@ public:
         TypeCount
     };
 
-
 protected:
 
-    explicit LineEnding( LineEnding::Type ending, const char* chars, const char* escaped_chars, const char* name );
+    explicit LineEnding(LineEnding::Type ending, const char* chars, const char* escaped_chars, const char* name);
     virtual ~LineEnding();
 
 public:
     static LineEnding* types();
     static int typeCount() { return TypeCount; }
-    static LineEnding* get( int idx );
+    static LineEnding* get(size_t idx);
 
     static LineEnding* unixType();
     static LineEnding* windowsType();
     static LineEnding* macClassicType();
 
+    static LineEnding* detect(const QString& str, LineEnding* unkownEnding = nullptr);
 
-    static LineEnding* detect( const QString& str, LineEnding* unkownEnding=0 );
-
-
-    /// This method returns the type
     virtual LineEnding::Type type() const { return type_; }
 
-    /// This method returns the chars
     virtual const char* chars() const { return charsRef_; }
 
-    /// This method returns the escaped chars
     virtual const char* escapedChars() const { return escapedCharsRef_; }
 
     /// This method returns the name of the line ending
     virtual const char* name() const { return nameRef_; }
-
-
- //   virtual LineEnding detectLineEnding
-//    virtual static QString lineEndingChars( LineEnding::Type endingType  );
 
 private:
 

--- a/edbee-lib/edbee/util/lineoffsetvector.cpp
+++ b/edbee-lib/edbee/util/lineoffsetvector.cpp
@@ -12,171 +12,178 @@ namespace edbee {
 
 LineOffsetVector::LineOffsetVector()
     : offsetList_(16)
-    , offsetDelta_(0)
     , offsetDeltaIndex_(0)
+    , offsetDelta_(0)
 {
     // make sure there's always line 0 in the buffer
-    int v=0;
+    ptrdiff_t v=0;
     offsetList_.replace( 0, 0, &v, 1);
 
     assertValid();
 }
 
+/// convenient method to apply the (signed) delta to an offset
+size_t applyDelta(ptrdiff_t offset, ptrdiff_t delta)
+{
+    ptrdiff_t result = static_cast<ptrdiff_t>(offset) + delta;
+    Q_ASSERT(result >= 0);
+    return static_cast<size_t>(result);
+}
+
 
 void LineOffsetVector::applyChange(TextBufferChange change)
 {
-// qDebug() << "";
-// qDebug() << "== [ applyChange ] ==========================";
-// qDebug() << ">> " << change.toDebugString();
+    ptrdiff_t offsetDelta = static_cast<ptrdiff_t>(change.newTextLength()) - static_cast<ptrdiff_t>(change.length());
 
-    int line = change.line() + 1;    // line 0 may NEVER be replaced!
+    // I assume it is save to cast a size_t to ptrdiff_t
+    if (sizeof(size_t) == sizeof(ptrdiff_t)) {
+        const ptrdiff_t* offsets = nullptr;
+        offsets = reinterpret_cast<const ptrdiff_t*>(change.newLineOffsets().constData());
+        applyChange(change.line(), change.lineCount(), change.newLineCount(), offsets, offsetDelta);
+    } else {
+        ptrdiff_t* offsets = new ptrdiff_t[change.newLineCount()]; // change.newLineOffsets().constData()
+        for (qsizetype i = 0, cnt = static_cast<qsizetype>(change.newLineCount()); i < cnt; ++i) {
+          offsets[i] = static_cast<const ptrdiff_t>(change.newLineOffsets()[i]);
+        }
+        applyChange(change.line(), change.lineCount(), change.newLineCount(), offsets, offsetDelta);
+        delete[] offsets;
+    }
+    return;
+}
+
+/// applies the change from a TextChangeData
+/// @param line the line-index this change is for
+/// @param removeineCount the number of lines to remove at line
+/// @param addLineCount the new number of lines to add
+/// @param newOffsets the new offets that are inserted at the line location (realy offsets! no delta applied!)
+/// @param offsetDelta the offset delta applied in this change. (difference in offset between the replaced texts)
+void LineOffsetVector::applyChange(size_t line, size_t removeLineCount, size_t addLineCount, const ptrdiff_t* newOffsets, ptrdiff_t offsetDelta)
+{
+    line += 1; // line 0 may NEVER be replaced!
 
     // repace the lines
     moveDeltaToIndex(line);
 
-// qDebug() << "";
-// QString offsets;
-// for( int i=0; i<change.newLineOffsets().size(); ++i ) {
-//     if( i ) { offsets.append(","); }
-//     offsets.append( QStringLiteral("%1").arg(change.newLineOffsets().at(i)));
-//     //qlog_info() << "-- " << i << ":" << change.newLineOffsets().at(i);
-// }
-// qlog_info() << "- before: " << toUnitTestString() ;
-// qlog_info() << "- offsetList_.replace(" << change.line() << "," << change.lineCount() << ": " << offsets << ")";
-
-    offsetList_.replace( line, change.lineCount(), change.newLineOffsets().constData(), change.newLineCount() );
-// qlog_info() << "- after: " << toUnitTestString();
-
+    // I assume it is save to cast a size_t to ptrdiff_t
+    // Officially this isn't allowed, so for now we allocate a new buffer
+    // and type cast every
+    offsetList_.replace(line, removeLineCount, newOffsets, addLineCount);
 
     // Add the delta to all the lines
-    int endLine = line + change.newLineCount();
+    size_t endLine = line + addLineCount;
 
-
-    if( offsetDeltaIndex_ < endLine ) {
+    if (offsetDeltaIndex_ < endLine) {
         offsetDeltaIndex_ = endLine;
     }
 
-    Q_ASSERT(offsetDeltaIndex_ >= 0);
     Q_ASSERT(offsetDeltaIndex_ <= this->length() );
 
-//qlog_info() <<"- offsetDeltaindex:" << offsetDeltaIndex_;
-
-    // qDebug() << "- endLine: " << endLine;
-    // qDebug() << "- change.newTextLength(): " << change.newTextLength();
-    // qDebug() << "- change.length(): " << change.length();
-    // qDebug() << "  => " << (static_cast<ptrdiff_t>(change.newTextLength()) - static_cast<ptrdiff_t>(change.length()));
-
-    // qDebug() << "";
-
-    changeOffsetDelta( endLine, static_cast<ptrdiff_t>(change.newTextLength()) - static_cast<ptrdiff_t>(change.length()));
-//qlog_info() << "end: " << toUnitTestString();
-//Q_ASSERT(this->length() !=5 );
+    changeOffsetDelta(endLine, offsetDelta);
     assertValid();
-}
-
-
-
-/*
-/// This method is should be called when text is replaced. This method
-/// updates all elements of the split vector and calculates all offsets
-/// @param offset the offset to change
-/// @param length the number of chars that are replaced
-
-void LineOffsetVector::textReplaced(int offset, int length, const QChar *newData , int newDataLength)
-{
-    LineChange change;
-    prepareChange(offset,length, newData, newDataLength, &change);
-    applyChange( &change );
 
 }
-*/
+
 
 /// this method returns the line offset at the given line offset
-int LineOffsetVector::at(int idx) const
+size_t LineOffsetVector::at(size_t idx) const
 {
-    Q_ASSERT( idx < length() );
-    if( idx >= offsetDeltaIndex_ ) {
-        return offsetList_.at(idx) + offsetDelta_;
+    Q_ASSERT(idx < length() );
+    if (idx >= offsetDeltaIndex_) {
+        return applyDelta(offsetList_.at(idx), offsetDelta_);
     }
-    return offsetList_.at(idx);
+    return applyDelta(offsetList_.at(idx), 0);
 }
 
-int LineOffsetVector::length() const
+
+size_t LineOffsetVector::length() const
 {
     return offsetList_.length();
 }
 
 
 /// this method searches the line from the given offset
-int LineOffsetVector::findLineFromOffset(int offset)
+size_t LineOffsetVector::findLineFromOffset(size_t offset)
 {
+    if (offset == 0) return 0;
 
-    if( offset == 0 ) return 0;
-    int offsetListLength = offsetList_.length();
-    int offsetAtDelta = 0;
-    if( offsetDeltaIndex_ < offsetListLength ) {
-        offsetAtDelta = offsetList_.at(offsetDeltaIndex_) + offsetDelta_;
+    size_t offsetListLength = offsetList_.length();
+    size_t offsetAtDelta = 0;
+    if (offsetDeltaIndex_ < offsetListLength) {
+        offsetAtDelta = applyDelta(offsetList_.at(offsetDeltaIndex_), offsetDelta_);
     } else {
-        offsetAtDelta = offsetList_.at( offsetListLength-1);
+        Q_ASSERT(offsetListLength > 0);
+        offsetAtDelta = applyDelta(offsetList_.at(offsetListLength - 1), 0);
     }
 
     // only binary search the left part
-    int line = 0;
-    if( offset < offsetAtDelta ) {
-        line = searchOffsetIgnoringOffsetDelta( offset, 0, offsetDeltaIndex_ );
+    size_t line = 0;
+    if (offset < offsetAtDelta) {
+        line = searchOffsetIgnoringOffsetDelta(static_cast<ptrdiff_t>(offset), 0, offsetDeltaIndex_);
 
     // binary search the right part
     } else {
-        line = searchOffsetIgnoringOffsetDelta( offset - offsetDelta_, offsetDeltaIndex_, offsetListLength );
+        line = searchOffsetIgnoringOffsetDelta(static_cast<ptrdiff_t>(offset) - offsetDelta_, offsetDeltaIndex_, offsetListLength);
     }
 
-    assertValid();
-
     return line;
-
 }
 
 /// This method appends an offset to the end of the list
 /// It simply applies the current offsetDelta because it will always be AFTER the current offsetDelta
-void LineOffsetVector::appendOffset(int offset)
+void LineOffsetVector::appendOffset(size_t offset)
 {
-    this->offsetList_.append( offset - offsetDelta_ );
-
+    ptrdiff_t newOffset = static_cast<ptrdiff_t>(offset) -offsetDelta_;
+    offsetList_.append(newOffset);
     assertValid();
 }
 
-/// This method returns the unitTestString representation
+
+/// This method returns the unitTestString representation => 1,2,[3>3,4
 QString LineOffsetVector::toUnitTestString()
 {
     QString s;
-    for (int i=0,cnt=offsetDeltaIndex_; i < cnt; ++i) {
+    for (size_t i = 0, cnt = offsetDeltaIndex_; i < cnt; ++i) {
         if (i != 0) { s.append(","); }
-        s.append( QStringLiteral("%1").arg( offsetList_[i] ) );
+        s.append(QStringLiteral("%1").arg( offsetList_[i]));
     }
-    s.append( QStringLiteral("[%1>").arg( offsetDelta_ ) );
-    for (int i=offsetDeltaIndex_, cnt = offsetList_.length(); i < cnt; ++i) {
+    if (offsetDeltaIndex_ > 0) s.append(",");
+    s.append( QStringLiteral("[%1>").arg(offsetDelta_) );
+    for (size_t i=offsetDeltaIndex_, cnt = offsetList_.length(); i < cnt; ++i) {
         if (i != offsetDeltaIndex_) { s.append(","); }
-        s.append( QStringLiteral("%1").arg( offsetList_[i] ) );
+        s.append(QStringLiteral("%1").arg(offsetList_[i]));
     }
     return s;
 }
+
+
+/// This method returns the unitTestString representaion with the offest removed (1,2,[3>3,4) => 1,2,6,7
+QString LineOffsetVector::toUnitTestFilledString()
+{
+    QString s;
+    for (size_t i = 0, cnt = length(); i < cnt; ++i) {
+        if (i != 0) { s.append(","); }
+        s.append(QStringLiteral("%1").arg(at(i)));
+    }
+    return s;
+}
+
 
 /// initializes the construct for unit testing
 /// @param offsetDelta the offsetDelta to use
 /// @param offsetDeltaIndex the offsetDeltaIndex to use
 /// @param a list of integer offsets. Close the list with -1 !!!
-void LineOffsetVector::initForUnitTesting(int offsetDelta, int offsetDeltaIndex, ... )
+void LineOffsetVector::initForUnitTesting(ptrdiff_t offsetDelta, size_t offsetDeltaIndex, ... )
 {
     offsetDelta_ = offsetDelta;
     offsetDeltaIndex_ = offsetDeltaIndex;
     offsetList_.clear();
 
     va_list offsets;
-    va_start( offsets, offsetDeltaIndex );
-    int val = va_arg ( offsets, int );
-    while( val >= 0 ) {
-        offsetList_.append( val);
-        val = va_arg ( offsets, int );
+    va_start(offsets, offsetDeltaIndex);
+    size_t val = va_arg(offsets, size_t);
+    while (val != std::string::npos) {
+        offsetList_.append(static_cast<ptrdiff_t>(val));
+        val = va_arg(offsets, size_t);
     }
     va_end(offsets);
 
@@ -184,84 +191,70 @@ void LineOffsetVector::initForUnitTesting(int offsetDelta, int offsetDeltaIndex,
 }
 
 
-
 /// This method returns the line from the start position. This method uses
 /// a binary search. Warning this method uses RAW values from the offsetList it does NOT
 /// take in account the offsetDelta
-int LineOffsetVector::searchOffsetIgnoringOffsetDelta(int offset, int org_start, int org_end )
+size_t LineOffsetVector::searchOffsetIgnoringOffsetDelta(ptrdiff_t offset, size_t org_start, size_t org_end )
 {
-//    const QList<int>& starts = lineOffsets_;
-    // This search happens in binary below
-    //
-    //    for( int i=0; i < starts.length(); ++i ) {
-    //        if( starts[i] > offset ) return i-1;
-    //    }
-    //    return starts.length() - 1;
+    size_t begin = org_start;
+    size_t end   = org_end - 1;
 
-//    int org_start = 0;
-//    int org_end   = starts.length();
+    if (begin == end) return begin;
 
-    int begin = org_start;
-    int end   = org_end-1;
-
-    if( begin == end ) return begin;
-
-
-    int half = end;
-    int r = 0;
-    while( begin <= end  ) {
-
+    size_t half = end;
+    ptrdiff_t r = 0;
+    while (begin <= end) {
         // BINAIRY SEARCH:
-        half = begin + ((end-begin)>>1);
+        half = begin + ((end - begin) >> 1);
 
         // compre the value
         r = offsetList_.at(half) - offset;
-        if( r == 0 ) { return half; }
-        if( r < 0 ) {
+        if (r == 0) { return half; }
+        if (r < 0) {
             begin = half + 1;
         } else {
             end = half -1;
         }
     }
 
-    if( r > 0 ) {
+    if (r > 0) {
         return half - 1;
     } else {
-        if( half == org_end ) return org_end -1 ;
+        if (half == org_end) return org_end -1 ;
         return half;
     }
-
-    assertValid();
 }
 
+
 /// This method moves the delta to the given index
-void LineOffsetVector::moveDeltaToIndex(int index)
+void LineOffsetVector::moveDeltaToIndex(size_t index)
 {
-    if( offsetDelta_ ) {
+    if (offsetDelta_) {
 
         // move to the right
-        if( offsetDeltaIndex_ < index ) {
-            for( int i=offsetDeltaIndex_; i<index; ++i ) {
-                offsetList_[i] += offsetDelta_; // apply the delta
+        if (offsetDeltaIndex_ < index) {
+            for(size_t i = offsetDeltaIndex_; i < index; ++i) {
+                offsetList_[i] += offsetDelta_;
             }
+
         // move to the left
-        } else if( index < offsetDeltaIndex_ ) {
+        } else if (index < offsetDeltaIndex_) {
 
             // In this situation there are 2 solution.
             // (1) Make the delta 0 or (2) apply the 'negative index' to the items on the left
-            int length            = offsetList_.length();
-            int delta0cost        = length - offsetDeltaIndex_;
-            int negativeDeltaCost = offsetDeltaIndex_ - index;
+            size_t length            = offsetList_.length();
+            size_t delta0cost        = length - offsetDeltaIndex_;
+            size_t negativeDeltaCost = offsetDeltaIndex_ - index;
 
             // prefer delta 0
-            if( delta0cost <= negativeDeltaCost ) {
-                for( int i=offsetDeltaIndex_; i < length; ++i ) {
+            if (delta0cost <= negativeDeltaCost) {
+                for (size_t i = offsetDeltaIndex_; i < length; ++i) {
                     offsetList_[i] += offsetDelta_;
                 }
                 offsetDelta_ = 0;
             // else apply the negative delta
             } else {
-                for( int i=index; i < offsetDeltaIndex_; ++i ) {
+                for (size_t i = index; i < offsetDeltaIndex_; ++i) {
                     offsetList_[i] -= offsetDelta_;
                 }
             }
@@ -272,10 +265,11 @@ void LineOffsetVector::moveDeltaToIndex(int index)
     assertValid();
 }
 
+
 /// This method moves the offset delta to the given location
-void LineOffsetVector::changeOffsetDelta(int index, ptrdiff_t delta)
+void LineOffsetVector::changeOffsetDelta(size_t index, ptrdiff_t delta)
 {
-    Q_ASSERT(0 <= index && index <= length());
+    Q_ASSERT(index <= length());
 
     // there are 3 situations.
     // (1) The delta is at the exact location of the previous delta
@@ -286,39 +280,22 @@ void LineOffsetVector::changeOffsetDelta(int index, ptrdiff_t delta)
     // (2) The new index is BEFORE the old index.
     } else if (index < offsetDeltaIndex_) {
         // apply the 'negative' offset to the given location
-        for( int i=index; i < offsetDeltaIndex_; ++i ) {
-            offsetList_[i] -= ( offsetDelta_ + delta );
+        for (size_t i = index; i < offsetDeltaIndex_; ++i) {
+            offsetList_[i] -= (offsetDelta_ + delta);
+            // offsetList_[i] -= (offsetDelta_ + delta);
         }
+
         offsetDeltaIndex_ = index;
         offsetDelta_ += delta;
 
     // (3) the index is after the old index.
-    } else if( offsetDeltaIndex_ < index ) {
+    } else if (offsetDeltaIndex_ < index) {
         // apply the old offsetsDelta to the indices before
-        for( int i = offsetDeltaIndex_; i < index; ++i ) {
+        for (size_t i = offsetDeltaIndex_; i < index; ++i) {
             offsetList_[i] += offsetDelta_;
         }
         offsetDeltaIndex_ = index;
         offsetDelta_ += delta;
-    }
-
-    // Remove all offset's that are incorrect - this shouldn't happen normally
-    // This removes all offset after the delta that are smaller the offset before the delta
-    if( offsetDeltaIndex_ < length() ) {
-        int offsetBeforeDelta = offsetDeltaIndex_ > 0 ? offsetList_[offsetDeltaIndex_ - 1] : 0;
-        int lastIncorrectIndex = -1;
-        for (int i = offsetDeltaIndex_; i < length(); ++i) {
-            if (offsetBeforeDelta < offsetList_[i] + offsetDelta_) {
-                break;
-            } else {
-                lastIncorrectIndex = i;
-            }
-        }
-
-        if (lastIncorrectIndex >= 0) {
-            int dummy = 0;
-            offsetList_.replace(offsetDeltaIndex_, lastIncorrectIndex - offsetDeltaIndex_ + 1, &dummy, 0);
-        }
     }
 
     // set the delta to 0 when at the end of the line
@@ -329,30 +306,34 @@ void LineOffsetVector::changeOffsetDelta(int index, ptrdiff_t delta)
     assertValid();
 }
 
-/// Asserts the data is valid
-void LineOffsetVector::assertValid()
+/// Sets the offset delta and asserts the delta can be changed this way
+/// -
+void LineOffsetVector::setOffsetDelta(ptrdiff_t delta)
 {
-// qlog_info() << "* assertValid: " << toUnitTestString();
-    Q_ASSERT(offsetDeltaIndex_ >= 0);
-
-    // assert all offsets are always valid
-    int lastOffset = -1;
-    for (int i = 0; i < offsetDeltaIndex_; ++i) {
-        Q_ASSERT(offsetList_[i] >= 0);
-        Q_ASSERT(lastOffset < offsetList_[i]);
-        lastOffset = offsetList_[i];
-    }
-    for (int i = offsetDeltaIndex_, cnt = offsetList_.length(); i < cnt; ++i) {
-        int offset = (offsetList_[i] + offsetDelta_);
-        Q_ASSERT( offset >= 0);
-        Q_ASSERT(lastOffset < offset);
-        lastOffset = offset;
-
-    }
-
+    size_t offsetBeforeDelta = offsetDeltaIndex_ > 0 ? applyDelta(offsetList_[offsetDeltaIndex_ -1], 0) : 0;
+    size_t offsetAtDelta = applyDelta(offsetList_[offsetDeltaIndex_], delta);
+    Q_ASSERT(offsetBeforeDelta < offsetAtDelta);
+    this->offsetDelta_ = delta;
 }
 
 
+/// Asserts the data is valid
+void LineOffsetVector::assertValid()
+{
+    Q_ASSERT(offsetDeltaIndex_ >= 0);
 
+    // assert all offsets are always valid
+    ptrdiff_t lastOffset = -1;
+    for (size_t i = 0; i < offsetDeltaIndex_; ++i) {
+        Q_ASSERT(lastOffset < offsetList_[i]);
+        lastOffset = offsetList_[i];
+    }
+
+    for (size_t i = offsetDeltaIndex_, cnt = offsetList_.length(); i < cnt; ++i) {
+        ptrdiff_t offset = offsetList_[i] + offsetDelta_;
+        Q_ASSERT(lastOffset < offset);
+        lastOffset = offset;
+    }
+}
 
 } // edbee

--- a/edbee-lib/edbee/util/lineoffsetvector.cpp
+++ b/edbee-lib/edbee/util/lineoffsetvector.cpp
@@ -232,8 +232,6 @@ void LineOffsetVector::changeOffsetDelta(size_t index, std::ptrdiff_t delta)
     // (2) The new index is BEFORE the old index.
     } else if (index < offsetDeltaIndex_) {
 
-qDebug() << "changeOFfsetDelta(" << index << ", " << delta <<")";
-qDebug() << "  => " << this->toUnitTestString();
         // apply the 'negative' offset to the given location
         for (size_t i=index; i < offsetDeltaIndex_; ++i) {
 
@@ -244,10 +242,7 @@ qDebug() << "  => " << this->toUnitTestString();
             } else {
                 offsetList_[i] -= static_cast<size_t>(offsetDelta_ + delta);
             }
-qDebug() << "   -= (" << offsetDelta_ << " + " << delta << "), (" << (offsetDelta_ + delta) << ")";
-qDebug() << "   => " << offsetList_[i];
         }
-qDebug() << "-- (offsetDelta_ = "<< offsetDelta_ <<", offsetDeltaIndex_=" << offsetDeltaIndex_ <<", delta=" << delta<<")";
         offsetDeltaIndex_ = index;
         offsetDelta_ += delta;
 

--- a/edbee-lib/edbee/util/lineoffsetvector.cpp
+++ b/edbee-lib/edbee/util/lineoffsetvector.cpp
@@ -16,107 +16,131 @@ LineOffsetVector::LineOffsetVector()
     , offsetDeltaIndex_(0)
 {
     // make sure there's always line 0 in the buffer
-    size_t v = 0;
-    offsetList_.replace(0, 0, &v, 1);
+    int v=0;
+    offsetList_.replace( 0, 0, &v, 1);
 }
 
 
 void LineOffsetVector::applyChange(TextBufferChange change)
 {
-    size_t line = change.line() + 1;    // line 0 may NEVER be replaced!
+//qlog_info() << "== [ applyChange ] =================";
+
+    int line = change.line() + 1;    // line 0 may NEVER be replaced!
 
     // repace the lines
-    moveDeltaToIndex(line);
+    moveDeltaToIndex( line );
 
-    offsetList_.replace(line, change.lineCount(), change.newLineOffsets().constData(), change.newLineCount());
+
+//QString offsets;
+//for( int i=0; i<change.newLineOffsets().size(); ++i ) {
+//    if( i ) { offsets.append(","); }
+//    offsets.append( QStringLiteral("%1").arg(change.newLineOffsets().at(i)));
+//    //qlog_info() << "-- " << i << ":" << change.newLineOffsets().at(i);
+//}
+
+
+//qlog_info() << "- before: " << toUnitTestString() ;
+//qlog_info() << "- offsetList_.replace(" << change.line() << "," << change.lineCount() << ": " << offsets << ")";
+    offsetList_.replace( line, change.lineCount(), change.newLineOffsets().constData(), change.newLineCount() );
+//qlog_info() << "- after: " << toUnitTestString();
+
 
     // Add the delta to all the lines
-    size_t endLine = line + change.newLineCount();
+    int endLine = line + change.newLineCount();
 
-    if (offsetDeltaIndex_ < endLine) {
+
+    if( offsetDeltaIndex_ < endLine ) {
         offsetDeltaIndex_ = endLine;
     }
 
-    Q_ASSERT(offsetDeltaIndex_ <= this->length());
+    Q_ASSERT(offsetDeltaIndex_ >= 0);
+    Q_ASSERT(offsetDeltaIndex_ <= this->length() );
 
-    changeOffsetDelta(endLine, static_cast<ptrdiff_t>(change.newTextLength()) - static_cast<ptrdiff_t>(change.length()));
+//qlog_info() <<"- offsetDeltaindex:" << offsetDeltaIndex_;
+
+    changeOffsetDelta( endLine, change.newTextLength() - change.length() );
+//qlog_info() << "end: " << toUnitTestString();
+//Q_ASSERT(this->length() !=5 );
 }
 
-// applies the given delta
-size_t applyDelta(size_t offset, ptrdiff_t delta)
+
+
+/*
+/// This method is should be called when text is replaced. This method
+/// updates all elements of the split vector and calculates all offsets
+/// @param offset the offset to change
+/// @param length the number of chars that are replaced
+/// @param text the new text
+void LineOffsetVector::textReplaced(int offset, int length, const QChar *newData , int newDataLength)
 {
-    size_t uDelta = static_cast<size_t>(qAbs(delta));
+    LineChange change;
+    prepareChange(offset,length, newData, newDataLength, &change);
+    applyChange( &change );
 
-    if (delta < 0) {
-        Q_ASSERT(uDelta <= offset);
-        return offset - uDelta;
-    } else {
-        return offset + uDelta;
-    }
 }
+*/
 
 /// this method returns the line offset at the given line offset
-size_t LineOffsetVector::at(size_t idx) const
+int LineOffsetVector::at(int idx) const
 {
-    Q_ASSERT(idx < length());
-    if (idx >= offsetDeltaIndex_) {
-        return applyDelta(offsetList_.at(idx), offsetDelta_);
+    Q_ASSERT( idx < length() );
+    if( idx >= offsetDeltaIndex_ ) {
+        return offsetList_.at(idx) + offsetDelta_;
     }
     return offsetList_.at(idx);
 }
 
-
-size_t LineOffsetVector::length() const
+int LineOffsetVector::length() const
 {
     return offsetList_.length();
 }
 
 
-/// Searches the line from the given offset
-size_t LineOffsetVector::findLineFromOffset(size_t offset)
+/// this method searches the line from the given offset
+int LineOffsetVector::findLineFromOffset(int offset)
 {
-    if (offset == 0) return 0;
-    size_t offsetListLength = offsetList_.length();
-    size_t offsetAtDelta = 0;
-    if (offsetDeltaIndex_ < offsetListLength) {
-        offsetAtDelta = applyDelta(offsetList_.at(offsetDeltaIndex_), offsetDelta_);
+
+    if( offset == 0 ) return 0;
+    int offsetListLength = offsetList_.length();
+    int offsetAtDelta = 0;
+    if( offsetDeltaIndex_ < offsetListLength ) {
+        offsetAtDelta = offsetList_.at(offsetDeltaIndex_) + offsetDelta_;
     } else {
-        offsetAtDelta = offsetList_.at( offsetListLength - 1);
+        offsetAtDelta = offsetList_.at( offsetListLength-1);
     }
 
     // only binary search the left part
-    size_t line = 0;
-    if (offset < offsetAtDelta) {
-        line = searchOffsetIgnoringOffsetDelta(offset, 0, offsetDeltaIndex_);
+    int line = 0;
+    if( offset < offsetAtDelta ) {
+        line = searchOffsetIgnoringOffsetDelta( offset, 0, offsetDeltaIndex_ );
 
     // binary search the right part
     } else {
-        line = searchOffsetIgnoringOffsetDelta(applyDelta(offset, - offsetDelta_), offsetDeltaIndex_, offsetListLength);
+        line = searchOffsetIgnoringOffsetDelta( offset - offsetDelta_, offsetDeltaIndex_, offsetListLength );
     }
     return line;
+
 }
 
-
-/// Appends an offset to the end of the list
+/// This method appends an offset to the end of the list
 /// It simply applies the current offsetDelta because it will always be AFTER the current offsetDelta
-void LineOffsetVector::appendOffset(size_t offset)
+void LineOffsetVector::appendOffset(int offset)
 {
-    this->offsetList_.append(applyDelta(offset, -offsetDelta_));
+    this->offsetList_.append( offset - offsetDelta_ );
 }
-
 
 /// This method returns the offset to string
-QString LineOffsetVector::toUnitTestString() const
+QString LineOffsetVector::toUnitTestString()
 {
     QString s;
-    for (size_t i=0, cnt = offsetDeltaIndex_; i < cnt; ++i) {
-        if (i != 0) { s.append(","); }
-        s.append(QStringLiteral("%1").arg(offsetList_[i]));
+    for( int i=0,cnt=offsetDeltaIndex_; i<cnt; ++i ) {
+        if( i != 0 ) { s.append(","); }
+        s.append( QStringLiteral("%1").arg( offsetList_[i] ) );
     }
-    s.append(QStringLiteral("[%1>").arg(offsetDelta_ ));
-    for (size_t i = offsetDeltaIndex_, cnt = offsetList_.length(); i < cnt; ++i) {
-        if (i != offsetDeltaIndex_) { s.append(","); }
-        s.append(QStringLiteral("%1").arg( offsetList_[i]));
+    s.append( QStringLiteral("[%1>").arg( offsetDelta_ ) );
+    for( int i=offsetDeltaIndex_,cnt=offsetList_.length(); i<cnt; ++i ) {
+        if( i != offsetDeltaIndex_ ) { s.append(","); }
+        s.append( QStringLiteral("%1").arg( offsetList_[i] ) );
     }
     return s;
 }
@@ -125,136 +149,141 @@ QString LineOffsetVector::toUnitTestString() const
 /// @param offsetDelta the offsetDelta to use
 /// @param offsetDeltaIndex the offsetDeltaIndex to use
 /// @param a list of integer offsets. Close the list with -1 !!!
-void LineOffsetVector::initForUnitTesting(ptrdiff_t offsetDelta, size_t offsetDeltaIndex, ... )
+void LineOffsetVector::initForUnitTesting(int offsetDelta, int offsetDeltaIndex, ... )
 {
     offsetDelta_ = offsetDelta;
     offsetDeltaIndex_ = offsetDeltaIndex;
     offsetList_.clear();
 
     va_list offsets;
-    va_start(offsets, offsetDeltaIndex);
-    size_t val = va_arg(offsets, size_t);
-    while (val != std::string::npos) {
-        offsetList_.append(val);
-        val = va_arg(offsets, size_t);
+    va_start( offsets, offsetDeltaIndex );
+    int val = va_arg ( offsets, int );
+    while( val >= 0 ) {
+        offsetList_.append( val);
+        val = va_arg ( offsets, int );
     }
     va_end(offsets);
 }
 
 
-/// Returns the line from the start position. This method uses a binary search.
-/// Warning this method uses RAW values from the offsetList it does NOT
+
+/// This method returns the line from the start position. This method uses
+/// a binary search. Warning this method uses RAW values from the offsetList it does NOT
 /// take in account the offsetDelta
-size_t LineOffsetVector::searchOffsetIgnoringOffsetDelta(size_t offset, size_t org_start, size_t org_end)
+int LineOffsetVector::searchOffsetIgnoringOffsetDelta(int offset, int org_start, int org_end )
 {
-    size_t begin = org_start;
-    size_t end   = org_end - 1;
+//    const QList<int>& starts = lineOffsets_;
+    // This search happens in binary below
+    //
+    //    for( int i=0; i < starts.length(); ++i ) {
+    //        if( starts[i] > offset ) return i-1;
+    //    }
+    //    return starts.length() - 1;
 
-    if (begin == end) return begin;
+//    int org_start = 0;
+//    int org_end   = starts.length();
 
-    size_t half = end;
-    size_t offsetAtHalf = 0;
+    int begin = org_start;
+    int end   = org_end-1;
+
+    if( begin == end ) return begin;
+
+
+    int half = end;
+    int r = 0;
     while( begin <= end  ) {
 
         // BINAIRY SEARCH:
         half = begin + ((end-begin)>>1);
 
-        // compare the value
-        offsetAtHalf = offsetList_.at(half);
-
-        if (offsetAtHalf == offset) {
-           return half;
-        }
-        if ( offsetAtHalf < offset ) {
+        // compre the value
+        r = offsetList_.at(half) - offset;
+        if( r == 0 ) { return half; }
+        if( r < 0 ) {
             begin = half + 1;
         } else {
             end = half -1;
         }
     }
 
-    if (offsetAtHalf > offset) {
+    if( r > 0 ) {
         return half - 1;
     } else {
-        if( half == org_end ) return org_end - 1;
+        if( half == org_end ) return org_end -1 ;
         return half;
     }
+
 }
 
-/// <oves the delta to the given index
-void LineOffsetVector::moveDeltaToIndex(size_t index)
+/// This method moves the delta to the given index
+void LineOffsetVector::moveDeltaToIndex(int index)
 {
-    if (offsetDelta_) {
+    if( offsetDelta_ ) {
 
         // move to the right
-        if (offsetDeltaIndex_ < index) {
-            for (size_t i = offsetDeltaIndex_; i < index; ++i) {
-                offsetList_[i] = applyDelta(offsetList_[i], offsetDelta_); // apply the delta
+        if( offsetDeltaIndex_ < index ) {
+            for( int i=offsetDeltaIndex_; i<index; ++i ) {
+                offsetList_[i] += offsetDelta_; // apply the delta
             }
         // move to the left
-        } else if (index < offsetDeltaIndex_) {
+        } else if( index < offsetDeltaIndex_ ) {
+
             // In this situation there are 2 solution.
             // (1) Make the delta 0 or (2) apply the 'negative index' to the items on the left
-            size_t length         = offsetList_.length();
-            size_t delta0cost     = length - offsetDeltaIndex_;
-            size_t negativeDeltaCost = offsetDeltaIndex_ - index;
+            int length            = offsetList_.length();
+            int delta0cost        = length - offsetDeltaIndex_;
+            int negativeDeltaCost = offsetDeltaIndex_ - index;
 
             // prefer delta 0
-            if (delta0cost <= negativeDeltaCost) {
-                for (size_t i=offsetDeltaIndex_; i < length; ++i) {
-                    offsetList_[i] = applyDelta(offsetList_[i], offsetDelta_);
+            if( delta0cost <= negativeDeltaCost ) {
+                for( int i=offsetDeltaIndex_; i < length; ++i ) {
+                    offsetList_[i] += offsetDelta_;
                 }
                 offsetDelta_ = 0;
-
             // else apply the negative delta
             } else {
-                for (size_t i = index; i < offsetDeltaIndex_; ++i) {
-                    offsetList_[i] = applyDelta(offsetList_[i], -offsetDelta_);
+                for( int i=index; i < offsetDeltaIndex_; ++i ) {
+                    offsetList_[i] -= offsetDelta_;
                 }
             }
         }
     }
     offsetDeltaIndex_ = index;
+
 }
 
-
 /// This method moves the offset delta to the given location
-void LineOffsetVector::changeOffsetDelta(size_t index, std::ptrdiff_t delta)
+void LineOffsetVector::changeOffsetDelta(int index, int delta)
 {
     // there are 3 situations.
     // (1) The delta is at the exact location of the previous delta
-    if (index == offsetDeltaIndex_) {
+    if( index == offsetDeltaIndex_ ) {
         offsetDeltaIndex_ = index;
         offsetDelta_ += delta;
 
     // (2) The new index is BEFORE the old index.
-    } else if (index < offsetDeltaIndex_) {
-        // apply the 'negative' offset to the given location
-        for (size_t i=index; i < offsetDeltaIndex_; ++i) {
+    } else if( index < offsetDeltaIndex_ ) {
 
-            // negative offset values are strange!
-            if (static_cast<size_t>(offsetDelta_ + delta) > offsetList_[i] ) {
-                Q_ASSERT(false && "Negative offset values aren't allowed");
-                offsetList_[i] = 0;
-            } else {
-                offsetList_[i] -= static_cast<size_t>(offsetDelta_ + delta);
-            }
+        // apply the 'negative' offset to the given location
+        for( int i=index; i < offsetDeltaIndex_; ++i ) {
+            offsetList_[i] -= ( offsetDelta_ + delta );
         }
         offsetDeltaIndex_ = index;
         offsetDelta_ += delta;
 
     // (3) the index is after the old index.
-    } else if (offsetDeltaIndex_ < index) {
+    } else if( offsetDeltaIndex_ < index ) {
 
         // apply the old offsetsDelta to the indices before
-        for (size_t i = offsetDeltaIndex_; i < index; ++i) {
-            offsetList_[i] = applyDelta(offsetList_[i], offsetDelta_);
+        for( int i = offsetDeltaIndex_; i<index; ++i ) {
+            offsetList_[i] += offsetDelta_;
         }
         offsetDeltaIndex_ = index;
         offsetDelta_ += delta;
     }
 
     // set the delta to 0 when at the end of the line
-    if (offsetDeltaIndex_ == length()) {
+    if( offsetDeltaIndex_ == length() ) {
         offsetDelta_ = 0;
     }
 

--- a/edbee-lib/edbee/util/lineoffsetvector.cpp
+++ b/edbee-lib/edbee/util/lineoffsetvector.cpp
@@ -16,51 +16,30 @@ LineOffsetVector::LineOffsetVector()
     , offsetDeltaIndex_(0)
 {
     // make sure there's always line 0 in the buffer
-    int v=0;
-    offsetList_.replace( 0, 0, &v, 1);
+    size_t v = 0;
+    offsetList_.replace(0, 0, &v, 1);
 }
 
 
 void LineOffsetVector::applyChange(TextBufferChange change)
 {
-//qlog_info() << "== [ applyChange ] =================";
-
-    int line = change.line() + 1;    // line 0 may NEVER be replaced!
+    size_t line = change.line() + 1;    // line 0 may NEVER be replaced!
 
     // repace the lines
     moveDeltaToIndex( line );
 
-
-//QString offsets;
-//for( int i=0; i<change.newLineOffsets().size(); ++i ) {
-//    if( i ) { offsets.append(","); }
-//    offsets.append( QStringLiteral("%1").arg(change.newLineOffsets().at(i)));
-//    //qlog_info() << "-- " << i << ":" << change.newLineOffsets().at(i);
-//}
-
-
-//qlog_info() << "- before: " << toUnitTestString() ;
-//qlog_info() << "- offsetList_.replace(" << change.line() << "," << change.lineCount() << ": " << offsets << ")";
-    offsetList_.replace( line, change.lineCount(), change.newLineOffsets().constData(), change.newLineCount() );
-//qlog_info() << "- after: " << toUnitTestString();
-
+    offsetList_.replace(line, change.lineCount(), change.newLineOffsets().constData(), change.newLineCount());
 
     // Add the delta to all the lines
     int endLine = line + change.newLineCount();
-
 
     if( offsetDeltaIndex_ < endLine ) {
         offsetDeltaIndex_ = endLine;
     }
 
-    Q_ASSERT(offsetDeltaIndex_ >= 0);
     Q_ASSERT(offsetDeltaIndex_ <= this->length() );
 
-//qlog_info() <<"- offsetDeltaindex:" << offsetDeltaIndex_;
-
-    changeOffsetDelta( endLine, change.newTextLength() - change.length() );
-//qlog_info() << "end: " << toUnitTestString();
-//Q_ASSERT(this->length() !=5 );
+    changeOffsetDelta(endLine, change.newTextLength() - change.length());
 }
 
 
@@ -81,42 +60,41 @@ void LineOffsetVector::textReplaced(int offset, int length, const QChar *newData
 */
 
 /// this method returns the line offset at the given line offset
-int LineOffsetVector::at(int idx) const
+size_t LineOffsetVector::at(size_t idx) const
 {
-    Q_ASSERT( idx < length() );
-    if( idx >= offsetDeltaIndex_ ) {
+    Q_ASSERT(idx < length());
+    if (idx >= offsetDeltaIndex_) {
         return offsetList_.at(idx) + offsetDelta_;
     }
     return offsetList_.at(idx);
 }
 
-int LineOffsetVector::length() const
+size_t LineOffsetVector::length() const
 {
     return offsetList_.length();
 }
 
 
 /// this method searches the line from the given offset
-int LineOffsetVector::findLineFromOffset(int offset)
+size_t LineOffsetVector::findLineFromOffset(size_t offset)
 {
-
     if( offset == 0 ) return 0;
-    int offsetListLength = offsetList_.length();
-    int offsetAtDelta = 0;
+    size_t offsetListLength = offsetList_.length();
+    size_t offsetAtDelta = 0;
     if( offsetDeltaIndex_ < offsetListLength ) {
         offsetAtDelta = offsetList_.at(offsetDeltaIndex_) + offsetDelta_;
     } else {
-        offsetAtDelta = offsetList_.at( offsetListLength-1);
+        offsetAtDelta = offsetList_.at( offsetListLength - 1);
     }
 
     // only binary search the left part
-    int line = 0;
-    if( offset < offsetAtDelta ) {
-        line = searchOffsetIgnoringOffsetDelta( offset, 0, offsetDeltaIndex_ );
+    size_t line = 0;
+    if (offset < offsetAtDelta) {
+        line = searchOffsetIgnoringOffsetDelta(offset, 0, offsetDeltaIndex_);
 
     // binary search the right part
     } else {
-        line = searchOffsetIgnoringOffsetDelta( offset - offsetDelta_, offsetDeltaIndex_, offsetListLength );
+        line = searchOffsetIgnoringOffsetDelta(offset - offsetDelta_, offsetDeltaIndex_, offsetListLength);
     }
     return line;
 
@@ -124,9 +102,9 @@ int LineOffsetVector::findLineFromOffset(int offset)
 
 /// This method appends an offset to the end of the list
 /// It simply applies the current offsetDelta because it will always be AFTER the current offsetDelta
-void LineOffsetVector::appendOffset(int offset)
+void LineOffsetVector::appendOffset(size_t offset)
 {
-    this->offsetList_.append( offset - offsetDelta_ );
+    this->offsetList_.append(offset - offsetDelta_);
 }
 
 /// This method returns the offset to string
@@ -149,100 +127,90 @@ QString LineOffsetVector::toUnitTestString()
 /// @param offsetDelta the offsetDelta to use
 /// @param offsetDeltaIndex the offsetDeltaIndex to use
 /// @param a list of integer offsets. Close the list with -1 !!!
-void LineOffsetVector::initForUnitTesting(int offsetDelta, int offsetDeltaIndex, ... )
+void LineOffsetVector::initForUnitTesting(size_t offsetDelta, size_t offsetDeltaIndex, ... )
 {
     offsetDelta_ = offsetDelta;
     offsetDeltaIndex_ = offsetDeltaIndex;
     offsetList_.clear();
 
     va_list offsets;
-    va_start( offsets, offsetDeltaIndex );
-    int val = va_arg ( offsets, int );
-    while( val >= 0 ) {
-        offsetList_.append( val);
-        val = va_arg ( offsets, int );
+    va_start(offsets, offsetDeltaIndex);
+    size_t val = va_arg(offsets, size_t);
+    while (val != std::string::npos) {
+        offsetList_.append(val);
+        val = va_arg(offsets, size_t);
     }
     va_end(offsets);
 }
 
 
 
-/// This method returns the line from the start position. This method uses
-/// a binary search. Warning this method uses RAW values from the offsetList it does NOT
+/// Returns the line from the start position. This method uses a binary search.
+/// Warning this method uses RAW values from the offsetList it does NOT
 /// take in account the offsetDelta
-int LineOffsetVector::searchOffsetIgnoringOffsetDelta(int offset, int org_start, int org_end )
+size_t LineOffsetVector::searchOffsetIgnoringOffsetDelta(size_t offset, size_t org_start, size_t org_end)
 {
-//    const QList<int>& starts = lineOffsets_;
-    // This search happens in binary below
-    //
-    //    for( int i=0; i < starts.length(); ++i ) {
-    //        if( starts[i] > offset ) return i-1;
-    //    }
-    //    return starts.length() - 1;
+    size_t begin = org_start;
+    size_t end   = org_end - 1;
 
-//    int org_start = 0;
-//    int org_end   = starts.length();
+    if (begin == end) return begin;
 
-    int begin = org_start;
-    int end   = org_end-1;
-
-    if( begin == end ) return begin;
-
-
-    int half = end;
-    int r = 0;
+    size_t half = end;
+    size_t offsetAtHalf = 0;
     while( begin <= end  ) {
 
         // BINAIRY SEARCH:
         half = begin + ((end-begin)>>1);
 
-        // compre the value
-        r = offsetList_.at(half) - offset;
-        if( r == 0 ) { return half; }
-        if( r < 0 ) {
+        // compare the value
+        offsetAtHalf = offsetList_.at(half);
+
+        if (offsetAtHalf == offset) {
+           return half;
+        }
+        if ( offsetAtHalf < offset ) {
             begin = half + 1;
         } else {
             end = half -1;
         }
     }
 
-    if( r > 0 ) {
+    if (offsetAtHalf > offset) {
         return half - 1;
     } else {
-        if( half == org_end ) return org_end -1 ;
+        if( half == org_end ) return org_end - 1;
         return half;
     }
-
 }
 
-/// This method moves the delta to the given index
-void LineOffsetVector::moveDeltaToIndex(int index)
+/// <oves the delta to the given index
+void LineOffsetVector::moveDeltaToIndex(size_t index)
 {
-    if( offsetDelta_ ) {
+    if (offsetDelta_) {
 
         // move to the right
-        if( offsetDeltaIndex_ < index ) {
-            for( int i=offsetDeltaIndex_; i<index; ++i ) {
+        if (offsetDeltaIndex_ < index) {
+            for (int i=offsetDeltaIndex_; i < index; ++i) {
                 offsetList_[i] += offsetDelta_; // apply the delta
             }
         // move to the left
-        } else if( index < offsetDeltaIndex_ ) {
+        } else if (index < offsetDeltaIndex_) {
 
             // In this situation there are 2 solution.
             // (1) Make the delta 0 or (2) apply the 'negative index' to the items on the left
-            int length            = offsetList_.length();
-            int delta0cost        = length - offsetDeltaIndex_;
-            int negativeDeltaCost = offsetDeltaIndex_ - index;
+            size_t length         = offsetList_.length();
+            size_t delta0cost     = length - offsetDeltaIndex_;
+            size_t negativeDeltaCost = offsetDeltaIndex_ - index;
 
             // prefer delta 0
-            if( delta0cost <= negativeDeltaCost ) {
-                for( int i=offsetDeltaIndex_; i < length; ++i ) {
+            if (delta0cost <= negativeDeltaCost) {
+                for (size_t i=offsetDeltaIndex_; i < length; ++i) {
                     offsetList_[i] += offsetDelta_;
                 }
                 offsetDelta_ = 0;
             // else apply the negative delta
             } else {
-                for( int i=index; i < offsetDeltaIndex_; ++i ) {
+                for (size_t i=index; i < offsetDeltaIndex_; ++i) {
                     offsetList_[i] -= offsetDelta_;
                 }
             }
@@ -253,29 +221,41 @@ void LineOffsetVector::moveDeltaToIndex(int index)
 }
 
 /// This method moves the offset delta to the given location
-void LineOffsetVector::changeOffsetDelta(int index, int delta)
+void LineOffsetVector::changeOffsetDelta(size_t index, std::ptrdiff_t delta)
 {
     // there are 3 situations.
     // (1) The delta is at the exact location of the previous delta
-    if( index == offsetDeltaIndex_ ) {
+    if (index == offsetDeltaIndex_) {
         offsetDeltaIndex_ = index;
         offsetDelta_ += delta;
 
     // (2) The new index is BEFORE the old index.
-    } else if( index < offsetDeltaIndex_ ) {
+    } else if (index < offsetDeltaIndex_) {
 
+qDebug() << "changeOFfsetDelta(" << index << ", " << delta <<")";
+qDebug() << "  => " << this->toUnitTestString();
         // apply the 'negative' offset to the given location
-        for( int i=index; i < offsetDeltaIndex_; ++i ) {
-            offsetList_[i] -= ( offsetDelta_ + delta );
+        for (size_t i=index; i < offsetDeltaIndex_; ++i) {
+
+            // negative offset values are strange!
+            if (static_cast<size_t>(offsetDelta_ + delta) > offsetList_[i] ) {
+                Q_ASSERT(false && "Negative offset values aren't allowed");
+                offsetList_[i] = 0;
+            } else {
+                offsetList_[i] -= static_cast<size_t>(offsetDelta_ + delta);
+            }
+qDebug() << "   -= (" << offsetDelta_ << " + " << delta << "), (" << (offsetDelta_ + delta) << ")";
+qDebug() << "   => " << offsetList_[i];
         }
+qDebug() << "-- (offsetDelta_ = "<< offsetDelta_ <<", offsetDeltaIndex_=" << offsetDeltaIndex_ <<", delta=" << delta<<")";
         offsetDeltaIndex_ = index;
         offsetDelta_ += delta;
 
     // (3) the index is after the old index.
-    } else if( offsetDeltaIndex_ < index ) {
+    } else if (offsetDeltaIndex_ < index) {
 
         // apply the old offsetsDelta to the indices before
-        for( int i = offsetDeltaIndex_; i<index; ++i ) {
+        for (size_t i = offsetDeltaIndex_; i < index; ++i) {
             offsetList_[i] += offsetDelta_;
         }
         offsetDeltaIndex_ = index;
@@ -283,7 +263,7 @@ void LineOffsetVector::changeOffsetDelta(int index, int delta)
     }
 
     // set the delta to 0 when at the end of the line
-    if( offsetDeltaIndex_ == length() ) {
+    if (offsetDeltaIndex_ == length()) {
         offsetDelta_ = 0;
     }
 

--- a/edbee-lib/edbee/util/lineoffsetvector.h
+++ b/edbee-lib/edbee/util/lineoffsetvector.h
@@ -26,6 +26,10 @@ class TextBufferChange;
 /// NOTE: The offsetDelta can be negative! If data is deleted negative offsets
 ///   make sure the offsets can be displaced quickly
 ///
+/// NOTE2:
+///   The internal offsetList_ can also be negative!
+///   This is required to handle efficient deletes
+///
 class EDBEE_EXPORT LineOffsetVector {
 public:
     /// a structure to describe the line change that happend
@@ -40,38 +44,42 @@ public:
     LineOffsetVector();
 
     void applyChange(TextBufferChange change);
+    void applyChange(size_t line, size_t lineCount, size_t newLineCount, const ptrdiff_t* newLineOffsets, ptrdiff_t offsetDelta);
 
+    size_t at(size_t idx) const;
+    size_t length() const;
 
-    int at(int idx) const;
-    int length() const;
+    size_t findLineFromOffset(size_t offset);
 
-    int findLineFromOffset( int offset );
+    ptrdiff_t offsetDelta() { return offsetDelta_; }
+    size_t offsetDeltaIndex() { return offsetDeltaIndex_; }
 
-    int offsetDelta() { return offsetDelta_; }
-    int offsetDeltaIndex() { return offsetDeltaIndex_; }
-
-    void appendOffset( int offset );
+    void appendOffset(size_t offset);
 
     /// TODO: temporary method (remove)
-    GapVector<int> & offsetList() { return offsetList_; }
+    // GapVector<size_t> & offsetList() { return offsetList_; }
 
 protected:
-    int searchOffsetIgnoringOffsetDelta(int offset, int org_start, int org_end );
+    size_t searchOffsetIgnoringOffsetDelta(ptrdiff_t offset, size_t org_start, size_t org_end);
 
-    void moveDeltaToIndex( int index );
-    void changeOffsetDelta( int index, ptrdiff_t delta );
+    void moveDeltaToIndex(size_t index);
+    void changeOffsetDelta(size_t index, ptrdiff_t delta);
+
+    void setOffsetDelta(ptrdiff_t delta);
+
 
 public:
     QString toUnitTestString();
-    void initForUnitTesting( int offsetDelta, int offsetDeltaIndex, ... );
+    QString toUnitTestFilledString();
+    void initForUnitTesting(ptrdiff_t offsetDelta, size_t offsetDeltaIndex, ... );
 
     void assertValid();
 
 private:
 
-    GapVector<int> offsetList_;    ///< All offsets
-    int offsetDelta_;           ///< The offset delta at the given offset index (can be negative!!)
-    int offsetDeltaIndex_;         ///< The index that contains the offset delta
+    GapVector<ptrdiff_t> offsetList_;  ///< All offsets { line-index => offset of the first character on that line, .. }
+    size_t offsetDeltaIndex_;          ///< The index that contains the offset delta
+    ptrdiff_t offsetDelta_;            ///< The offset delta at the given offset index (can be negative!!)
 
 
 friend class LineOffsetVectorTest;

--- a/edbee-lib/edbee/util/lineoffsetvector.h
+++ b/edbee-lib/edbee/util/lineoffsetvector.h
@@ -16,7 +16,7 @@ class TextBufferChange;
 
 
 
-/// This class implements the vector for storing the line numbers at certain offsets/
+/// Implements the vector for storing the line numbers at certain offsets
 /// The class allows the 'gap' position to contain a delta offset. Which means that
 ///
 /// all offsets after the gap are increased with the offsetDelta when searched. Inserting/deleting
@@ -25,7 +25,7 @@ class TextBufferChange;
 /// The line offset pointed at by each index is the first character in the given line.
 class EDBEE_EXPORT LineOffsetVector {
 public:
-    /// a structure to describe the line change that happend
+/// a structure to describe the line change that happend
 //    struct LineChange {
 //        int line;                   ///< the first line that's going to be replaced
 //        int lineCount;              ///< the number of lines that are replaced
@@ -39,34 +39,34 @@ public:
 
     void applyChange( TextBufferChange change );
 
-    int at( int idx ) const;
-    int length() const;
+    size_t at(size_t idx) const;
+    size_t length() const;
 
-    int findLineFromOffset( int offset );
+    size_t findLineFromOffset(size_t offset);
 
-    int offsetDelta() { return offsetDelta_; }
-    int offsetDeltaIndex() { return offsetDeltaIndex_; }
+    ptrdiff_t offsetDelta() { return offsetDelta_; }
+    size_t offsetDeltaIndex() { return offsetDeltaIndex_; }
 
-    void appendOffset( int offset );
+    void appendOffset(size_t offset);
 
     /// TODO: temporary method (remove)
-    GapVector<int> & offsetList() { return offsetList_; }
+    GapVector<size_t> & offsetList() { return offsetList_; }
 
 protected:
-    int searchOffsetIgnoringOffsetDelta(int offset, int org_start, int org_end );
+    size_t searchOffsetIgnoringOffsetDelta(size_t offset, size_t org_start, size_t org_end );
 
-    void moveDeltaToIndex( int index );
-    void changeOffsetDelta( int index, int delta );
+    void moveDeltaToIndex(size_t index);
+    void changeOffsetDelta(size_t index, std::ptrdiff_t delta);
 
 public:
     QString toUnitTestString();
-    void initForUnitTesting( int offsetDelta, int offsetDeltaIndex, ... );
+    void initForUnitTesting(size_t offsetDelta, size_t offsetDeltaIndex, ...);
 
 private:
 
-    GapVector<int> offsetList_;    ///< All offsets
-    int offsetDelta_;              ///< The offset delta at the given offset index
-    int offsetDeltaIndex_;         ///< The index that contains the offset delta
+    GapVector<size_t> offsetList_; ///< All offsets
+    ptrdiff_t offsetDelta_;        ///< The offset delta at the given offset index
+    size_t offsetDeltaIndex_;      ///< The index that contains the offset delta
 
 
 friend class LineOffsetVectorTest;

--- a/edbee-lib/edbee/util/lineoffsetvector.h
+++ b/edbee-lib/edbee/util/lineoffsetvector.h
@@ -16,7 +16,7 @@ class TextBufferChange;
 
 
 
-/// Implements the vector for storing the line numbers at certain offsets
+/// This class implements the vector for storing the line numbers at certain offsets/
 /// The class allows the 'gap' position to contain a delta offset. Which means that
 ///
 /// all offsets after the gap are increased with the offsetDelta when searched. Inserting/deleting
@@ -25,7 +25,7 @@ class TextBufferChange;
 /// The line offset pointed at by each index is the first character in the given line.
 class EDBEE_EXPORT LineOffsetVector {
 public:
-/// a structure to describe the line change that happend
+    /// a structure to describe the line change that happend
 //    struct LineChange {
 //        int line;                   ///< the first line that's going to be replaced
 //        int lineCount;              ///< the number of lines that are replaced
@@ -39,34 +39,34 @@ public:
 
     void applyChange( TextBufferChange change );
 
-    size_t at(size_t idx) const;
-    size_t length() const;
+    int at( int idx ) const;
+    int length() const;
 
-    size_t findLineFromOffset(size_t offset);
+    int findLineFromOffset( int offset );
 
-    ptrdiff_t offsetDelta() { return offsetDelta_; }
-    size_t offsetDeltaIndex() { return offsetDeltaIndex_; }
+    int offsetDelta() { return offsetDelta_; }
+    int offsetDeltaIndex() { return offsetDeltaIndex_; }
 
-    void appendOffset(size_t offset);
+    void appendOffset( int offset );
 
     /// TODO: temporary method (remove)
-    GapVector<size_t> & offsetList() { return offsetList_; }
+    GapVector<int> & offsetList() { return offsetList_; }
 
 protected:
-    size_t searchOffsetIgnoringOffsetDelta(size_t offset, size_t org_start, size_t org_end );
+    int searchOffsetIgnoringOffsetDelta(int offset, int org_start, int org_end );
 
-    void moveDeltaToIndex(size_t index);
-    void changeOffsetDelta(size_t index, std::ptrdiff_t delta);
+    void moveDeltaToIndex( int index );
+    void changeOffsetDelta( int index, int delta );
 
 public:
-    QString toUnitTestString() const;
-    void initForUnitTesting(ptrdiff_t offsetDelta, size_t offsetDeltaIndex, ...);
+    QString toUnitTestString();
+    void initForUnitTesting( int offsetDelta, int offsetDeltaIndex, ... );
 
 private:
 
-    GapVector<size_t> offsetList_; ///< All offsets
-    ptrdiff_t offsetDelta_;        ///< The offset delta at the given offset index
-    size_t offsetDeltaIndex_;      ///< The index that contains the offset delta
+    GapVector<int> offsetList_;    ///< All offsets
+    int offsetDelta_;              ///< The offset delta at the given offset index
+    int offsetDeltaIndex_;         ///< The index that contains the offset delta
 
 
 friend class LineOffsetVectorTest;

--- a/edbee-lib/edbee/util/lineoffsetvector.h
+++ b/edbee-lib/edbee/util/lineoffsetvector.h
@@ -59,8 +59,8 @@ protected:
     void changeOffsetDelta(size_t index, std::ptrdiff_t delta);
 
 public:
-    QString toUnitTestString();
-    void initForUnitTesting(size_t offsetDelta, size_t offsetDeltaIndex, ...);
+    QString toUnitTestString() const;
+    void initForUnitTesting(ptrdiff_t offsetDelta, size_t offsetDeltaIndex, ...);
 
 private:
 

--- a/edbee-lib/edbee/util/lineoffsetvector.h
+++ b/edbee-lib/edbee/util/lineoffsetvector.h
@@ -15,7 +15,6 @@ namespace edbee {
 class TextBufferChange;
 
 
-
 /// This class implements the vector for storing the line numbers at certain offsets/
 /// The class allows the 'gap' position to contain a delta offset. Which means that
 ///
@@ -23,6 +22,10 @@ class TextBufferChange;
 /// text this way usually only results in the changine of the offset delta. Which means speeeed
 ///
 /// The line offset pointed at by each index is the first character in the given line.
+///
+/// NOTE: The offsetDelta can be negative! If data is deleted negative offsets
+///   make sure the offsets can be displaced quickly
+///
 class EDBEE_EXPORT LineOffsetVector {
 public:
     /// a structure to describe the line change that happend
@@ -34,12 +37,12 @@ public:
 //        QVector<int> newOffsets;    ///< the new offsets
 //    };
 
-
     LineOffsetVector();
 
-    void applyChange( TextBufferChange change );
+    void applyChange(TextBufferChange change);
 
-    int at( int idx ) const;
+
+    int at(int idx) const;
     int length() const;
 
     int findLineFromOffset( int offset );
@@ -56,21 +59,22 @@ protected:
     int searchOffsetIgnoringOffsetDelta(int offset, int org_start, int org_end );
 
     void moveDeltaToIndex( int index );
-    void changeOffsetDelta( int index, int delta );
+    void changeOffsetDelta( int index, ptrdiff_t delta );
 
 public:
     QString toUnitTestString();
     void initForUnitTesting( int offsetDelta, int offsetDeltaIndex, ... );
 
+    void assertValid();
+
 private:
 
     GapVector<int> offsetList_;    ///< All offsets
-    int offsetDelta_;              ///< The offset delta at the given offset index
+    int offsetDelta_;           ///< The offset delta at the given offset index (can be negative!!)
     int offsetDeltaIndex_;         ///< The index that contains the offset delta
 
 
 friend class LineOffsetVectorTest;
-
 
 };
 

--- a/edbee-lib/edbee/util/rangelineiterator.cpp
+++ b/edbee-lib/edbee/util/rangelineiterator.cpp
@@ -16,18 +16,18 @@ namespace edbee {
 /// @param range the range to iterate over the lines
 RangeLineIterator::RangeLineIterator(TextDocument* doc, const TextRange& range )
 {
-    curLine_ = doc->lineFromOffset( range.min() );
-    endLine_ = doc->lineFromOffset( range.max() );
+    curLine_ = doc->lineFromOffset(range.min());
+    endLine_ = doc->lineFromOffset(range.max());
 }
 
  /// Constructs a line iterator by supplying two offsets
 /// @param doc the textdocument for this iterator
 /// @param startOffset the start offset for iterating
 /// @param endOffset the endOffset for iterating
-RangeLineIterator::RangeLineIterator(TextDocument* doc, int startOffset, int endOffset )
+RangeLineIterator::RangeLineIterator(TextDocument* doc, size_t startOffset, size_t endOffset)
 {
-    curLine_ = doc->lineFromOffset( startOffset );
-    endLine_ = doc->lineFromOffset( endOffset );
+    curLine_ = doc->lineFromOffset(startOffset);
+    endLine_ = doc->lineFromOffset(endOffset);
 }
 
 
@@ -39,9 +39,9 @@ bool RangeLineIterator::hasNext() const
 
 
 /// returns the next line number
-int RangeLineIterator::next()
+size_t RangeLineIterator::next()
 {
-    int result = curLine_;
+    size_t result = curLine_;
     ++curLine_;
     return result;
 }

--- a/edbee-lib/edbee/util/rangelineiterator.h
+++ b/edbee-lib/edbee/util/rangelineiterator.h
@@ -29,15 +29,15 @@ class TextRange;
 /// @endcode
 class EDBEE_EXPORT RangeLineIterator {
 public:
-    RangeLineIterator( TextDocument* doc, const TextRange& range );
-    RangeLineIterator( TextDocument* doc, int start, int end );
+    RangeLineIterator(TextDocument* doc, const TextRange& range);
+    RangeLineIterator(TextDocument* doc, size_t start, size_t end);
 
     bool hasNext() const;
-    int next();
+    size_t next();
 
 private:
-    int curLine_;              ///< The current line number
-    int endLine_;              ///< The last line
+    size_t curLine_;              ///< The current line number
+    size_t endLine_;              ///< The last line
 };
 
 

--- a/edbee-lib/edbee/util/rangesetlineiterator.cpp
+++ b/edbee-lib/edbee/util/rangesetlineiterator.cpp
@@ -11,11 +11,11 @@
 namespace edbee {
 
 /// Constructs the rangeset line iterator
-RangeSetLineIterator::RangeSetLineIterator( TextRangeSet* rangeSet )
+RangeSetLineIterator::RangeSetLineIterator(TextRangeSet* rangeSet)
     : rangeSetRef_(rangeSet)
     , rangeIndex_(0)
-    , rangeEndLine_(-1)
-    , curLine_(-1)
+    , rangeEndLine_(std::string::npos)
+    , curLine_(std::string::npos)
 {
     findNextLine();
 }
@@ -24,14 +24,14 @@ RangeSetLineIterator::RangeSetLineIterator( TextRangeSet* rangeSet )
 /// Checks if there's a next line number available
 bool RangeSetLineIterator::hasNext() const
 {
-    return curLine_ >= 0;
+    return curLine_ != std::string::npos;
 }
 
 
 /// returns the next line number
-int RangeSetLineIterator::next()
+size_t RangeSetLineIterator::next()
 {
-    int result = curLine_;
+    size_t result = curLine_;
     findNextLine();
     return result;
 }
@@ -41,30 +41,29 @@ int RangeSetLineIterator::next()
 void RangeSetLineIterator::findNextLine()
 {
     // current line isn't at the end of the current range
-    if( curLine_ < rangeEndLine_ ) {
+    if (curLine_ != std::string::npos && curLine_ < rangeEndLine_) {
         ++curLine_;
 
     // the curLine_ is finished with the current range
     } else {
-
         // when the rangeset is finishedd
-        while( rangeIndex_ < rangeSetRef_->rangeCount() ) {
+        while (rangeIndex_ < rangeSetRef_->rangeCount()) {
             TextRange& range = rangeSetRef_->range(rangeIndex_);
             ++rangeIndex_;
 
             // get the start/end lines
-            int startLine = rangeSetRef_->textDocument()->lineFromOffset( range.min() );
-            int endLine = rangeSetRef_->textDocument()->lineFromOffset( range.max() );
+            size_t startLine = rangeSetRef_->textDocument()->lineFromOffset(range.min());
+            size_t endLine = rangeSetRef_->textDocument()->lineFromOffset(range.max());
             if( startLine == curLine_ ) { ++startLine; }
 
             // still in range?
-            if( startLine <= endLine ) {
+            if (startLine <= endLine) {
                 curLine_ = startLine;
                 rangeEndLine_ = endLine;
                 return;
             }
         }
-        curLine_ = -1;  // done
+        curLine_ = std::string::npos;  // done
     }
 }
 

--- a/edbee-lib/edbee/util/rangesetlineiterator.h
+++ b/edbee-lib/edbee/util/rangesetlineiterator.h
@@ -15,27 +15,27 @@ class TextRangeSet;
 /// Usage sample:
 /// @code{.cpp}
 ///
-/// RangeSetLineIterator itr( controller->textSelection() )
-/// while( itr.hasNext() ) {
+/// RangeSetLineIterator itr(controller->textSelection())
+/// while (itr.hasNext()) {
 ///     qDebug() << "Line: " << itr.next();
 /// }
 ///
 /// @endcode
 class EDBEE_EXPORT RangeSetLineIterator {
 public:
-    RangeSetLineIterator( TextRangeSet* rangeSet );
+    RangeSetLineIterator(TextRangeSet* rangeSet);
 
     bool hasNext() const;
-    int next();
+    size_t next();
 
 private:
     void findNextLine();
 
 private:
     TextRangeSet* rangeSetRef_;     ///< a reference to the range sets
-    int rangeIndex_;                ///< the current range index
-    int rangeEndLine_;              ///< the last line of the current range
-    int curLine_;                   ///< The current line number (this value is -1 if there's no current line)
+    size_t rangeIndex_;             ///< the current range index
+    size_t rangeEndLine_;           ///< the last line of the current range (std::string::npos when no end is known)
+    size_t curLine_;                ///< The current line number (this value is std::string::npos if there's no current line)
 
 
 };

--- a/edbee-lib/edbee/util/regexp.cpp
+++ b/edbee-lib/edbee/util/regexp.cpp
@@ -3,6 +3,7 @@
 
 // This is required for windows, to prevent linkage errors (somehow the sources of oniguruma assumes we're linking with a dll)
 
+
 #ifdef __clang__
   #pragma clang diagnostic push
 #else
@@ -32,6 +33,7 @@
 #include "edbee/debug.h"
 
 namespace edbee {
+
 
 /// The onig regexp-engine
 class OnigRegExpEngine : public RegExpEngine
@@ -115,15 +117,15 @@ public:
 
 
     /// returns the pattern used
-    virtual QString pattern() { return pattern_; }
+    virtual QString pattern() override { return pattern_; }
 
 
     /// returns true if the supplied regular expression was valid
-    virtual bool isValid() { return valid_; }
+    virtual bool isValid() override { return valid_; }
 
 
     /// returns the error message
-    virtual QString error() { return error_; }
+    virtual QString error() override { return error_; }
 
 
     /// returns the index of the given QChar array in the given text
@@ -131,10 +133,11 @@ public:
     /// @param offset the offset to start searching
     /// @param length the length of the string data
     /// @param reverse should the search be reversed?
-    int indexIn(const QChar* charPtr, int offset, int length, bool reverse)
+    /// @return the position or std::string::npos if no match
+    virtual size_t indexIn(const QChar* charPtr, ptrdiff_t offset, size_t length, bool reverse)
     {
         // invalid reg-exp don't use it!
-        if( !valid_ ) { return -2; }
+        if (!valid_) { return std::string::npos; }
 
         // delete old regenion an make a new one
         deleteRegion();
@@ -154,15 +157,15 @@ public:
 
         int result = onig_search(reg_, stringStart, stringEnd, stringOffset, stringRange, region_, ONIG_OPTION_NONE);
         if (result >= 0) {
-            Q_ASSERT(result%2==0);
-            return result>>1;
+            Q_ASSERT(result % 2 == 0);
+            return static_cast<size_t>(result) >> 1;
 
         } else if (result == ONIG_MISMATCH) {
-            return -1;
+            return std::string::npos;
 
         } else { // error
             fillError(result);
-            return -2;
+            return std::string::npos;
 
         }
     }
@@ -171,14 +174,14 @@ public:
     /// returns the position of the given match or returns an error code
     /// @param str the string to the search in
     /// @param offset the offset in the string to start the search
-    /// @return the position of the given match (-1 if not found, -2 on error)
-    virtual int indexIn(const QString& str, int offset)
+    /// @return the position of the given match (std::string::npos if not found, or on error)
+    virtual size_t indexIn(const QString& str, ptrdiff_t offset) override
     {
         line_ = str;
-        int length = static_cast<int>(line_.length()); // very scary, calling line_.length() invalidates the line_.data() pointer :S
+        size_t length = static_cast<size_t>(line_.length()); // very scary, calling line_.length() invalidates the line_.data() pointer :S
         lineRef_ = line_.data();
 
-        return indexIn( lineRef_, offset, length, false );
+        return indexIn(lineRef_, offset, length, false);
     }
 
 
@@ -186,8 +189,8 @@ public:
     /// @param str the pointer to the line
     /// @param offset the offset to start searching
     /// @param length the total length of the str pointer
-    /// @return the position of the given match (-1 if not found, -2 on error)
-    virtual int indexIn(const QChar* charPtr, int offset, int length)
+    /// @return the position of the given match (std::string::npos if not found, or on error)
+    virtual size_t indexIn(const QChar* charPtr, ptrdiff_t offset, size_t length) override
     {
         return indexIn(charPtr, offset, length, false);
     }
@@ -196,13 +199,13 @@ public:
     /// returns the last index of the given string
     /// @param str the string to search in
     /// @param offset the offset of the start of the search
-    /// @return the index of the match (-1 if not found, -2 on error)
-    virtual int lastIndexIn(const QString& str, int offset)
+    /// @return the position of the given match (std::string::npos if not found, or on error)
+    virtual size_t lastIndexIn(const QString& str, ptrdiff_t offset) override
     {
         line_ = str;
-        int length = static_cast<int>(line_.length()); // very scary, calling line_.length() invalidates the line_.data() pointer :S
+        size_t length = static_cast<size_t>(line_.length()); // very scary, calling line_.length() invalidates the line_.data() pointer :S
         lineRef_ = line_.data();
-        return lastIndexIn( lineRef_, offset, length);
+        return lastIndexIn(lineRef_, offset, length);
     }
 
 
@@ -210,11 +213,11 @@ public:
     /// @param str the string to search in
     /// @param offset the offset of the start of the search
     /// @param length the length of the supplied string data
-    /// @return the index of the match (-1 if not found, -2 on error)
-    virtual int lastIndexIn(const QChar* str, int offset, int length)
+    /// @return the position of the given match (std::string::npos if not found, or on error)
+    virtual size_t lastIndexIn(const QChar* str, ptrdiff_t offset, size_t length) override
     {
         if (offset < 0) {
-            offset = length + offset;
+            offset = static_cast<ptrdiff_t>(length) + offset;
             if(offset < 0) offset = 0;
         }
         return indexIn(str, offset, length, true);
@@ -223,12 +226,13 @@ public:
 
     /// returns the offset of the given match
     /// @param nth the given match
-    virtual int pos(int nth) const
+    /// @retuns the position or std::string::npos on no match
+    virtual size_t pos(size_t nth) const override
     {
-        if (!region_) { return -1; } // no region
-        if (nth < region_->num_regs) {
+        if (!region_) { return std::string::npos; } // no region
+        if (static_cast<int>(nth) < region_->num_regs) {
             int result = region_->beg[nth];
-            if (result < 0) { return -1; }
+            if (result < 0) { return std::string::npos; }
 
             if (result % 2 != 0) {
                 qlog_warn() << "*** ERROR ***:" << nth;
@@ -239,39 +243,37 @@ public:
                      qlog_info() << QStringLiteral(" - %1: (%2,%3)").arg(i).arg(region_->beg[i]).arg(region_->end[i]);
                  }
                 // fprintf(stderr,
-                Q_ASSERT(result%2==0);
+                Q_ASSERT(result%2 == 0);
             }
-            return result >> 1;
+            return static_cast<size_t>(result) >> 1;
         }
-        return -1;
+        return std::string::npos;
     }
 
 
     /// returns the length of the nth match
-    /// @param nth the match number
-    virtual int len(int nth) const
+    /// @param nth the match number or std::string::npos if no match is found at the index
+    virtual size_t len(size_t nth) const override
     {
-        if (!region_) { return -1; } // no region
-        if( nth < region_->num_regs ) {
+        if (!region_) { return std::string::npos; } // no region
+        if (static_cast<ptrdiff_t>(nth) < region_->num_regs) {
             int result = region_->end[nth] - region_->beg[nth]; // end is the first character AFTER the match
             Q_ASSERT(result % 2 == 0);
-            return result >> 1;
+            return static_cast<size_t>(result) >> 1;
         }
-        return -1;
+        return std::string::npos;
     }
-
 
     /// returns the capture at the given index
     /// @param nth the position of the match
     /// @return the match ath the given position
-    virtual QString cap(int nth = 0) const
+    virtual QString cap(size_t nth = 0) const override
     {
-        int p = pos(nth);
-        int l = len(nth);
-        if( p < 0 || l < 0 ) return QString();
-        return QString( lineRef_+p,l);
+        size_t p = pos(nth);
+        size_t l = len(nth);
+        if( p == std::string::npos || l == std::string::npos ) return QString();
+        return QString(lineRef_ + p, static_cast<qsizetype>(l));
     }
-
 };
 
 
@@ -308,22 +310,33 @@ public:
 
 
     /// Returns the supplied pattern
-    virtual QString pattern() { return reg_->pattern(); }
+    virtual QString pattern() override
+    {
+        return reg_->pattern();
+    }
 
     /// Returns true if the given regular expression was valid
-    virtual bool isValid() { return reg_->isValid(); }
+    virtual bool isValid() override
+    {
+        return reg_->isValid();
+    }
 
     /// returns the error message
-    virtual QString error() { return reg_->errorString(); }
+    virtual QString error() override
+    {
+        return reg_->errorString();
+    }
 
 
     /// returns the index of the regexp in the given string
     /// @param str the string to search in
     /// @param offset the start offset of the search
-    /// @return the index of the given match or < 0 if no match was found
-    virtual int indexIn(const QString& str, int offset)
+    /// @return the index of the given match or std::string::npos if no match was found
+    virtual size_t indexIn(const QString& str, ptrdiff_t offset) override
     {
-        return reg_->indexIn( str, offset );
+        int result = reg_->indexIn(str, static_cast<int>(offset));
+        if (result < 0) return std::string::npos;
+        return static_cast<size_t>(result);
     }
 
 
@@ -331,21 +344,25 @@ public:
     /// @param str the pointer to the given string
     /// @param offset the offset to start searching
     /// @param length the length of the given string
-    /// @return the index of the given match or < 0 if no match was found
-    virtual int indexIn(const QChar* str, int offset, int length)
+    /// @return the index of the given match or std::string::npos if no match was found
+    virtual size_t indexIn(const QChar* str, ptrdiff_t offset, size_t length) override
     {
-        QString realString(str + offset, length);
-        return reg_->indexIn(realString, offset);
+        QString realString(str + offset, static_cast<qsizetype>(length));
+        int result = reg_->indexIn(realString, static_cast<int>(offset));
+        if (result < 0) return std::string::npos;
+        return static_cast<size_t>(result);
     }
 
 
     /// Returns the last match of this regexp in the given string
     /// @param str the string to search in
     /// @param offset the offset to start searching from
-    /// @return the matched index or < 0 if not found
-    virtual int lastIndexIn(const QString& str, int offset)
+    /// @return the index of the given match or std::string::npos if no match was found
+    virtual size_t lastIndexIn(const QString& str, ptrdiff_t offset) override
     {
-        return reg_->lastIndexIn(str, offset);
+        int result = reg_->lastIndexIn(str, static_cast<int>(offset));
+        if (result < 0) return std::string::npos;
+        return static_cast<size_t>(result);
     }
 
 
@@ -353,30 +370,45 @@ public:
     /// @param str the string to search in
     /// @param offset the offset to start searching from
     /// @param length the length of the given string
-    /// @return the matched index or < 0 if not found
-    virtual int lastIndexIn(const QChar* str, int offset, int length)
+    /// @return the index of the given match or std::string::npos if no match was found
+    virtual size_t lastIndexIn(const QChar* str, ptrdiff_t offset, size_t length) override
     {
-        QString realString( str+offset, length );
-        return reg_->lastIndexIn( realString, offset );
+        QString realString(str+offset, static_cast<qsizetype>(length));
+        int result = reg_->lastIndexIn(realString, static_cast<int>(offset));
+        if (result < 0) return std::string::npos;
+        return static_cast<size_t>(result);
     }
 
 
     /// returns the position of the nth group match
     /// @param nth the group number to return
-    /// @return the position of the nth match
-    virtual int pos(int nth = 0) const { return reg_->pos(nth); }
+    /// @return the position of the nth match or std::string::npos if not found
+    virtual size_t pos(size_t nth = 0) const override
+    {
+        int result = reg_->pos(static_cast<int>(nth));
+        if (result < 0) return std::string::npos;
+        return static_cast<size_t>(result);
+    }
 
 
     /// returns the length of the nth group match
     /// @param nth the group number to return
-    /// @return the length of the nth match
-    virtual int len(int nth = 0) const { return static_cast<int>(reg_->cap(nth).length()); }
+    /// @return the length of the nth match or std::string::npos if not found
+    virtual size_t len(size_t nth = 0) const override
+    {
+        qsizetype result = reg_->cap(static_cast<int>(nth)).length();
+        if (result < 0) return std::string::npos;
+        return static_cast<size_t>(result);
+    }
 
 
     /// returns the nth group
     /// @param nth the group number to return
-    /// @return the content of the given match
-    virtual QString cap(int nth = 0) const { return reg_->cap(nth); }
+    /// @return the content of the given match or std::string::npos if not found
+    virtual QString cap(size_t nth = 0) const override
+    {
+        return reg_->cap(static_cast<int>(nth));
+    }
 };
 
 
@@ -449,9 +481,16 @@ QString RegExp::pattern() const
 /// Returns the position of the first match, or -1 if there was no match.
 /// The caretMode parameter can be used to instruct whether ^ should match at index 0 or at offset.
 /// You might prefer to use QString::indexOf(), QString::contains(), or even QStringList::filter(). To replace matches use QString::replace().
-int RegExp::indexIn(const QString& str, int offset)  // const
+/// @returns the index (returns std::string::npos if not found)
+
+// size_t RegExp::indexIn(const QString& str, ptrdiff_t offset)
+// {
+//     return d_->indexIn(str, offset);
+// }
+
+size_t RegExp::indexIn(const QString &str, size_t offset)
 {
-    return d_->indexIn(str, offset);
+    return d_->indexIn(str, static_cast<ptrdiff_t>(offset));
 }
 
 
@@ -459,20 +498,32 @@ int RegExp::indexIn(const QString& str, int offset)  // const
 /// @param str the string to search in
 /// @param offset the offset to start searching
 /// @param length the length of the supplied string
-/// @return the found index of the regular expression
-int RegExp::indexIn(const QChar* str, int offset, int length)
+/// @return the found index of the regular expression (returns std::string::npos if not found)
+
+// size_t RegExp::indexIn(const QChar* str, ptrdiff_t offset, size_t length)
+// {
+//     return d_->indexIn(str, offset, length);
+// }
+
+size_t RegExp::indexIn(const QChar *str, size_t offset, size_t length)
 {
-    return d_->indexIn(str, offset, length);
+    return d_->indexIn(str, static_cast<ptrdiff_t>(offset), length);
 }
 
 
 /// Searches for the last match of the regular expression in the given string
 /// @param str the string to search in
 /// @param offset the offset to start searching
-/// @return the found index of the regular expression
-int RegExp::lastIndexIn(const QString &str, int offset)
+/// @return the found index of the regular expression (returns std::string::npos if not found)
+
+// size_t RegExp::lastIndexIn(const QString& str, ptrdiff_t offset)
+// {
+//     return d_->lastIndexIn(str, offset);
+// }
+
+size_t RegExp::lastIndexIn(const QString& str, size_t offset)
 {
-    return d_->lastIndexIn(str, offset);
+    return d_->lastIndexIn(str, static_cast<ptrdiff_t>(offset));
 }
 
 
@@ -480,31 +531,41 @@ int RegExp::lastIndexIn(const QString &str, int offset)
 /// @param str the string to search in
 /// @param offset the offset to start searching
 /// @param length the length of the supplied string
-/// @return the found index of the regular expression
-int RegExp::lastIndexIn(const QChar *str, int offset, int length)
+/// @return the found index of the regular expression (returns std::string::npos if not found)
+
+// size_t RegExp::lastIndexIn(const QChar* str, ptrdiff_t offset, size_t length)
+// {
+//     return d_->lastIndexIn(str, offset, length);
+// }
+
+size_t RegExp::lastIndexIn(const QChar* str, size_t offset, size_t length)
 {
-    return d_->lastIndexIn(str, offset, length);
+    return d_->lastIndexIn(str, static_cast<ptrdiff_t>(offset), length);
 }
 
+
 /// Returns the position of the nth captured text in the searched string. If nth is 0 (the default), pos() returns the position of the whole match.
-/// For zero-length matches, pos() always returns -1. (For example, if cap(4) would return an empty string, pos(4) returns -1.) This is a feature of the implementation.
-int RegExp::pos(int nth) const
+/// (returns std::string::npos if not found)
+size_t RegExp::pos(size_t nth) const
 {
     return d_->pos(nth);
 }
 
 
 /// The length of nth element
-int RegExp::len(int nth) const
+/// (returns std::string::npos if not found)
+size_t RegExp::len(size_t nth) const
 {
     return d_->len(nth);
 }
 
 
 /// This method returns the given matched length
-QString RegExp::cap(int nth) const
+/// (returns std::string::npos if not found)
+QString RegExp::cap(size_t nth) const
 {
     return d_->cap(nth);
 }
+
 
 } // edbee

--- a/edbee-lib/edbee/util/regexp.cpp
+++ b/edbee-lib/edbee/util/regexp.cpp
@@ -1,7 +1,6 @@
 // edbee - Copyright (c) 2012-2025 by Rick Blommers and contributors
 // SPDX-License-Identifier: MIT
 
-#include <QRegExp>
 
 // This is required for windows, to prevent linkage errors (somehow the sources of oniguruma assumes we're linking with a dll)
 
@@ -28,6 +27,9 @@
 #endif
 
 #include "regexp.h"
+
+#include <QRegExp>
+
 #include "edbee/debug.h"
 
 namespace edbee {

--- a/edbee-lib/edbee/util/regexp.h
+++ b/edbee-lib/edbee/util/regexp.h
@@ -37,6 +37,8 @@ public:
     enum Engine {
         EngineOniguruma = 1,
         EngineQRegExp = 2
+        // EngineQRegularExpression = 3,
+
 //        QRegExp::RegExp	0	A rich Perl-like pattern matching syntax. This is the default.
 //        QRegExp::RegExp2	3	Like RegExp, but with greedy quantifiers. (Introduced in Qt 4.2.)
 //        QRegExp::Wildcard	1	This provides a simple pattern matching syntax similar to that used by shells (command interpreters) for "file globbing". See QRegExp wildcard matching.
@@ -50,9 +52,7 @@ public:
         SyntaxFixedString       /// A plain fixed string
     };
 
-
-
-    RegExp( const QString& pattern, bool caseSensitive=true, Syntax syntax=SyntaxDefault, Engine engine=EngineOniguruma );
+    RegExp(const QString& pattern, bool caseSensitive=true, Syntax syntax=SyntaxDefault, Engine engine=EngineOniguruma);
     virtual ~RegExp();
 
     static QString escape( const QString& str, Engine engine=EngineOniguruma );
@@ -62,19 +62,16 @@ public:
     QString pattern() const ;
 
 
-    int	indexIn( const QString& str, int offset = 0 ); // const;
-    int indexIn( const QChar* str, int offset, int length );
-    int lastIndexIn( const QString& str, int offset=-1 );
-    int lastIndexIn( const QChar* str, int offset, int length );
-    int pos( int nth = 0 ) const;
-    int len( int nth = 0 ) const;
-    QString cap( int nth = 0) const;
-
+    int	indexIn(const QString& str, int offset = 0); // const;
+    int indexIn(const QChar* str, int offset, int length);
+    int lastIndexIn(const QString& str, int offset = -1);
+    int lastIndexIn(const QChar* str, int offset, int length);
+    int pos(int nth = 0) const;
+    int len(int nth = 0) const;
+    QString cap(int nth = 0) const;
 
     /// matched length is equal to pos-0-length
     int matchedLength() { return len(0); }
-
-    //    int cap( int nth = 0 ) const;
 
 private:
     RegExpEngine* d_;       ///< The private data member

--- a/edbee-lib/edbee/util/regexp.h
+++ b/edbee-lib/edbee/util/regexp.h
@@ -17,14 +17,31 @@ public:
     virtual QString pattern() = 0;
     virtual bool isValid() = 0;
     virtual QString error() = 0;
-    virtual int indexIn( const QString& str, int offset ) = 0;
-    virtual int indexIn( const QChar* str, int offset, int length ) = 0;
-    virtual int lastIndexIn( const QString& str, int offset ) = 0;
-    virtual int lastIndexIn( const QChar* str, int offset, int length ) = 0;
 
-    virtual int pos( int nth = 0 ) const = 0;
-    virtual int len( int nth = 0 ) const = 0;
-    virtual QString cap( int nth = 0 ) const = 0;
+    /// returns the index of the given substring
+    /// @param offset the offset to start, negative is to search from the end (-1 from the last position)
+    /// @return the matched index of (std::string::npos on no match)
+    virtual size_t indexIn(const QString& str, ptrdiff_t offset) = 0;
+
+    /// returns the index of the given substring
+    /// @param offset the offset to start, negative is to search from the end (-1 from the last position)
+    /// @return the matched index of (std::string::npos on no match)
+    virtual size_t indexIn(const QChar* str, ptrdiff_t offset, size_t length) = 0;
+
+    /// returns the last index of the given substring
+    /// @param offset the offset to start, negative is to search from the end (-1 from the last position)
+    /// @return the matched index of (std::string::npos on no match)
+    virtual size_t lastIndexIn(const QString& str, ptrdiff_t offset) = 0;
+    virtual size_t lastIndexIn(const QChar* str, ptrdiff_t offset, size_t length) = 0;
+
+    /// returns the position of the given match or std::string::npos if there's no nth match
+    virtual size_t pos(size_t nth = 0) const = 0;
+
+    /// returns the length of the given match or std::string::npos if there's no nth match
+    virtual size_t len(size_t nth = 0) const = 0;
+
+    /// returns the nth match or std::string::npos if there's no nth match
+    virtual QString cap(size_t nth = 0) const = 0;
 };
 
 
@@ -62,16 +79,20 @@ public:
     QString pattern() const ;
 
 
-    int	indexIn(const QString& str, int offset = 0); // const;
-    int indexIn(const QChar* str, int offset, int length);
-    int lastIndexIn(const QString& str, int offset = -1);
-    int lastIndexIn(const QChar* str, int offset, int length);
-    int pos(int nth = 0) const;
-    int len(int nth = 0) const;
-    QString cap(int nth = 0) const;
+    // size_t indexIn(const QString& str, ptrdiff_t offset = 0);
+    size_t indexIn(const QString& str, size_t offset = 0);
+    // size_t indexIn(const QChar* str, ptrdiff_t offset, size_t length);
+    size_t indexIn(const QChar* str, size_t offset, size_t length);
+    // size_t lastIndexIn(const QString& str, ptrdiff_t offset = -1);
+    size_t lastIndexIn(const QString& str, size_t offset);
+    // size_t lastIndexIn(const QChar* str, ptrdiff_t offset, size_t length);
+    size_t lastIndexIn(const QChar* str, size_t offset, size_t length);
+    size_t pos(size_t nth = 0) const;
+    size_t len(size_t nth = 0) const;
+    QString cap(size_t nth = 0) const;
 
     /// matched length is equal to pos-0-length
-    int matchedLength() { return len(0); }
+    size_t matchedLength() { return len(0); }
 
 private:
     RegExpEngine* d_;       ///< The private data member

--- a/edbee-lib/edbee/util/simpleprofiler.cpp
+++ b/edbee-lib/edbee/util/simpleprofiler.cpp
@@ -8,7 +8,7 @@
 namespace edbee {
 
 /// This method returns the profile instance
-SimpleProfiler *SimpleProfiler::instance()
+SimpleProfiler* SimpleProfiler::instance()
 {
     static SimpleProfiler profiler;
     return &profiler;
@@ -16,7 +16,7 @@ SimpleProfiler *SimpleProfiler::instance()
 
 
 /// the constructor for a profile stat issue
-SimpleProfiler::ProfilerItem::ProfilerItem(const char *filename, int line, const char *function, const char* name )
+SimpleProfiler::ProfilerItem::ProfilerItem(const char *filename, int line, const char *function, const char* name)
     : filename_(filename)
     , line_(line)
     , function_(function)
@@ -43,15 +43,15 @@ SimpleProfiler::~SimpleProfiler()
 
 
 /// begin the profiling
-void SimpleProfiler::begin(const char *file, int line, const char *function, const char* name )
+void SimpleProfiler::begin(const char *file, int line, const char *function, const char* name)
 {
     // build the key
     QString key = QStringLiteral("%1:%2").arg(file).arg(line);
 
     // fetch or create the item
-    ProfilerItem *item = statsMap_.value(key,0);
-    if( !item ) {
-        item = new ProfilerItem(file,line,function,name);
+    ProfilerItem* item = statsMap_.value(key, nullptr);
+    if (!item) {
+        item = new ProfilerItem(file, line, function, name);
         statsMap_.insert(key,item);
     }
 
@@ -59,31 +59,33 @@ void SimpleProfiler::begin(const char *file, int line, const char *function, con
     stack_.push(stackItem);
 }
 
+
 /// ends profiling
 void SimpleProfiler::end()
 {
-    Q_ASSERT( stack_.size() > 0 );
+    Q_ASSERT(stack_.size() > 0);
+
     ProfileStackItem stackItem = stack_.pop();
     stackItem.item->incCallCount();
-    int duration = QDateTime::currentMSecsSinceEpoch() - stackItem.startTime;
-    stackItem.item->addDuration( duration );
-    if( !stack_.isEmpty() ) {
-        stack_.top().item->addChildDuration( duration );
+    qint64 duration = QDateTime::currentMSecsSinceEpoch() - stackItem.startTime;
+    stackItem.item->addDuration(duration);
+    if (!stack_.isEmpty()) {
+        stack_.top().item->addChildDuration(duration);
     }
-
 }
 
 
-static bool sortByDuration( const SimpleProfiler::ProfilerItem* a, const SimpleProfiler::ProfilerItem* b )
+static bool sortByDuration(const SimpleProfiler::ProfilerItem* a, const SimpleProfiler::ProfilerItem* b)
 {
    return b->durationWithoutChilds() < a->durationWithoutChilds();
 }
+
 
 /// This method dumps the results to the output
 void SimpleProfiler::dumpResults()
 {
     QList<ProfilerItem*> items = statsMap_.values();
-    if( items.length() > 0 ) {
+    if (items.length() > 0) {
         std::sort(items.begin(), items.end(), sortByDuration);
 
         qlog_info() << "";
@@ -93,21 +95,21 @@ void SimpleProfiler::dumpResults()
         qint64 totalDuration = 0;
         int totalCallCount = 0;
         int totalDurationWitoutChilds = 0;
-        foreach( ProfilerItem* item, items ) {
+        foreach (ProfilerItem* item, items) {
             totalDuration  += item->duration();
             totalCallCount += item->callCount();
             totalDurationWitoutChilds += item->durationWithoutChilds();
         }
 
-        foreach( ProfilerItem* item, items ) {
-            double durationPercentage = totalDuration > 0 ? 100.0 * item->duration() / totalDuration : 100;
+        foreach (ProfilerItem* item, items) {
+            double durationPercentage = totalDuration > 0 ? 100.0 * static_cast<double>(item->duration()) / static_cast<double>(totalDuration) : 100;
             double callCountPercentage = totalCallCount > 0 ? 100.0 * item->callCount() / totalCallCount : 100;
-            double durationWithoutChildsPercenage = totalDurationWitoutChilds > 0 ? 100.0 * item->durationWithoutChilds() / totalDurationWitoutChilds : 100;
+            double durationWithoutChildsPercenage = totalDurationWitoutChilds > 0 ? 100.0 * static_cast<double>(item->durationWithoutChilds()) / totalDurationWitoutChilds : 100;
 
             QString line = QStringLiteral("%1x(%2%) %3ms(%4%) %5ms(%6%) |  %7:%8 %9")
-               .arg(item->callCount(),8).arg( callCountPercentage, 6, 'f', 2 )
-               .arg(item->duration(),6).arg( durationPercentage, 6, 'f', 2 )
-               .arg(item->durationWithoutChilds(), 6 ).arg( durationWithoutChildsPercenage, 6, 'f', 2 )
+               .arg(item->callCount(), 8).arg(callCountPercentage, 6, 'f', 2)
+               .arg(item->duration(), 6).arg(durationPercentage, 6, 'f', 2)
+               .arg(item->durationWithoutChilds(), 6).arg( durationWithoutChildsPercenage, 6, 'f', 2)
                .arg(item->filename()).arg(item->line()).arg(item->name())
             ;
             qlog_info() << line;
@@ -118,9 +120,9 @@ void SimpleProfiler::dumpResults()
         qlog_info() << "Total Calls   : " << totalCallCount;
         qlog_info() << "Total Items   : " << items.size() << "ms";
 
-        if( !stack_.isEmpty() ) {
+        if (!stack_.isEmpty()) {
             qlog() << "** WARNING: The stack isn't empty!! ** ";
-            foreach( ProfileStackItem stackItem, stack_) {
+            foreach (ProfileStackItem stackItem, stack_) {
                 qlog() << " * " << stackItem.item->function() << ":" << stackItem.item->line();
             }
         }

--- a/edbee-lib/edbee/util/simpleprofiler.h
+++ b/edbee-lib/edbee/util/simpleprofiler.h
@@ -15,7 +15,6 @@
 namespace edbee {
 
 #ifdef CONFIG_PROFILE
-
 #define PROF_BEGIN \
     SimpleProfiler::instance()->begin( __FILE__, __LINE__, __func__, 0 );
 
@@ -31,7 +30,6 @@ namespace edbee {
 #define PROF_BEGIN_NAMED(name)
 #endif
 
-
 /// __FILE__ / __LINE__ / __FUNCTION__ (or __func__ )
 
 /// A simple profiler class that can be used to profile certain parts of the code.
@@ -43,11 +41,10 @@ public:
 
     static SimpleProfiler* instance();
 
-
     /// the class to 'record a singlel item
     class ProfilerItem {
     public:
-        ProfilerItem( const char* filename, int line, const char* function, const char* name );
+        ProfilerItem(const char* filename, int line, const char* function, const char* name);
         const char* filename() const { return filename_; }
         int line() const { return line_; }
         const char* function() const { return function_; }
@@ -58,8 +55,8 @@ public:
         qint64 durationWithoutChilds() const { return duration_ - childDuration_; }
 
         void incCallCount() { ++callCount_; }
-        void addDuration( qint64 duration ) { duration_ += duration; }
-        void addChildDuration( qint64 duration ) { childDuration_ += duration; }
+        void addDuration(qint64 duration) { duration_ += duration; }
+        void addChildDuration(qint64 duration) { childDuration_ += duration; }
 
     protected:
         const char* filename_;      ///< The filename
@@ -78,21 +75,17 @@ public:
         qint64 startTime;
     };
 
-
-
     SimpleProfiler();
     virtual ~SimpleProfiler();
 
-
-    void begin( const char* file, int line, const char* function, const char* name );
+    void begin(const char* file, int line, const char* function, const char* name);
     void end();
 
     void dumpResults();
 
-
 protected:
 
-    QMap<QString,ProfilerItem*> statsMap_;   ///< The statistics
+    QMap<QString, ProfilerItem*> statsMap_;  ///< The statistics
     QStack<ProfileStackItem> stack_;         ///< The current items being processed
 };
 

--- a/edbee-lib/edbee/util/textcodec.cpp
+++ b/edbee-lib/edbee/util/textcodec.cpp
@@ -1,10 +1,10 @@
 // edbee - Copyright (c) 2012-2025 by Rick Blommers and contributors
 // SPDX-License-Identifier: MIT
 
+#include "textcodec.h"
+
 #include <QTextCodec>
 #include <QApplication>
-
-#include "textcodec.h"
 
 #include "edbee/debug.h"
 
@@ -17,20 +17,20 @@ TextCodecManager::TextCodecManager()
     // append all special encodings
     QList<QByteArray> encList;
     encList << "UTF-8" << "UTF-16" << "UTF-16BE" << "UTF-16LE" << "UTF-32" << "UTF-32BE" << "UTF-32LE";
-    foreach( QByteArray enc, encList ) {
+    foreach(QByteArray enc, encList ) {
         QTextCodec* codec = QTextCodec::codecForName(enc);
-        giveTextCodec( new TextCodec( QString(codec->name()), codec, QTextCodec::IgnoreHeader ) );
-        giveTextCodec( new TextCodec( QStringLiteral("%1 with BOM").arg( QString(codec->name()) ), codec, QTextCodec::DefaultConversion ) );
+        giveTextCodec(new TextCodec(QString(codec->name()), codec, QTextCodec::IgnoreHeader));
+        giveTextCodec(new TextCodec(QStringLiteral("%1 with BOM").arg( QString(codec->name())), codec, QTextCodec::DefaultConversion));
     }
 
     // append the items
     QList<QByteArray> names = QTextCodec::availableCodecs();
     std::sort(names.begin(), names.end());
-    foreach( QByteArray name, names) {
+    foreach(QByteArray name, names) {
         QTextCodec* codec = QTextCodec::codecForName(name);
-        if( !codecRefMap_.contains( codec->name() ) ) {
-            TextCodec* textCodec = new TextCodec( name, codec, QTextCodec::DefaultConversion );
-            giveTextCodec( textCodec );
+        if (!codecRefMap_.contains(codec->name())) {
+            TextCodec* textCodec = new TextCodec(name, codec, QTextCodec::DefaultConversion);
+            giveTextCodec(textCodec);
         }
     }
 }
@@ -45,7 +45,7 @@ TextCodecManager::~TextCodecManager()
 
 /// Registers the given codec. The ownership of this codec is transfered to the codec manager
 /// @param codec the codec to register.
-void TextCodecManager::giveTextCodec( TextCodec* codec )
+void TextCodecManager::giveTextCodec(TextCodec* codec)
 {
     codecList_.append(codec);
     codecRefMap_.insert(codec->name(), codec);
@@ -75,10 +75,10 @@ TextCodec* TextCodecManager::codecForName(const QString& name)
 /// @param name the name of the codec
 /// @param codec the Qt codec to reference
 /// @param the QTextCodec conversion flags (is used for creating codecs with and without BOM)
-TextCodec::TextCodec( const QString& name, const QTextCodec* codec, QTextCodec::ConversionFlags flags)
+TextCodec::TextCodec(const QString& name, const QTextCodec* codec, QTextCodec::ConversionFlags flags)
     : name_(name)
-    , codecRef_( codec )
-    , flags_( flags )
+    , codecRef_(codec)
+    , flags_(flags)
 {
 }
 
@@ -92,14 +92,14 @@ const QTextCodec* TextCodec::codec()
 /// Creates a QTextEncoder
 QTextEncoder* TextCodec::makeEncoder()
 {
-    return codec()->makeEncoder( flags_ );
+    return codec()->makeEncoder(flags_);
 }
 
 
 /// Creates a QTextDecodec
 QTextDecoder* TextCodec::makeDecoder()
 {
-    return codec()->makeDecoder( flags_ );
+    return codec()->makeDecoder(flags_);
 }
 
 

--- a/edbee-lib/edbee/util/textcodec.h
+++ b/edbee-lib/edbee/util/textcodec.h
@@ -20,12 +20,12 @@ class TextCodec;
 class EDBEE_EXPORT TextCodecManager {
 public:
     TextCodecManager();
-    ~TextCodecManager();
+    virtual ~TextCodecManager();
 
 public:
-    void giveTextCodec( TextCodec* codec );
+    void giveTextCodec(TextCodec* codec);
     QList<TextCodec*> codecList();
-    TextCodec* codecForName( const QString& name );
+    TextCodec* codecForName(const QString& name);
 
 private:
     QList<TextCodec*> codecList_;
@@ -33,11 +33,11 @@ private:
 };
 
 
-/// This class represents a single text codec
+/// Represents a single text codec
 /// The codec has a name and contains methods to create encoders and decoders
 class EDBEE_EXPORT TextCodec {
 public:
-    TextCodec( const QString& name, const QTextCodec* codec, QTextCodec::ConversionFlags flags );
+    TextCodec(const QString& name, const QTextCodec* codec, QTextCodec::ConversionFlags flags);
     const QTextCodec* codec();
     QTextEncoder* makeEncoder();
     QTextDecoder* makeDecoder();

--- a/edbee-lib/edbee/util/textcodecdetector.cpp
+++ b/edbee-lib/edbee/util/textcodecdetector.cpp
@@ -31,42 +31,44 @@ TextCodec *TextCodecDetector::globalPreferedCodec()
     return globalPreferedCodecRef_;
 }
 
-void TextCodecDetector::setGlobalPreferedCodec(TextCodec *codec)
+
+void TextCodecDetector::setGlobalPreferedCodec(TextCodec* codec)
 {
     globalPreferedCodecRef_ = codec;
 }
 
 
-
-TextCodecDetector::TextCodecDetector(const QByteArray* buffer, TextCodec *preferedCodec)
+TextCodecDetector::TextCodecDetector(const QByteArray* buffer, TextCodec* preferedCodec)
     : bufferRef_(buffer->constData())
-    , bufferLength_(buffer->size())
-    , preferedCodecRef_(0)
-    , fallbackCodecRef_(0)
+    , bufferLength_(static_cast<size_t>(buffer->size()))
+    , preferedCodecRef_(nullptr)
+    , fallbackCodecRef_(nullptr)
 {
-    setPreferedCodec( preferedCodec );
-    setFallbackCodec( 0 );
+    setPreferedCodec(preferedCodec);
+    setFallbackCodec(nullptr);
 }
 
-TextCodecDetector::TextCodecDetector(const char* buffer, int length, TextCodec *preferedCodec)
+
+TextCodecDetector::TextCodecDetector(const char* buffer, size_t length, TextCodec* preferedCodec)
     : bufferRef_(buffer)
     , bufferLength_(length)
-    , preferedCodecRef_(0)
-    , fallbackCodecRef_(0)
+    , preferedCodecRef_(nullptr)
+    , fallbackCodecRef_(nullptr)
 {
-    setPreferedCodec( preferedCodec );
-    setFallbackCodec( 0 );
+    setPreferedCodec(preferedCodec);
+    setFallbackCodec(0);
 }
+
 
 TextCodecDetector::~TextCodecDetector()
 {
-
 }
+
 
 /// This method returns the prefered codec
 void TextCodecDetector::setPreferedCodec(TextCodec* codec)
 {
-    if( codec ) {
+    if (codec) {
         preferedCodecRef_ = codec;
     } else {
         /// prefer UTF-8
@@ -80,17 +82,14 @@ void TextCodecDetector::setPreferedCodec(TextCodec* codec)
 /// @param codec the codec to use. When you use 0 the system codec is used
 void TextCodecDetector::setFallbackCodec(TextCodec* codec)
 {
-    if( codec ) {
+    if (codec) {
         fallbackCodecRef_ = codec;
     } else {
         /// prefer System
-        fallbackCodecRef_ = Edbee::instance()->codecManager()->codecForName("ISO-8859-1"); //QTextCodec::codecForLocale();    // is identical to: QTextCodec::codecForName(“System”)
+        fallbackCodecRef_ = Edbee::instance()->codecManager()->codecForName("ISO-8859-1"); // QTextCodec::codecForLocale();    // is identical to: QTextCodec::codecForName(“System”)
         Q_ASSERT(fallbackCodecRef_);
     }
 }
-
-
-
 
 
 /// Detects the encoding of the provided buffer.
@@ -121,11 +120,11 @@ TextCodec* TextCodecDetector::detectCodec()
 {
     // if the file has a Byte Order Marker, we can assume the file is in UTF-xx
     // otherwise, the file would not be human readable
-    if( hasUTF8Bom(bufferRef_,bufferLength_) ) return codecManager()->codecForName("UTF-8 with BOM");
-    if( hasUTF16LEBom(bufferRef_,bufferLength_) ) return codecManager()->codecForName("UTF-16LE with BOM");
-    if( hasUTF16BEBom(bufferRef_,bufferLength_) ) return codecManager()->codecForName("UTF-16BE with BOM");
-    if( hasUTF32LEBom(bufferRef_,bufferLength_) ) return codecManager()->codecForName("UTF-32LE with BOM");
-    if( hasUTF32BEBom(bufferRef_,bufferLength_) ) return codecManager()->codecForName("UTF-32BE with BOM");
+    if (hasUTF8Bom(bufferRef_,bufferLength_)) return codecManager()->codecForName("UTF-8 with BOM");
+    if (hasUTF16LEBom(bufferRef_,bufferLength_)) return codecManager()->codecForName("UTF-16LE with BOM");
+    if (hasUTF16BEBom(bufferRef_,bufferLength_)) return codecManager()->codecForName("UTF-16BE with BOM");
+    if (hasUTF32LEBom(bufferRef_,bufferLength_)) return codecManager()->codecForName("UTF-32LE with BOM");
+    if (hasUTF32BEBom(bufferRef_,bufferLength_)) return codecManager()->codecForName("UTF-32BE with BOM");
 
     // if a byte has its most significant bit set, the file is in UTF-8 or in the default encoding
     // otherwise, the file is in US-ASCII
@@ -136,8 +135,8 @@ TextCodec* TextCodecDetector::detectCodec()
     bool validU8Char = true;
 
     // TODO the buffer is not read up to the end, but up to length - 6
-    int length = bufferLength_;
-    int i = 0;
+    size_t length = bufferLength_;
+    size_t i = 0;
     while( i < length - 6 )
     {
         char b0 = bufferRef_[i];
@@ -230,44 +229,43 @@ TextCodec* TextCodecDetector::detectCodec()
 
 
 /// Has a Byte Order Marker for UTF-8
-bool TextCodecDetector::hasUTF8Bom( const char* bom, int length )
+bool TextCodecDetector::hasUTF8Bom(const char* bom, size_t length)
 {
-    if( length < 3 ) return false;
+    if (length < 3) return false;
     return (bom[0] == -17 && bom[1] == -69 && bom[2] == -65);
 }
 
+
 /// Has a Byte Order Marker for UTF-16 Low Endian
 /// (ucs-2le, ucs-4le, and ucs-16le).
-bool TextCodecDetector::hasUTF16LEBom( const char* bom, int length )
+bool TextCodecDetector::hasUTF16LEBom(const char* bom, size_t length)
 {
-    if( length < 2 ) return false;
+    if (length < 2) return false;
     return (bom[0] == -1 && bom[1] == -2);
 }
 
+
 /// Has a Byte Order Marker for UTF-16 Big Endian
 /// (utf-16 and ucs-2).
-bool TextCodecDetector::hasUTF16BEBom( const char* bom, int length )
+bool TextCodecDetector::hasUTF16BEBom(const char* bom, size_t length)
 {
-    if( length < 2 ) return false;
+    if (length < 2) return false;
     return (bom[0] == -2 && bom[1] == -1);
 }
 
 
-
 /// Has a Byte Order Marker for UTF-32 Low Endian
-bool TextCodecDetector::hasUTF32LEBom( const char* bom, int length )
+bool TextCodecDetector::hasUTF32LEBom(const char* bom, size_t length)
 {
-    if( length < 4 ) return false;
+    if (length < 4) return false;
     return (bom[0] == -1 && bom[1] == -2 && bom[2] == 0 && bom[3] == 0 );
 }
 
 /// Has a Byte Order Marker for UTF-32 Big Endian
-bool TextCodecDetector::hasUTF32BEBom( const char* bom, int length )
+bool TextCodecDetector::hasUTF32BEBom(const char* bom, size_t length)
 {
-    if( length < 4 ) return false;
+    if (length < 4) return false;
     return (bom[0] == 0 && bom[1] == 0 && bom[2] == -2 && bom[3] == -1);
 }
-
-
 
 } // edbee

--- a/edbee-lib/edbee/util/textcodecdetector.h
+++ b/edbee-lib/edbee/util/textcodecdetector.h
@@ -33,18 +33,16 @@ class EDBEE_EXPORT TextCodecDetector {
 public:
 
     static TextCodec* globalPreferedCodec();
-    static void setGlobalPreferedCodec( TextCodec* codec );
+    static void setGlobalPreferedCodec(TextCodec* codec);
 
-
-    explicit TextCodecDetector( const QByteArray* buffer=0,  TextCodec* preferedCodec=0 );
-    explicit TextCodecDetector( const char* buffer, int length=0, TextCodec* preferedCodec=0 );
+    explicit TextCodecDetector(const QByteArray* buffer = nullptr,  TextCodec* preferedCodec = nullptr);
+    explicit TextCodecDetector(const char* buffer, size_t length = 0, TextCodec* preferedCodec = nullptr );
     virtual ~TextCodecDetector();
-
 
     virtual TextCodec* detectCodec();
 
     /// Sets the buffer reference
-    virtual void setBuffer( const char* buf, int length )
+    virtual void setBuffer( const char* buf, size_t length )
     {
         bufferRef_ = buf;
         bufferLength_ = length;
@@ -54,21 +52,18 @@ public:
     virtual const char*buffer() const { return bufferRef_; }
 
     /// Returns the buffer length
-    virtual int bufferLength() { return bufferLength_; }
+    virtual size_t bufferLength() { return bufferLength_; }
 
-    virtual void setPreferedCodec( TextCodec* codec=0 );
+    virtual void setPreferedCodec(TextCodec* codec = nullptr);
     virtual TextCodec* preferedCodec() { return preferedCodecRef_; }
 
-
-    virtual void setFallbackCodec( TextCodec* codec=0 );
+    virtual void setFallbackCodec(TextCodec* codec = nullptr);
     virtual TextCodec* fallbackCodec() const { return fallbackCodecRef_; }
-
-
 
 protected:
 
     ///  If the byte has the form 10xxxxx, then it's a continuation byte of a multiple byte character;
-    virtual bool isContinuationChar( char b) { return /*-128 <= b && */ b <= -65; }
+    virtual bool isContinuationChar(char b) { return /*-128 <= b && */ b <= -65; }
 
     /// If the byte has the form 110xxxx, then it's the first byte of a two-bytes sequence character.
     virtual bool  isTwoBytesSequence(char b) { return -64 <= b && b <= -33; }
@@ -86,21 +81,21 @@ protected:
     virtual bool isSixBytesSequence(char b){  return -4 <= b && b <= -3; }
 
 public:
-    static bool hasUTF8Bom( const char* buffer, int length );
-    static bool hasUTF16LEBom( const char* buffer, int length );
-    static bool hasUTF16BEBom( const char* buffer, int length );
-    static bool hasUTF32LEBom( const char* buffer, int length );
-    static bool hasUTF32BEBom( const char* buffer, int length );
+    static bool hasUTF8Bom(const char* buffer, size_t length);
+    static bool hasUTF16LEBom(const char* buffer, size_t length);
+    static bool hasUTF16BEBom(const char* buffer, size_t length);
+    static bool hasUTF32LEBom(const char* buffer, size_t length);
+    static bool hasUTF32BEBom(const char* buffer, size_t length);
 
 
 private:
 
-    //const QByteArray *bufferRef_;   ///< A reference to the current buffer of data
+    //const QByteArray *bufferRef_; ///< A reference to the current buffer of data
     const char* bufferRef_;         ///< A reference to the buffer
-    int bufferLength_;              ///< The size of the buffer
+    size_t bufferLength_;           ///< The size of the buffer
 
     TextCodec* preferedCodecRef_;  ///< The prefered codec to use
-    TextCodec* fallbackCodecRef_;   ///< The default codec to return. This is the codec to use if there's a problem detecting the codec or returning the prefered codec
+    TextCodec* fallbackCodecRef_;  ///< The default codec to return. This is the codec to use if there's a problem detecting the codec or returning the prefered codec
 
 
 };

--- a/edbee-lib/edbee/util/util.cpp
+++ b/edbee-lib/edbee/util/util.cpp
@@ -43,27 +43,27 @@ QString Util::convertTabsToSpaces(const QString& str, int tabSize )
 /// @param str the string to convert
 /// @param tabSize the tab size to use for conversion
 /// @return a vector with the character-offset in the given string that contains the given tab-column
-QList<int> Util::tabColumnOffsets(const QString& str, int tabSize)
+QList<size_t> Util::tabColumnOffsets(const QString& str, unsigned int tabSize)
 {
     // build the resut (column 0 is always available)
-    QList<int> offsets;
+    QList<size_t> offsets;
     offsets.push_back( 0);
 
-    int column = 0;
+    size_t column = 0;
 
     // iterate over all characters
-    for( int offset=0,cnt=str.size(); offset<cnt; ++offset ) {
-        QChar c = str.at(offset);
+    for (size_t offset = 0, cnt = static_cast<size_t>(str.size()); offset < cnt; ++offset) {
+        QChar c = str.at(static_cast<qsizetype>(offset));
 
         // when a tab character is found, we need to jump to the next column
-        if( c == '\t' ) {
-            int amount = tabSize - column % tabSize;
+        if (c == '\t') {
+            size_t amount = tabSize - column % tabSize;
             column += amount;
         } else {
             ++column;
         }
         // when we've reached another tab-column, we add the column
-        if( column % tabSize == 0 ) {
+        if (column % tabSize == 0) {
            offsets.push_back( offset+1 );
         }
     }

--- a/edbee-lib/edbee/util/util.cpp
+++ b/edbee-lib/edbee/util/util.cpp
@@ -16,21 +16,21 @@ namespace edbee {
 /// @param str the string where to convert the tabs to space
 /// @param tabSize the size of a single tab. This needs to be at least 1
 /// @return A string with all tabs converted to spaces
-QString Util::convertTabsToSpaces(const QString& str, int tabSize )
+QString Util::convertTabsToSpaces(const QString& str, int tabSize)
 {
     Q_ASSERT(tabSize > 0);
 
     QString result;
-    result.reserve( str.length() );
+    result.reserve( str.length());
 
     // append all characters to the result
-    for( int i=0,cnt=str.size(); i<cnt; ++i ) {
+    for (qsizetype i=0, cnt = str.size(); i<cnt; ++i ) {
         QChar c = str.at(i);
 
         // when a tab character is used it is converted to the correct column
         if( c == '\t' ) {
             int amount = tabSize - result.length() % tabSize;
-            result.append( QStringLiteral(" ").repeated(amount) );
+            result.append(QStringLiteral(" ").repeated(amount));
         } else {
             result.append(c);
         }
@@ -47,7 +47,7 @@ QList<size_t> Util::tabColumnOffsets(const QString& str, unsigned int tabSize)
 {
     // build the resut (column 0 is always available)
     QList<size_t> offsets;
-    offsets.push_back( 0);
+    offsets.push_back(0);
 
     size_t column = 0;
 
@@ -69,7 +69,6 @@ QList<size_t> Util::tabColumnOffsets(const QString& str, unsigned int tabSize)
     }
     return offsets;
 }
-
 
 
 } // edbee

--- a/edbee-lib/edbee/util/util.h
+++ b/edbee-lib/edbee/util/util.h
@@ -17,11 +17,10 @@ namespace edbee {
 /// You can use this class like this:   Util().converTabsToSpaces()
 class EDBEE_EXPORT Util {
 public:
-    QString convertTabsToSpaces( const QString& str, int tabSize );
+    QString convertTabsToSpaces(const QString& str, int tabSize);
     QList<size_t> tabColumnOffsets(const QString& str, unsigned int tabSize);
 
-
-    /// This method calculates 2 intersections between 2 ranges.
+    /// Calculates 2 intersections between 2 ranges.
     /// @param exclusive if it is exclusive then an overlap will not be included. In other words:
     ///			- Inclusive:  end < begin
     ///			- Exclusive:  end <= begin
@@ -29,19 +28,19 @@ public:
     /// @param resultEnd a pointer to the variable receiving the result
     /// @return false => no overlap, true => overlap
     template<typename T>
-    bool intersection( T begin1, T end1, T begin2, T end2, bool exclusive=false, T* resultBegin=0, T* resultEnd=0 )
+    bool intersection(T begin1, T end1, T begin2, T end2, bool exclusive = false, T* resultBegin = nullptr, T* resultEnd=nullptr)
     {
-        if( exclusive ) {
-            if( end1 <= begin2 ) return false;
-            if( end2 <= begin1 ) return false;
+        if (exclusive) {
+            if (end1 <= begin2) return false;
+            if (end2 <= begin1) return false;
         } else {
-            if( end1 < begin2 ) return false;
-            if( end2 < begin1 ) return false;
+            if (end1 < begin2) return false;
+            if (end2 < begin1) return false;
         }
 
         // assign the result
-        if( resultBegin ) { *resultBegin = qMax(begin1,begin2);  }
-        if( resultEnd ) { *resultEnd = qMin(end1,end2); }
+        if (resultBegin) { *resultBegin = qMax(begin1, begin2); }
+        if (resultEnd) { *resultEnd = qMin(end1, end2); }
         return true;
     }
 };

--- a/edbee-lib/edbee/util/util.h
+++ b/edbee-lib/edbee/util/util.h
@@ -18,7 +18,7 @@ namespace edbee {
 class EDBEE_EXPORT Util {
 public:
     QString convertTabsToSpaces( const QString& str, int tabSize );
-    QList<int> tabColumnOffsets( const QString& str, int tabSize );
+    QList<size_t> tabColumnOffsets(const QString& str, unsigned int tabSize);
 
 
     /// This method calculates 2 intersections between 2 ranges.

--- a/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
+++ b/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
@@ -6,7 +6,7 @@
 #include <QWidget>
 #include <QAccessibleInterface>
 
-#include "edbee/models/changes/textchange.h"
+// #include "edbee/models/changes/textchange.h"
 #include "edbee/models/textdocument.h"
 #include "edbee/models/textrange.h"
 #include "edbee/texteditorwidget.h"
@@ -36,40 +36,42 @@ namespace edbee {
 
 /// Workaround for the strang line-reading on windows
 /// It virtually replaces every <newline> with <space><newline>
-static int D2V(TextEditorWidget* widget, int offset)
+static int D2V(TextEditorWidget* widget, size_t offset)
 {
 #ifdef WINDOWS_END_LINE_READ_ERROR_FIX
-    int line = widget->textDocument()->lineFromOffset(offset);
-    return offset + line;
+    size_t line = widget->textDocument()->lineFromOffset(offset);
+    return static_cast<int>(offset + line);
 #else
     Q_UNUSED(widget)
-    return offset;
+    return static_cast<int>(offset);
 #endif
 }
 
+
 /// Converts the virtual-offset to the document-offset
-static int V2D(TextEditorWidget* widget, int vOffset)
+static size_t V2D(TextEditorWidget* widget, int vOffset)
 {
 #ifdef WINDOWS_END_LINE_READ_ERROR_FIX
     TextDocument* doc = widget->textDocument();
-    int displacement = 0;
-    for( int i=0, cnt = doc->lineCount(); i < cnt; ++i ) {
-        int lineVOffset = doc->offsetFromLine(i) + i;
+    size_t displacement = 0;
+    for (size_t i=0, cnt = doc->lineCount(); i < cnt; ++i) {
+        size_t lineVOffset = doc->offsetFromLine(i) + i;
 
-        if( vOffset < lineVOffset) {
-            return vOffset - displacement; // remove the newline count
+        if (static_cast<size_t>(vOffset) < lineVOffset) {
+            return static_cast<size_t>(vOffset) - displacement; // remove the newline count
         }
         displacement = i;
     }
-    return vOffset - displacement;
+    return static_cast<size_t>(vOffset) - displacement;
 #else
     Q_UNUSED(widget)
-    return vOffset;
+    return static_cast<size_t>(vOffset);
 #endif
 }
 
+
 /// returns the virtual length of the textdocument
-static int VLEN(TextEditorWidget* widget)
+static size_t VLEN(TextEditorWidget* widget)
 {
 #if ! defined(WINDOWS_END_LINE_READ_ERROR_FIX)
     return widget->textDocument()->length();
@@ -79,6 +81,7 @@ static int VLEN(TextEditorWidget* widget)
     return widget->textDocument()->length() + widget->textDocument()->lineCount() - 1;
 #endif
 }
+
 
 /// Converts the given text to a virtual text
 /// It prepends every newline with a space
@@ -91,6 +94,7 @@ static const QString VTEXT(QString str)
     return str;
 #endif
 }
+
 
 /// Converts the given text to a virtual text
 /// It prepends every newline with a space
@@ -119,22 +123,22 @@ static const QString VTEXT_PART(TextDocument* doc, size_t offset, size_t length)
 
     return doc->textPart(offset, qMin(length, doc->length() - offset));
 #else
-    int docLength = doc->length();
+    size_t docLength = doc->length();
 #if defined(WINDOWS_LAST_LINE_ERROR_FIX)
-        int endOffset = qMin(offset + length, docLength + 2);
+        size_t endOffset = qMin(offset + length, docLength + 2);
 #endif // WINDOWS_LAST_LINE_ERROR_FIX - First use
     //qDebug() << "VTEXT_PART: " << offset << ", " << length << " :: docLength: " << docLength << ", endOffset: " << endOffset;
 
     QString txt;
-    if( offset < docLength ) {
-        int len = offset + length > docLength ? docLength - offset : length;
-        //qDebug() << " - A  offset:" << offset <<", len: " << len;
+    if (offset < docLength) {
+        size_t len = offset + length > docLength ? docLength - offset : length;
+        // qDebug() << " - A  offset:" << offset <<", len: " << len;
         txt = VTEXT(doc->textPart(offset, len));
     }
 
 #if defined(WINDOWS_LAST_LINE_ERROR_FIX)
-    //qDebug() << " - B  endOffset: " << endOffset << " >= " << docLength;
-    if( endOffset >= docLength ) {
+    // qDebug() << " - B  endOffset: " << endOffset << " >= " << docLength;
+    if (endOffset >= docLength) {
         txt.append(WINDOWS_EMPTY_LINE_FIX);
     }
 #endif // WINDOWS_LAST_LINE_ERROR_FIX - Second use
@@ -154,12 +158,14 @@ AccessibleTextEditorWidget::AccessibleTextEditorWidget(TextEditorWidget* widget)
 {
 }
 
+
 AccessibleTextEditorWidget::~AccessibleTextEditorWidget()
 {
 }
 
+
 /// Construct the AccessibleTextEditor interface for the given widget
-QAccessibleInterface *AccessibleTextEditorWidget::factory(const QString &className, QObject *object)
+QAccessibleInterface *AccessibleTextEditorWidget::factory(const QString& className, QObject* object)
 {
     // edbee::TextMarginComponent, edbee::TextEditorScrollArea, edbee::TextEditorComponent
 #ifdef VIA_EDITOR_COMPONENT
@@ -176,6 +182,7 @@ QAccessibleInterface *AccessibleTextEditorWidget::factory(const QString &classNa
     return nullptr;
 }
 
+
 /// Returns the widget that should be used for accessibility events
 QWidget* AccessibleTextEditorWidget::eventWidgetForTextEditor(TextEditorWidget* widget)
 {
@@ -186,33 +193,33 @@ QWidget* AccessibleTextEditorWidget::eventWidgetForTextEditor(TextEditorWidget* 
 #endif
 }
 
+
 /// Notifies a text-selection change event
-void AccessibleTextEditorWidget::notifyTextSelectionEvent(TextEditorWidget *widget, TextSelection *selection)
+void AccessibleTextEditorWidget::notifyTextSelectionEvent(TextEditorWidget* widget, TextSelection* selection)
 {
     QWidget* eventWidget = eventWidgetForTextEditor(widget);
-    for(int i=0, cnt = selection->rangeCount(); i < cnt; ++i) {
+    for (size_t i=0, cnt = selection->rangeCount(); i < cnt; ++i) {
         TextRange range = selection->range(i);
-
 
         QAccessibleTextSelectionEvent ev(eventWidget, D2V(widget, range.min()), D2V(widget, range.max()));
         ev.setCursorPosition(D2V(widget, range.caret()));
 
-//        qDebug() << " !!updateAccessibility: QAccessibleTextSelectionEvent: " << range.min()<< ", " << range.max() << ", " << range.caret();
+        // qDebug() << " !!updateAccessibility: QAccessibleTextSelectionEvent: " << range.min()<< ", " << range.max() << ", " << range.caret();
 
         QAccessible::updateAccessibility(&ev);
 
         // also send a caret event for range 0 without a selection
-        if( i ==0 && !range.hasSelection()) {
+        if (i ==0 && !range.hasSelection()) {
             const QAccessibleTextInterface* ti = QAccessible::queryAccessibleInterface(eventWidget)->textInterface();
             QAccessibleTextCursorEvent event(eventWidget, ti->cursorPosition());
             QAccessible::updateAccessibility(&event);
         }
-
     }
 }
 
+
 /// Notifies a text change event happens
-void AccessibleTextEditorWidget::notifyTextChangeEvent(TextEditorWidget *widget, TextBufferChange *change, QString oldDocText)
+void AccessibleTextEditorWidget::notifyTextChangeEvent(TextEditorWidget* widget, TextBufferChange* change, QString oldDocText)
 {
     QWidget* eventWidget = eventWidgetForTextEditor(widget);
 
@@ -222,19 +229,19 @@ void AccessibleTextEditorWidget::notifyTextChangeEvent(TextEditorWidget *widget,
     QAccessibleTextUpdateEvent ev(eventWidget, D2V(widget, change->offset()), oldText, newText);
     // TODO: When a caret is included, (Inherited change, use this caret position)
 
-//    qDebug() << "-- change: length: " << change->length()
-//             << ", newTextLength: " << change->newTextLength()
-//             << ", offset :" << change->offset()
-//             << ", newText: " << QString(change->newText())
-//             << ", CONTENT: " << widget->textDocument()->text();
-//    qDebug() << "!! updateAccessibility: QAccessibleTextUpdateEvent: " << change->offset()<< ", oldText: " << oldText << ", newText: " << newText;
+    //    qDebug() << "-- change: length: " << change->length()
+    //             << ", newTextLength: " << change->newTextLength()
+    //             << ", offset :" << change->offset()
+    //             << ", newText: " << QString(change->newText())
+    //             << ", CONTENT: " << widget->textDocument()->text();
+    //    qDebug() << "!! updateAccessibility: QAccessibleTextUpdateEvent: " << change->offset()<< ", oldText: " << oldText << ", newText: " << newText;
 
     QAccessible::updateAccessibility(&ev);
 
 
 }
 
-void *AccessibleTextEditorWidget::interface_cast(QAccessible::InterfaceType t)
+void* AccessibleTextEditorWidget::interface_cast(QAccessible::InterfaceType t)
 {
     if (t == QAccessible::TextInterface) {
         return static_cast<QAccessibleTextInterface*>(this);
@@ -251,10 +258,8 @@ QAccessible::State AccessibleTextEditorWidget::state() const
     s.focusable = true;
     s.readOnly = false;
     s.editable = true;
-
     return s;
 }
-
 
 
 /// Returns a selection. The size of the selection is returned in startOffset and endOffset.
@@ -262,25 +267,27 @@ QAccessible::State AccessibleTextEditorWidget::state() const
 ///
 /// The accessibility APIs support multiple selections. For most widgets though, only one selection
 /// is supported with selectionIndex equal to 0.
-void AccessibleTextEditorWidget::selection(int selectionIndex, int *startOffset, int *endOffset) const
+void AccessibleTextEditorWidget::selection(int selectionIndex, int* startOffset, int* endOffset) const
 {
-    if(selectionIndex >= textSelection()->rangeCount()) {
+    if (selectionIndex >= static_cast<int>(textSelection()->rangeCount())) {
         *startOffset = 0;
         *endOffset = 0;
     }
 
-    TextRange& range = textSelection()->range(selectionIndex);
+    TextRange& range = textSelection()->range(static_cast<size_t>(selectionIndex));
     *startOffset = D2V(textWidget(), range.min());
     *endOffset = D2V(textWidget(), range.max());
     //qDebug() << " selection >> " << selectionIndex << ", " << range.min() << " =>" << *startOffset << ", " << range.max() << " => " << *endOffset;
 }
 
+
 /// Returns the number of selections in this text.
 int AccessibleTextEditorWidget::selectionCount() const
 {
-    if( !textSelection()->hasSelection()) return 0; // no selection (only caret)
-    return textSelection()->rangeCount();
+    if (!textSelection()->hasSelection()) return 0; // no selection (only caret)
+    return static_cast<int>(textSelection()->rangeCount());
 }
+
 
 /// Select the text from startOffset to endOffset. The startOffset is the first character that will be selected.
 /// The endOffset is the first character that will not be selected.
@@ -296,21 +303,24 @@ void AccessibleTextEditorWidget::addSelection(int startOffset, int endOffset)
     controller()->changeAndGiveTextSelection(&selection);
 }
 
+
 /// Clears the selection with index selectionIndex.
 void AccessibleTextEditorWidget::removeSelection(int selectionIndex)
 {
     TextSelection selection = *textSelection();
-    selection.removeRange(selectionIndex);
+    selection.removeRange(static_cast<size_t>(selectionIndex));
     controller()->changeAndGiveTextSelection(&selection);
 }
+
 
 /// Set the selection selectionIndex to the range from startOffset to endOffset.
 void AccessibleTextEditorWidget::setSelection(int selectionIndex, int startOffset, int endOffset)
 {
     TextSelection selection = *textSelection();
-    selection.setRange(V2D(textWidget(), startOffset), V2D(textWidget(), endOffset), selectionIndex);
+    selection.setRange(V2D(textWidget(), startOffset), V2D(textWidget(), endOffset), static_cast<size_t>(selectionIndex));
     controller()->changeAndGiveTextSelection(&selection);
 }
+
 
 /// Returns the current cursor position.
 int AccessibleTextEditorWidget::cursorPosition() const
@@ -319,12 +329,14 @@ int AccessibleTextEditorWidget::cursorPosition() const
     return caret;
 }
 
+
 /// Move the cursor position
 void AccessibleTextEditorWidget::setCursorPosition(int position)
 {
-    //qDebug() << "AccessibleTextEditorWidget::setCursorPosition: " << position << " => <" << V2D(textWidget(), position);
+    // qDebug() << "AccessibleTextEditorWidget::setCursorPosition: " << position << " => <" << V2D(textWidget(), position);
     controller()->moveCaretToOffset(V2D(textWidget(), position), false);
 }
+
 
 QString AccessibleTextEditorWidget::text(QAccessible::Text t) const
 {
@@ -334,12 +346,13 @@ QString AccessibleTextEditorWidget::text(QAccessible::Text t) const
     return VTEXT(textWidget()->textDocument());
 }
 
+
 /// Returns the text from startOffset to endOffset. The startOffset is the first character that will be returned.
 /// The endOffset is the first character that will not be returned.
 QString AccessibleTextEditorWidget::text(int vStartOffset, int vEndOffset) const
 {
-    int startOffset = V2D(textWidget(), vStartOffset);
-    int endOffset = V2D(textWidget(), vEndOffset);
+    size_t startOffset = V2D(textWidget(), vStartOffset);
+    size_t endOffset = V2D(textWidget(), vEndOffset);
 
     //qDebug() << "text: " << VTEXT_PART(textWidget()->textDocument(), startOffset, endOffset - startOffset);
     //qDebug() << "      - vStartOffset " << vStartOffset << ", vEndOffset " << vEndOffset ;
@@ -351,7 +364,7 @@ QString AccessibleTextEditorWidget::text(int vStartOffset, int vEndOffset) const
 int AccessibleTextEditorWidget::characterCount() const
 {
     //qDebug() << " characterCount >> " << VLEN(textWidget());
-    return VLEN(textWidget());
+    return static_cast<int>(VLEN(textWidget()));
 }
 
 
@@ -359,15 +372,15 @@ int AccessibleTextEditorWidget::characterCount() const
 QRect AccessibleTextEditorWidget::characterRect(int vOffset) const
 {
     TextEditorComponent* comp = textWidget()->textEditorComponent();
-    int offset = V2D(textWidget(), vOffset);
+    size_t offset = V2D(textWidget(), vOffset);
 
     // workaround for newline char rect (is at the wrong location)
     // Very dirty workaround, it's dependent on the selection
 #ifdef WINDOWS_END_LINE_READ_ERROR_FIX
-        if(offset > 0 && offset <= textDocument()->length()){
+        if (offset > 0 && offset <= textDocument()->length()) {
             TextRange& range = textSelection()->range(0);
-            if( range.hasSelection()) {
-                if( offset == range.max() || textDocument()->charAt(offset) == '\n') {
+            if (range.hasSelection()) {
+                if (offset == range.max() || textDocument()->charAt(offset) == '\n') {
                     offset -= 1;
                 }
             }
@@ -386,10 +399,10 @@ QRect AccessibleTextEditorWidget::characterRect(int vOffset) const
 
 
 /// Returns the offset of the character at the point in screen coordinates.
-int AccessibleTextEditorWidget::offsetAtPoint(const QPoint &point) const
+int AccessibleTextEditorWidget::offsetAtPoint(const QPoint& point) const
 {
-    int line = renderer()->rawLineIndexForYpos(point.y());
-    int col = renderer()->columnIndexForXpos(line, point.x());
+    size_t line = renderer()->rawLineIndexForYpos(point.y());
+    size_t col = renderer()->columnIndexForXpos(line, point.x());
     // qDebug() << " offsetAtPoint >>" << point << ": " << line << ", " << col;
 
    return D2V(textWidget(), textDocument()->offsetFromLineAndColumn(line, col));
@@ -406,7 +419,7 @@ void AccessibleTextEditorWidget::scrollToSubstring(int startIndex, int endIndex)
 
 /// Returns the text attributes at the position offset.
 /// In addition the range of the attributes is returned in startOffset and endOffset.
-QString AccessibleTextEditorWidget::attributes(int offset, int *startOffset, int *endOffset) const
+QString AccessibleTextEditorWidget::attributes(int offset, int *startOffset, int* endOffset) const
 {
     Q_UNUSED(offset)
     Q_UNUSED(startOffset)
@@ -427,30 +440,29 @@ QString AccessibleTextEditorWidget::attributes(int offset, int *startOffset, int
 /// to the cursor position before calling this function.
 /// An offset of -1 is used for the text length and custom implementations of this function have to return the
 /// result as if the length was passed in as offset.
-QString AccessibleTextEditorWidget::textAfterOffset(int vOffset, QAccessible::TextBoundaryType boundaryType, int *startOffset, int *endOffset) const
+QString AccessibleTextEditorWidget::textAfterOffset(int vOffset, QAccessible::TextBoundaryType boundaryType, int* startOffset, int* endOffset) const
 {
-    if(boundaryType == QAccessible::LineBoundary && vOffset >= 0) {
-        int offset = V2D(textWidget(), vOffset);
+    if (boundaryType == QAccessible::LineBoundary && vOffset >= 0) {
+        size_t offset = V2D(textWidget(), vOffset);
 
-        int line = textDocument()->lineFromOffset(offset);
+        size_t line = textDocument()->lineFromOffset(offset);
         // qDebug() << " => " << textDocument()->line(line);
-        int start = textDocument()->offsetFromLine(line);
-        int end = textDocument()->offsetFromLine(line+1);
+        size_t start = textDocument()->offsetFromLine(line);
+        size_t end = textDocument()->offsetFromLine(line + 1);
 
         QString str = VTEXT_PART(textDocument(), start, end - start);
         *startOffset = D2V(textWidget(), start);
-        *endOffset = *startOffset + str.length(); //D2V(textWidget(), end);
+        *endOffset = *startOffset + static_cast<int>(str.length()); // D2V(textWidget(), end);
 
-
-//        qDebug() << "textAfterOffset: vOffset: " << vOffset << " => " << offset
-//                 << ", startOffset: " << *startOffset << " (start: " << start << ")"
-//                 << ", endOffset: " << *endOffset << " (end: " << end << ")"
-//                 <<  " => " << str;
+        // qDebug() << "textAfterOffset: vOffset: " << vOffset << " => " << offset
+        //          << ", startOffset: " << *startOffset << " (start: " << start << ")"
+        //          << ", endOffset: " << *endOffset << " (end: " << end << ")"
+        //          <<  " => " << str;
         return str;
     }
 
     QString str = QAccessibleTextInterface::textAfterOffset(vOffset, boundaryType, startOffset, endOffset);
-//    qDebug() << "?? textAfterOffset: vOffset: " << vOffset << ", boundaryType: " << boundaryType << " => " << str << " (" << *startOffset << ", " << *endOffset <<")";
+    // qDebug() << "?? textAfterOffset: vOffset: " << vOffset << ", boundaryType: " << boundaryType << " => " << str << " (" << *startOffset << ", " << *endOffset <<")";
     return str;
 }
 
@@ -466,7 +478,7 @@ QString AccessibleTextEditorWidget::textAfterOffset(int vOffset, QAccessible::Te
 /// this function should use the cursor position as offset. Thus an offset of -2 must be converted to the cursor
 /// position before calling this function. An offset of -1 is used for the text length and custom implementations
 /// of this function have to return the result as if the length was passed in as offset.
-QString AccessibleTextEditorWidget::textAtOffset(int vOffset, QAccessible::TextBoundaryType boundaryType, int *startOffset, int *endOffset) const
+QString AccessibleTextEditorWidget::textAtOffset(int vOffset, QAccessible::TextBoundaryType boundaryType, int* startOffset, int* endOffset) const
 {
     //  QAccessible::CharBoundary	0	Use individual characters as boundary.
     //  QAccessible::WordBoundary	1	Use words as boundaries.
@@ -475,31 +487,30 @@ QString AccessibleTextEditorWidget::textAtOffset(int vOffset, QAccessible::TextB
     //  QAccessible::LineBoundary	4	Use newlines as boundary.
     //  QAccessible::NoBoundary	5	No boundary (use the whole text).
 
+    if (boundaryType == QAccessible::LineBoundary && vOffset >= 0) {
+        size_t offset = V2D(textWidget(), vOffset);
+        size_t line = textDocument()->lineFromOffset(offset);
 
-    if(boundaryType == QAccessible::LineBoundary && vOffset >= 0) {
-        int offset = V2D(textWidget(), vOffset);
-        int line = textDocument()->lineFromOffset(offset);
-
-        int start = textDocument()->offsetFromLine(line);
-        int end = textDocument()->offsetFromLine(line+1);
+        size_t start = textDocument()->offsetFromLine(line);
+        size_t end = textDocument()->offsetFromLine(line + 1);
 
 
         QString str = VTEXT_PART(textDocument(), start, end - start);
         *startOffset = D2V(textWidget(), start);
-        *endOffset = (*startOffset) + str.length(); //D2V(textWidget(), end);
+        *endOffset = (*startOffset) + static_cast<int>(str.length()); // D2V(textWidget(), end);
 
-
-//        qDebug() << "textAtOffset: vOffset: " << vOffset << " => " << offset
-//                 << ", startOffset: " << *startOffset << " (start: " << start << ")"
-//                 << ", endOffset: " << *endOffset << " (end: " << end << ")"
-//                 <<  " => " << str << " (" << str.length() << ")";
-       return str;
+        // qDebug() << "textAtOffset: vOffset: " << vOffset << " => " << offset
+        //          << ", startOffset: " << *startOffset << " (start: " << start << ")"
+        //          << ", endOffset: " << *endOffset << " (end: " << end << ")"
+        //          <<  " => " << str << " (" << str.length() << ")";
+        return str;
     }
 
     QString str = QAccessibleTextInterface::textAtOffset(vOffset, boundaryType, startOffset, endOffset);
-//    qDebug() << "?? textAtOffset: offset: " << vOffset << ", boundaryType: " << boundaryType << " => " << str << " (" << *startOffset << ", " << *endOffset <<")";
+    // qDebug() << "?? textAtOffset: offset: " << vOffset << ", boundaryType: " << boundaryType << " => " << str << " (" << *startOffset << ", " << *endOffset <<")";
     return str;
 }
+
 
 /// Returns the text item of type boundaryType that is close to offset offset and sets startOffset and endOffset values
 /// to the start and end positions of that item; returns an empty string if there is no such an item.
@@ -512,17 +523,19 @@ QString AccessibleTextEditorWidget::textAtOffset(int vOffset, QAccessible::TextB
 /// function should use the cursor position as offset. Thus an offset of -2 must be converted to the cursor position
 /// before calling this function. An offset of -1 is used for the text length and custom implementations of this function
 /// have to return the result as if the length was passed in as offset.
-QString AccessibleTextEditorWidget::textBeforeOffset(int offset, QAccessible::TextBoundaryType boundaryType, int *startOffset, int *endOffset) const
+QString AccessibleTextEditorWidget::textBeforeOffset(int offset, QAccessible::TextBoundaryType boundaryType, int* startOffset, int* endOffset) const
 {
     // qDebug() << "?? textBeforeOffset: offset: " << offset << ", boundaryType: " << boundaryType;
     return QAccessibleTextInterface::textBeforeOffset(offset, boundaryType, startOffset, endOffset);
 }
+
 
 QAccessibleInterface *AccessibleTextEditorWidget::focusChild() const
 {
     QAccessibleInterface* child = QAccessibleWidget::focusChild();
     return child;
 }
+
 
 /// Returns the rectangle for the editor widget
 /// It returns the location of the textWidget (even when the TextComponent has got focus)
@@ -533,25 +546,30 @@ QRect AccessibleTextEditorWidget::rect() const
     return focusRect;
 }
 
+
 TextDocument* AccessibleTextEditorWidget::textDocument() const
 {
     return textWidget()->textDocument();
 }
+
 
 TextSelection *AccessibleTextEditorWidget::textSelection() const
 {
     return textWidget()->textSelection();
 }
 
+
 TextEditorController* AccessibleTextEditorWidget::controller() const
 {
     return textWidget()->controller();
 }
 
+
 TextRenderer *AccessibleTextEditorWidget::renderer() const
 {
     return textWidget()->textRenderer();
 }
+
 
 TextEditorWidget *AccessibleTextEditorWidget::textWidget() const
 {

--- a/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
+++ b/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
@@ -110,7 +110,7 @@ static const QString VTEXT(TextDocument* doc)
 /// Return a part of text, translating the virtual characters
 /// It prepends every newline with a space
 /// It assumes an extra space + newline is placed at the end of the document
-static const QString VTEXT_PART(TextDocument* doc, int offset, int length)
+static const QString VTEXT_PART(TextDocument* doc, size_t offset, size_t length)
 {
 #if ! defined(WINDOWS_END_LINE_READ_ERROR_FIX)
     if(length < 0) {

--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
@@ -211,18 +211,17 @@ void TextEditorAutoCompleteComponent::showInfoTip()
 
     infoTipRef_->resize(tipSize.width(), tipSize.height() - 4);
 
-    //position the list
-    positionWidgetForCaretOffset( qMax(0,range.caret() - currentWord_.length()) );
+    // position the list
+    positionWidgetForCaretOffset(qMax(0u, range.caret() - currentWord_.length()));
 
     QPoint newLoc(listWidgetRef_->parentWidget()->mapToGlobal(r.topRight()).x() + xOffset, listWidgetRef_->parentWidget()->mapToGlobal(r.topRight()).y() + 1);
-
     QRect screen = QApplication::primaryScreen()->availableGeometry();
 
-    if( newLoc.x() + infoTipRef_->width() > screen.x() + screen.width() && (menuRef_->x() - infoTipRef_->width() - 1) >= 0 ){
+    if (newLoc.x() + infoTipRef_->width() > screen.x() + screen.width() && (menuRef_->x() - infoTipRef_->width() - 1) >= 0 ){
         newLoc.setX(menuRef_->x() - infoTipRef_->width() - 1);
     }
 
-    if(!infoTip.isEmpty()) {
+    if (!infoTip.isEmpty()) {
         infoTipRef_->repaint();
         infoTipRef_->move(newLoc);
         infoTipRef_->show();

--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
@@ -11,6 +11,7 @@
 #include <QWidgetAction>
 #include <QListWidget>
 #include <QListWidgetItem>
+#include <QScreen>
 #include <QTextEdit>
 // #include <QtGui>
 #include <QTime>
@@ -216,7 +217,7 @@ void TextEditorAutoCompleteComponent::showInfoTip()
     infoTipRef_->resize(tipSize.width(), tipSize.height() - 4);
 
     // position the list
-    positionWidgetForCaretOffset(qMax(0u, range.caret() - static_cast<size_t>(currentWord_.length())));
+    positionWidgetForCaretOffset(qMax(static_cast<size_t>(0u), range.caret() - static_cast<size_t>(currentWord_.length())));
 
     QPoint newLoc(listWidgetRef_->parentWidget()->mapToGlobal(r.topRight()).x() + xOffset, listWidgetRef_->parentWidget()->mapToGlobal(r.topRight()).y() + 1);
     QRect screen = QApplication::primaryScreen()->availableGeometry();

--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
@@ -4,6 +4,7 @@
 #include "texteditorautocompletecomponent.h"
 
 #include <QApplication>
+#include <QAbstractTextDocumentLayout>
 #include <QKeyEvent>
 #include <QLayout>
 #include <QHBoxLayout>
@@ -11,7 +12,7 @@
 #include <QListWidget>
 #include <QListWidgetItem>
 #include <QTextEdit>
-#include <QtGui>
+// #include <QtGui>
 #include <QTime>
 
 #include "edbee/edbee.h"
@@ -29,7 +30,7 @@
 
 namespace edbee {
 
-TextEditorAutoCompleteComponent::TextEditorAutoCompleteComponent(TextEditorController *controller, TextEditorComponent *parent, TextMarginComponent *margin)
+TextEditorAutoCompleteComponent::TextEditorAutoCompleteComponent(TextEditorController* controller, TextEditorComponent* parent, TextMarginComponent* margin)
     : QWidget(parent)
     , controllerRef_(controller)
     , menuRef_(nullptr)
@@ -77,19 +78,19 @@ TextEditorAutoCompleteComponent::TextEditorAutoCompleteComponent(TextEditorContr
     p.setColor(QPalette::Base, QColor(37, 37, 38));
     p.setColor(QPalette::Text, Qt::white);
 
-    listWidgetRef_->setAttribute(Qt::WA_NoMousePropagation,true);   // do not wheel
+    listWidgetRef_->setAttribute(Qt::WA_NoMousePropagation, true); // do not wheel
     listWidgetRef_->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     listWidgetRef_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     listWidgetRef_->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
 
-    AutoCompleteDelegate *acDel = new AutoCompleteDelegate(controllerRef_, this);
+    AutoCompleteDelegate* acDel = new AutoCompleteDelegate(controllerRef_, this);
     listWidgetRef_->setItemDelegate(acDel);
 
     // make clicking in the list word
     listWidgetRef_->setMouseTracking(true);
-    connect( listWidgetRef_, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(listItemClicked(QListWidgetItem*)));
-    connect( listWidgetRef_, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(listItemDoubleClicked(QListWidgetItem*)));
-    connect( listWidgetRef_, SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)), this, SLOT(showInfoTip()));
+    connect(listWidgetRef_, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(listItemClicked(QListWidgetItem*)));
+    connect(listWidgetRef_, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(listItemDoubleClicked(QListWidgetItem*)));
+    connect(listWidgetRef_, SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)), this, SLOT(showInfoTip()));
 }
 
 
@@ -99,62 +100,66 @@ TextEditorController *TextEditorAutoCompleteComponent::controller() const
     return controllerRef_;
 }
 
+
 /// Returns the QListWidget used for the autocomplete
 QListWidget *TextEditorAutoCompleteComponent::listWidget() const
 {
     return listWidgetRef_;
 }
 
+
 QSize TextEditorAutoCompleteComponent::sizeHint() const
 {
-    if(!listWidgetRef_) return QSize();
+    if (!listWidgetRef_) return QSize();
 
-    return QSize(850, ( qMin(listWidgetRef_->count(), 10) * 15 ) + 5);
+    return QSize(850, (qMin(listWidgetRef_->count(), 10) * 15) + 5);
 }
 
 /// This method check if the autocomplete should be shown
 /// this method ALSO sets the word that's display
-bool TextEditorAutoCompleteComponent::shouldDisplayAutoComplete(TextRange& range, QString& word )
+bool TextEditorAutoCompleteComponent::shouldDisplayAutoComplete(TextRange& range, QString& word)
 {
     // when it's a selection (which shouldn't be posssible, but still check it)
-    if( range.hasSelection()) return false;
+    if (range.hasSelection()) return false;
 
     // when the character AFTER the current is a identifier we should NOT open it
     TextDocument* doc = controller()->textDocument();
     QChar nextChar = doc->charAtOrNull(range.caret());
-    if( nextChar.isLetterOrNumber() ) return false;
+    if (nextChar.isLetterOrNumber()) return false;
 
     // expand the given range to word
     TextRange wordRange = range;
-    wordRange.expandToWord(doc, doc->config()->whitespaces(), QStringList() );
+    wordRange.expandToWord(doc, doc->config()->whitespaces(), QStringList());
     wordRange.maxVar() = range.max(); // next go past the right caret!
-    word = doc->textPart(wordRange.min(), wordRange.length()).trimmed();      // workaround for space select bug! #61
+    word = doc->textPart(wordRange.min(), wordRange.length()).trimmed(); // workaround for space select bug! #61
 
-    if(word.isEmpty()) {
+    if (word.isEmpty()) {
         canceled_ = false;
         return false;
     }
 
     // canceled state, hides the autocomplete
-    if( canceled_ ) { return false; }
-
+    if (canceled_) { return false; }
 
     // else we can should
     return true;
 }
 
+
 void TextEditorAutoCompleteComponent::showInfoTip()
 {
-    if( !listWidgetRef_->isVisible() )
+    if (!listWidgetRef_->isVisible()) {
         return;
+    }
 
     const QModelIndex &current = listWidgetRef_->currentIndex();
-    if( !current.isValid() )
+    if (!current.isValid()) {
         return;
+    }
 
     QString infoTip = current.data(Qt::UserRole).toString();
-    if( infoTip.isEmpty() ) {
-//        infoTip = "No tooltip data found!";
+    if (infoTip.isEmpty()) {
+        // infoTip = "No tooltip data found!";
     }
 
     if( infoTipRef_.isNull() ) {
@@ -169,20 +174,20 @@ void TextEditorAutoCompleteComponent::showInfoTip()
     QFontMetrics fm(font);
     int maxWidth = 0;
 
-    //for( QListWidgetItem *item : listWidgetRef_->findItems("*", Qt::MatchWildcard)) {
-    for( int i=0; i<listWidgetRef_->count(); i++ ){
+    // for( QListWidgetItem *item : listWidgetRef_->findItems("*", Qt::MatchWildcard)) {
+    for(int i=0; i < listWidgetRef_->count(); i++){
         QListWidgetItem *item = listWidgetRef_->item(i);
         QString sLabel = item->data(Qt::DisplayRole).toString();
         QString sDetail = item->data(Qt::UserRole).toString();
         QString sType = "";
         int widthMod = 4;
-        if( listWidgetRef_->count() > 10 ){
+        if (listWidgetRef_->count() > 10){
             widthMod = listWidgetRef_->verticalScrollBar()->width();
             sLabel = sLabel + " ";
         }
-        if( sDetail.contains(" = ") ){
+        if (sDetail.contains(" = ")){
             sType = QString("%1").arg(sDetail.split(" = ").value(0));
-            int width = fm.horizontalAdvance(QString("%1   %2").arg(sLabel).arg(sType)) + widthMod;
+            int width = fm.horizontalAdvance(QString("%1   %2").arg(sLabel, sType)) + widthMod;
             maxWidth = qMax(width, maxWidth);
         } else {
             int width = fm.horizontalAdvance(QString("%1").arg(sLabel)) + widthMod;
@@ -191,28 +196,27 @@ void TextEditorAutoCompleteComponent::showInfoTip()
     }
 
     int spacing = 0;
-    menuRef_->resize(QSize(maxWidth + spacing + 2, ( qMin(listWidgetRef_->count(), 10) * fm.height() ) + 6 ));
-    listWidgetRef_->resize(QSize(maxWidth + spacing, ( qMin(listWidgetRef_->count(), 10) * fm.height() + 4 )));
-//    menuRef_->resize(QSize(maxWidth + spacing + 2, ( qMin(listWidgetRef_->count(), 10) * fm.height() ) ));
-//    listWidgetRef_->resize(QSize(maxWidth + spacing, ( qMin(listWidgetRef_->count(), 10) * fm.height() )));
-
+    menuRef_->resize(QSize(maxWidth + spacing + 2, (qMin(listWidgetRef_->count(), 10) * fm.height() ) + 6));
+    listWidgetRef_->resize(QSize(maxWidth + spacing, (qMin(listWidgetRef_->count(), 10) * fm.height() + 4)));
+    // menuRef_->resize(QSize(maxWidth + spacing + 2, ( qMin(listWidgetRef_->count(), 10) * fm.height() ) ));
+    // listWidgetRef_->resize(QSize(maxWidth + spacing, ( qMin(listWidgetRef_->count(), 10) * fm.height() )));
 
     QRect r = listWidgetRef_->visualItemRect(listWidgetRef_->currentItem());
     int xOffset;
-    if( listWidgetRef_->count() > 10 )
+    if (listWidgetRef_->count() > 10) {
         xOffset = 22+1;
-    else
+    } else {
         xOffset = 5+1;
+    }
 
     //fetch the current selection
     TextRange range = controller()->textSelection()->range(0);
 
     QSize tipSize = infoTipRef_->tipText->documentLayout()->documentSize().toSize();
-
     infoTipRef_->resize(tipSize.width(), tipSize.height() - 4);
 
     // position the list
-    positionWidgetForCaretOffset(qMax(0u, range.caret() - currentWord_.length()));
+    positionWidgetForCaretOffset(qMax(0u, range.caret() - static_cast<size_t>(currentWord_.length())));
 
     QPoint newLoc(listWidgetRef_->parentWidget()->mapToGlobal(r.topRight()).x() + xOffset, listWidgetRef_->parentWidget()->mapToGlobal(r.topRight()).y() + 1);
     QRect screen = QApplication::primaryScreen()->availableGeometry();
@@ -231,19 +235,23 @@ void TextEditorAutoCompleteComponent::showInfoTip()
     }
 }
 
+
 void TextEditorAutoCompleteComponent::hideInfoTip()
 {
-    if ( !infoTipRef_.isNull() )
+    if (!infoTipRef_.isNull()) {
         infoTipRef_->hide();
+    }
 }
+
 
 /// Fills the autocomplete list
 bool TextEditorAutoCompleteComponent::fillAutoCompleteList(TextDocument* document, const TextRange& range, const QString& word)
 {
     listWidgetRef_->clear();
-    QList<TextAutoCompleteItem*> items = document->autoCompleteProviderList()->findAutoCompleteItemsForRange(document,range,word);
-    if( items.length() > 0 ) {
-        foreach( TextAutoCompleteItem* item, items ) {
+    QList<TextAutoCompleteItem*> items = document->autoCompleteProviderList()->findAutoCompleteItemsForRange(document, range, word);
+
+    if (items.length() > 0) {
+        foreach (TextAutoCompleteItem* item, items) {
             QListWidgetItem *wItem = new QListWidgetItem();
             wItem->setData(Qt::DisplayRole, item->label());
             wItem->setData(Qt::DecorationRole, item->kind());
@@ -251,19 +259,17 @@ bool TextEditorAutoCompleteComponent::fillAutoCompleteList(TextDocument* documen
             wItem->setData(Qt::WhatsThisRole, item->documentation());
             listWidgetRef_->addItem(wItem);
         }
-        listWidgetRef_->setCurrentIndex(listWidgetRef_->model()->index(0,0) );
-    }
-    else
-    {
+        listWidgetRef_->setCurrentIndex(listWidgetRef_->model()->index(0, 0));
+    } else {
         hide();
     }
 
     QFont font = controller()->textDocument()->config()->font();
     QFontMetrics fm(font);
 
-    setFixedHeight( ( qMin(listWidgetRef_->count(), 10) * fm.height() ) + 4 );
+    setFixedHeight((qMin(listWidgetRef_->count(), 10) * fm.height()) + 4);
 
-    if( items.length() > 10 ) {
+    if (items.length() > 10) {
         listWidgetRef_->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
     } else {
         listWidgetRef_->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -274,7 +280,7 @@ bool TextEditorAutoCompleteComponent::fillAutoCompleteList(TextDocument* documen
 
 
 /// positions the widget so it's visible.
-void TextEditorAutoCompleteComponent::positionWidgetForCaretOffset(int offset)
+void TextEditorAutoCompleteComponent::positionWidgetForCaretOffset(size_t offset)
 {
     // find the caret position
     TextRenderer* renderer = controller()->textRenderer();
@@ -306,7 +312,7 @@ void TextEditorAutoCompleteComponent::positionWidgetForCaretOffset(int offset)
     newLoc.setX(qMax(screen.left(), newLoc.x()));                                   //constrain the origin of the list to the leftmost pixel
     newLoc.setY(qMax(screen.top(), newLoc.y()));                                    //constrain the origin of the list to the topmost pixel
     newLoc.setX(qMin(screen.x() + screen.width() - menuRef_->width(), newLoc.x())); //ensure that the entire width of the list can be shown to the right
-    if( newLoc.y() + menuRef_->height() > screen.bottom() ){                        //if the list could go below the bottom, draw above
+    if (newLoc.y() + menuRef_->height() > screen.bottom()){                        //if the list could go below the bottom, draw above
         newLoc.setY(qMin(newLoc.y(), screen.bottom()) - menuRef_->height());        //positions the list above the word
     } else {
         newLoc.setY(newLoc.y() + renderer->lineHeight()); //places it below the line, as normal
@@ -314,35 +320,38 @@ void TextEditorAutoCompleteComponent::positionWidgetForCaretOffset(int offset)
     menuRef_->move(newLoc.x(), newLoc.y());
 }
 
+
 /// intercepts hide() calls to inform the tooltip to hide as well
-void TextEditorAutoCompleteComponent::hideEvent(QHideEvent *event)
+void TextEditorAutoCompleteComponent::hideEvent(QHideEvent* event)
 {
     infoTipRef_->hide();
     event->isAccepted();
 }
 
+
 /// we need to intercept keypresses if the widget is visible
 bool TextEditorAutoCompleteComponent::eventFilter(QObject *obj, QEvent *event)
 {
-    if( event->type() == QEvent::Close && obj == menuRef_) {
+    if (event->type() == QEvent::Close && obj == menuRef_) {
         hide();
         hideInfoTip();
         return QObject::eventFilter(obj, event);
     }
-    if( obj == listWidgetRef_ && event->type()==QEvent::KeyPress ) {
+
+    if(obj == listWidgetRef_ && event->type() == QEvent::KeyPress) {
         QKeyEvent* key = static_cast<QKeyEvent*>(event);
 
         // text keys are allowed
-        if( !key->text().isEmpty() ) {
+        if (!key->text().isEmpty()) {
             QChar nextChar = key->text().at(0);
-            if( nextChar.isLetterOrNumber() ) {
+            if (nextChar.isLetterOrNumber()) {
               QApplication::sendEvent(editorComponentRef_, event);
               return true;
             }
         }
 
         // escape key
-        switch( key->key() ) {
+        switch (key->key()) {
             case Qt::Key_Escape:
                 menuRef_->close();
                 canceled_ = true;
@@ -351,11 +360,11 @@ bool TextEditorAutoCompleteComponent::eventFilter(QObject *obj, QEvent *event)
             case Qt::Key_Enter:
             case Qt::Key_Return:
             case Qt::Key_Tab:
-                if( listWidgetRef_->currentItem() && currentWord_ == listWidgetRef_->currentItem()->text() ) { // sends normal enter/return/tab if you've typed a full word
+                if (listWidgetRef_->currentItem() && currentWord_ == listWidgetRef_->currentItem()->text()) { // sends normal enter/return/tab if you've typed a full word
                     menuRef_->close();
                     QApplication::sendEvent(editorComponentRef_, event);
                     return true;
-                } else if ( listWidgetRef_->currentItem() ) {
+                } else if (listWidgetRef_->currentItem()) {
                     insertCurrentSelectedListItem();
                     menuRef_->close();
                     return true;
@@ -392,11 +401,12 @@ bool TextEditorAutoCompleteComponent::eventFilter(QObject *obj, QEvent *event)
 void TextEditorAutoCompleteComponent::insertCurrentSelectedListItem()
 {
     TextSelection* sel = controller()->textSelection();
-    sel->moveCarets(- currentWord_.length());
-    if( listWidgetRef_->currentItem() ) {
+    sel->moveCarets(-currentWord_.length());
+    if (listWidgetRef_->currentItem()) {
         controller()->replaceSelection(listWidgetRef_->currentItem()->text());
     }
 }
+
 
 void TextEditorAutoCompleteComponent::updateList()
 {
@@ -409,17 +419,16 @@ void TextEditorAutoCompleteComponent::updateList()
     }
 
     // when the character after
-    if(!shouldDisplayAutoComplete(range, currentWord_)) {
-        if(isVisible()) {
+    if (!shouldDisplayAutoComplete(range, currentWord_)) {
+        if (isVisible()) {
             menuRef_->close();
         }
         return;
     }
 
     // fills the autocomplete list with the curent word
-    if( fillAutoCompleteList(doc, range, currentWord_)) {
+    if (fillAutoCompleteList(doc, range, currentWord_)) {
         menuRef_->popup(menuRef_->pos());
-
         editorComponentRef_->setFocus();
 
         // position the widget
@@ -429,11 +438,13 @@ void TextEditorAutoCompleteComponent::updateList()
     }
 }
 
+
 /// this event is called when a key pressed
 void TextEditorAutoCompleteComponent::textKeyPressed()
 {
     updateList();
 }
+
 
 /// processes backspaces
 void TextEditorAutoCompleteComponent::backspacePressed()
@@ -441,36 +452,44 @@ void TextEditorAutoCompleteComponent::backspacePressed()
     updateList();
 }
 
+
 void TextEditorAutoCompleteComponent::listItemClicked(QListWidgetItem* item)
 {
     item->setSelected(true);
     showInfoTip();
 }
 
-void TextEditorAutoCompleteComponent::listItemDoubleClicked(QListWidgetItem*)
+
+void TextEditorAutoCompleteComponent::listItemDoubleClicked(QListWidgetItem* item)
 {
+    Q_UNUSED(item);
     insertCurrentSelectedListItem();
     menuRef_->close();
 }
 
+
 void TextEditorAutoCompleteComponent::selectItemOnHover(QModelIndex modelIndex)
 {
-    listWidgetRef_->selectionModel()->select(modelIndex,QItemSelectionModel::SelectCurrent);
+    listWidgetRef_->selectionModel()->select(modelIndex, QItemSelectionModel::SelectCurrent);
 }
 
-AutoCompleteDelegate::AutoCompleteDelegate(TextEditorController *controller, QObject *parent) : QAbstractItemDelegate(parent)
+
+
+AutoCompleteDelegate::AutoCompleteDelegate(TextEditorController* controller, QObject* parent)
+    : QAbstractItemDelegate(parent)
 {
     pixelSize = 12;
     controllerRef_ = controller;
 }
+
 
 TextEditorController *AutoCompleteDelegate::controller() const
 {
     return controllerRef_;
 }
 
-void AutoCompleteDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
-                          const QModelIndex &index) const
+
+void AutoCompleteDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     TextRenderer* renderer = controller()->textRenderer();
     TextTheme* themeRef_ = renderer->theme();
@@ -480,10 +499,11 @@ void AutoCompleteDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     QFont font = controller()->textDocument()->config()->font();
     QFontMetrics fm(font);
 
-    if (option.state & QStyle::State_Selected)
+    if (option.state & QStyle::State_Selected) {
         painter->fillRect(option.rect, renderer->theme()->selectionColor());
-    else
+    } else {
         painter->fillRect(option.rect, renderer->theme()->backgroundColor());
+    }
     painter->save();
 
     painter->setRenderHint(QPainter::Antialiasing, true);
@@ -491,7 +511,7 @@ void AutoCompleteDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 
     QString sLabel = index.data(Qt::DisplayRole).toString();
     QString sDetail = index.data(Qt::UserRole).toString();
-    QString sDocumentation = index.data(Qt::WhatsThisRole).toString();
+    // QString sDocumentation = index.data(Qt::WhatsThisRole).toString();
     QString sType = "void";
 
     if (sDetail.contains(" = ")) {
@@ -501,30 +521,31 @@ void AutoCompleteDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     QRect typeRect = option.rect;
     QRect hyphenRect = option.rect;
     QRect nameRect = option.rect;
-    QPen typePen = QPen(themeRef_->findHighlightForegroundColor());
-    QPen namePen = QPen(themeRef_->foregroundColor());
+    // QPen typePen = QPen(themeRef_->findHighlightForegroundColor());
+    // QPen namePen = QPen(themeRef_->foregroundColor());
 
     hyphenRect.setX(hyphenRect.x() + fm.horizontalAdvance(sLabel));
     typeRect.setX(nameRect.x() + nameRect.width() - fm.horizontalAdvance(sType) - 1);
     painter->setFont(font);
     painter->drawText(nameRect, sLabel);
 
-    if (sType != "void")
-    {
+    if (sType != "void") {
         painter->drawText(typeRect, sType);
     }
     painter->restore();
 }
 
+
 QSize AutoCompleteDelegate::sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const
 {
     const QFont font = controller()->textDocument()->config()->font();
     QFontMetrics fm(font);
-    return QSize(100, ( fm.height() ) );
+    return QSize(100, (fm.height()));
 }
 
-FakeToolTip::FakeToolTip(TextEditorController *controller, QWidget *parent) :
-    QWidget(parent, Qt::ToolTip | Qt::WindowStaysOnTopHint )
+
+FakeToolTip::FakeToolTip(TextEditorController* controller, QWidget* parent)
+    : QWidget(parent, Qt::ToolTip | Qt::WindowStaysOnTopHint )
 {
     setFocusPolicy(Qt::NoFocus);
     setAttribute(Qt::WA_ShowWithoutActivating);
@@ -532,7 +553,6 @@ FakeToolTip::FakeToolTip(TextEditorController *controller, QWidget *parent) :
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     tipText = new QTextDocument(this);
-
     tipText->setHtml("");
 
     controllerRef_ = controller;
@@ -556,13 +576,17 @@ void FakeToolTip::setText(const QString text)
     tipText->setHtml(QString("<p>%1</p>").arg(text));
 }
 
+
 TextEditorController *FakeToolTip::controller()
 {
     return controllerRef_;
 }
 
-void FakeToolTip::paintEvent(QPaintEvent*)
+
+void FakeToolTip::paintEvent(QPaintEvent* event)
 {
+    Q_UNUSED(event);
+
     QStyle *style = this->style();
     QPainter *p = new QPainter(this);
     QStyleOptionFrame *opt = new QStyleOptionFrame();
@@ -597,8 +621,10 @@ void FakeToolTip::paintEvent(QPaintEvent*)
     delete opt;
 }
 
-void FakeToolTip::resizeEvent(QResizeEvent *)
+void FakeToolTip::resizeEvent(QResizeEvent* event)
 {
+    Q_UNUSED(event);
+
     QStyleHintReturnMask frameMask;
     QStyleOption option;
     option.initFrom(this);

--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.h
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.h
@@ -33,7 +33,7 @@ class FakeToolTip : public QWidget
     Q_OBJECT
 
 public:
-    explicit FakeToolTip(TextEditorController *controller, QWidget *parent = 0);
+    explicit FakeToolTip(TextEditorController *controller, QWidget *parent = nullptr);
     void setText(const QString text);
     QTextDocument* tipText;
     TextEditorController* controller();
@@ -42,9 +42,10 @@ private:
     TextEditorController* controllerRef_;       ///< A reference to the controller
 
 protected:
-    void paintEvent(QPaintEvent *e);
-    void resizeEvent(QResizeEvent *e);
+    void paintEvent(QPaintEvent* e);
+    void resizeEvent(QResizeEvent* e);
 };
+
 
 // inspiration:
 // http://doc.qt.io/qt-5/qtwidgets-tools-customcompleter-example.html
@@ -55,7 +56,7 @@ class EDBEE_EXPORT TextEditorAutoCompleteComponent : public QWidget
 {
     Q_OBJECT
 public:
-    explicit TextEditorAutoCompleteComponent(TextEditorController* controller, TextEditorComponent *parent, TextMarginComponent *margin);
+    explicit TextEditorAutoCompleteComponent(TextEditorController* controller, TextEditorComponent* parent, TextMarginComponent* margin);
 
     TextEditorController* controller() const;
     QListWidget* listWidget() const;
@@ -66,11 +67,11 @@ protected:
     bool shouldDisplayAutoComplete(TextRange& range, QString& word);
     void hideInfoTip();
     bool fillAutoCompleteList(TextDocument *document, const TextRange &range, const QString& word );
-
-    void positionWidgetForCaretOffset(int offset);
+    
+    void positionWidgetForCaretOffset(size_t offset);
     bool eventFilter(QObject* obj, QEvent* event);
 
-    void hideEvent(QHideEvent *event);
+    void hideEvent(QHideEvent* event);
     //void focusOutEvent(QFocusEvent *event);
     //void moveEvent(QMoveEvent *event);
 
@@ -81,8 +82,8 @@ public slots:
     void updateList();
     void backspacePressed();
     void textKeyPressed();
-    void listItemClicked(QListWidgetItem*item);
-    void listItemDoubleClicked(QListWidgetItem*item);
+    void listItemClicked(QListWidgetItem* item);
+    void listItemDoubleClicked(QListWidgetItem* item);
     void selectItemOnHover(QModelIndex modelIndex);
     void showInfoTip();
 
@@ -98,20 +99,18 @@ private:
     QPointer<FakeToolTip> infoTipRef_;
 };
 
+
 class AutoCompleteDelegate : public QAbstractItemDelegate
 {
     Q_OBJECT
 
 public:
-    AutoCompleteDelegate(TextEditorController *controller, QObject *parent = 0);
+    AutoCompleteDelegate(TextEditorController* controller, QObject* parent = nullptr);
 
     TextEditorController* controller() const;
 
-    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
-
-public slots:
 
 private:
     TextEditorController* controllerRef_;       ///< A reference to the controller

--- a/edbee-lib/edbee/views/components/texteditorcomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorcomponent.cpp
@@ -418,8 +418,8 @@ void TextEditorComponent::mousePressEvent(QMouseEvent* event)
         int y = event->pos().y();
 
 
-        int line = renderer->rawLineIndexForYpos( y );
-        int col = renderer->columnIndexForXpos( line, x );
+        size_t line = renderer->rawLineIndexForYpos(y);
+        int col = renderer->columnIndexForXpos(line, x);
 
         if( event->button() == Qt::LeftButton ) {
             registerClickEvent();
@@ -432,14 +432,14 @@ void TextEditorComponent::mousePressEvent(QMouseEvent* event)
                 return;
             }
 
-            if( event->modifiers()&Qt::ControlModifier ) {
+            if (event->modifiers()&Qt::ControlModifier) {
                 controller()->addCaretAt( line, col );
             } else {
                 controller()->moveCaretTo( line, col, event->modifiers()&Qt::ShiftModifier );
             }
         }
         if( QApplication::clipboard()->supportsSelection() && event->button() == Qt::MiddleButton ) { // X11 / linux support middle button paste
-            controller()->moveCaretTo( line, col, false ); // clear actual selection and put cursor under mouse
+            controller()->moveCaretTo(line, col, false); // clear actual selection and put cursor under mouse
             controller()->replaceSelection( QApplication::clipboard()->text(QClipboard::Selection), CoalesceId_Paste );
             controller()->updateStatusText();
         }
@@ -516,7 +516,7 @@ void TextEditorComponent::mouseMoveEvent(QMouseEvent* event )
 #else
         auto eventPos = event->position().toPoint();
 #endif
-        int line = renderer->rawLineIndexForYpos( eventPos.y() );
+        size_t line = renderer->rawLineIndexForYpos(eventPos.y());
         int col = 0;
         if( line >= 0 ) { col = renderer->columnIndexForXpos( line, eventPos.x() ); }
         if( line < 0 ) { line = 0; }
@@ -622,12 +622,11 @@ void TextEditorComponent::repaintCarets()
 }
 
 
-
 /// updates the given line so it will be repainted
-void TextEditorComponent::updateLineAtOffset(int offset)
+void TextEditorComponent::updateLineAtOffset(size_t offset)
 {
     TextRenderer* renderer = textRenderer();
-    int yPos = renderer->yPosForOffset( offset ) - textEditorRenderer_->extraPixelsToUpdateAroundLines();
+    size_t yPos = renderer->yPosForOffset(offset) - textEditorRenderer_->extraPixelsToUpdateAroundLines();
 
 // the text-only line:
 //    viewport()->update( renderer->viewportX(), yPos - renderer->viewportY(), renderer->viewportWidth(), renderer->lineHeight()  );

--- a/edbee-lib/edbee/views/components/texteditorcomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorcomponent.cpp
@@ -46,9 +46,9 @@ TextEditorComponent::TextEditorComponent(TextEditorController* controller, QWidg
     , clickRange_()
     , lastClickEvent_(0)
 {
-    textEditorRenderer_ = new TextEditorRenderer( controller->textRenderer());
+    textEditorRenderer_ = new TextEditorRenderer(controller->textRenderer());
 
-//    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    // setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding );
 
     // disabled autofilling of backgrounds
@@ -60,10 +60,8 @@ TextEditorComponent::TextEditorComponent(TextEditorController* controller, QWidg
     setAttribute(Qt::WA_OpaquePaintEvent);          // make sure not everything is redrawn
     setAttribute(Qt::WA_NoSystemBackground);
 
-//    setAttribute( Qt::WA_MacShowFocusRect); // show a mac focus rect
-
+    // setAttribute( Qt::WA_MacShowFocusRect); // show a mac focus rect
     setFocusPolicy(Qt::WheelFocus);
-
 
     //  setFocusPolicy(Qt::ClickFocus);       (since 2013-02-16, can be removed tab still works :) )
     setAttribute(Qt::WA_KeyCompression);
@@ -74,9 +72,9 @@ TextEditorComponent::TextEditorComponent(TextEditorController* controller, QWidg
 
     // set the timer for the carets
     caretTimer_ = new QTimer();
-    connect( caretTimer_, SIGNAL(timeout()), SLOT(repaintCarets()) );
-    if( config()->caretBlinkingRate() > 0 ) {
-        caretTimer_->start( config()->caretBlinkingRate() >> 1 );
+    connect(caretTimer_, SIGNAL(timeout()), SLOT(repaintCarets()));
+    if (config()->caretBlinkingRate() > 0) {
+        caretTimer_->start(config()->caretBlinkingRate() >> 1);
     }
 }
 
@@ -130,6 +128,7 @@ TextSelection *TextEditorComponent::textSelection()
     return controllerRef_->textSelection();
 }
 
+
 void TextEditorComponent::giveTextEditorRenderer(TextEditorRenderer *renderer)
 {
     delete textEditorRenderer_;
@@ -144,14 +143,14 @@ QSize TextEditorComponent::sizeHint() const
     int height = ren->totalHeight();
 
     // when scroll past end is enabled we need to be able to scroll past the last line
-    if( config()->scrollPastEnd() ) {
+    if (config()->scrollPastEnd()) {
         int viewPortHeight = controllerRef_->widget()->textScrollArea()->size().height();
         height += viewPortHeight;
-        height -= textRenderer()->lineHeight()*2;   // *2 because we have an extra blank line at the end
+        height -= textRenderer()->lineHeight() * 2;   // *2 because we have an extra blank line at the end
     }
 
     // added 1 extra emWidth so there's at least 1 character spacing at the end
-    return QSize( ren->totalWidth() + ren->emWidth() , height );
+    return QSize(ren->totalWidth() + ren->emWidth() , height);
 }
 
 
@@ -160,19 +159,16 @@ QSize TextEditorComponent::sizeHint() const
 /// When resetting the timer the caret is displayed directly
 void TextEditorComponent::resetCaretTime()
 {
-    // restart the timer
-    if( caretTimer_->isActive() ) {
+    if (caretTimer_->isActive()) {
         caretTimer_->start();
         textRenderer()->resetCaretTime();
     }
-
 }
 
 
 /// A slow and full update of the control
 void TextEditorComponent::fullUpdate()
 {
-//    qlog_info() << "**** fullUpdate!!! **** ";
     controller()->textRenderer()->invalidateCaches();
     updateGeometry();
     update();
@@ -189,14 +185,11 @@ void TextEditorComponent::paintEvent(QPaintEvent* paintEvent)
     // retrieve the scrollbar-offsets
     const QRect& clipRect = paintEvent->rect();
 
-    int offsetX = 0; //horizontalScrollBar()->value();
-    int offsetY = 0; //verticalScrollBar()->value();
-    QRect translatedRect( clipRect.x()+offsetX, clipRect.y()+offsetY, clipRect.width(), clipRect.height() );
-
-//qlog_info() << "CLIPRECT..... " << translatedRect;
+    int offsetX = 0; // horizontalScrollBar()->value();
+    int offsetY = 0; // verticalScrollBar()->value();
+    QRect translatedRect(clipRect.x() + offsetX, clipRect.y() + offsetY, clipRect.width(), clipRect.height());
 
     // render the editor
-//    textRenderer()->render( p, translatedRect );
     textRenderer()->renderBegin(translatedRect);
     textEditorRenderer_->render(&p);
     textRenderer()->renderEnd(translatedRect);
@@ -207,24 +200,26 @@ void TextEditorComponent::paintEvent(QPaintEvent* paintEvent)
     // draw a clipping rectangle
     p.setClipping(false);
     p.setPen( QColor( 0,200,0 ));
-  QRect clipDrawRect( clipRect );
+    QRect clipDrawRect( clipRect );
     clipDrawRect.adjust(0,0,-1,-1);
     p.drawRect( clipDrawRect );
     p.setClipping(true);
 #endif
 
-//    QStyleOptionFocusRect option;
-//    option.init(this);
-//    option.backgroundColor = palette().color(QPalette::Window);
-    //    style()->drawPrimitive(QStyle::PE_FrameFocusRect, &option, &p,this);
+    // QStyleOptionFocusRect option;
+    // option.init(this);
+    // option.backgroundColor = palette().color(QPalette::Window);
+    // style()->drawPrimitive(QStyle::PE_FrameFocusRect, &option, &p,this);
 }
 
-void TextEditorComponent::moveEvent(QMoveEvent *moveEvent)
+
+void TextEditorComponent::moveEvent(QMoveEvent* moveEvent)
 {
     Q_UNUSED(moveEvent)
 }
 
-void TextEditorComponent::hideEvent(QHideEvent *hideEvent)
+
+void TextEditorComponent::hideEvent(QHideEvent* hideEvent)
 {
     Q_UNUSED(hideEvent)
 }
@@ -235,12 +230,12 @@ void TextEditorComponent::hideEvent(QHideEvent *hideEvent)
 bool TextEditorComponent::event(QEvent* event)
 {
     // keypress event
-    if( event->type() == QEvent::KeyPress ) {
+    if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-        if( keyEvent ) {
+        if (keyEvent) {
             int key = keyEvent->key();
-            if( key == Qt::Key_Tab || key == Qt::Key_Backtab ) {
-                keyPressEvent( keyEvent );
+            if (key == Qt::Key_Tab || key == Qt::Key_Backtab) {
+                keyPressEvent(keyEvent);
                 keyEvent->accept();
                 return true;
             }
@@ -250,48 +245,47 @@ bool TextEditorComponent::event(QEvent* event)
 }
 
 
-
 /// handle keypresses
 void TextEditorComponent::keyPressEvent(QKeyEvent* event)
 {
     int key = event->key();
 
     // unkown key return or control key
-    if( key == Qt::Key_unknown ) { return; }
-    if(key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt || key == Qt::Key_Meta) { return; }
+    if (key == Qt::Key_unknown) { return; }
+    if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt || key == Qt::Key_Meta) { return; }
     // convert the key to a string
     Qt::KeyboardModifiers modifiers = event->modifiers();
-    if(modifiers & Qt::ShiftModifier)    key += Qt::SHIFT;
-    if(modifiers & Qt::ControlModifier)  key += Qt::CTRL;
-    if(modifiers & Qt::AltModifier)      key += Qt::ALT;
-    if(modifiers & Qt::MetaModifier)     key += Qt::META;
-//    if(modifiers & Qt::KeypadModifier)   key += Qt::KeypadModifier;
+    if (modifiers & Qt::ShiftModifier)    key += Qt::SHIFT;
+    if (modifiers & Qt::ControlModifier)  key += Qt::CTRL;
+    if (modifiers & Qt::AltModifier)      key += Qt::ALT;
+    if (modifiers & Qt::MetaModifier)     key += Qt::META;
+    // if(modifiers & Qt::KeypadModifier)   key += Qt::KeypadModifier;
 
     // grow the current sequence
     QKeySequence::SequenceMatch match;
-    QKeySequence keySequence = TextEditorKeyMap::joinKeySequences( lastKeySequence_, QKeySequence( key ) );
-    QString command = keyMap()->findBySequence( keySequence, match );
+    QKeySequence keySequence = TextEditorKeyMap::joinKeySequences(lastKeySequence_, QKeySequence(key));
+    QString command = keyMap()->findBySequence(keySequence, match);
 
     // when a sequence was busy and we didn't find a match, eat the key :P
     // this is different from other editors like sublime, but I think it's more natural to
     // ignore the key if a sequence of keys is detected
-    if( match == QKeySequence::NoMatch && !lastKeySequence_.isEmpty() ) {
+    if (match == QKeySequence::NoMatch && !lastKeySequence_.isEmpty()) {
         lastKeySequence_ = QKeySequence();
-//        qlog_info() << "[[[ eat the last key ]]";
+        // qlog_info() << "[[[ eat the last key ]]";
         return;
     }
 
     // a partial match
-    if( match == QKeySequence::PartialMatch ) {
+    if (match == QKeySequence::PartialMatch) {
         lastKeySequence_ = keySequence;
-//        qlog_info() << "[[[ match in progress for " << command << "]]";
+        // qlog_info() << "[[[ match in progress for " << command << "]]";
         return;
     }
 
-    // we've found the command
-    if( match == QKeySequence::ExactMatch ) {
-//        qlog_info() << "[[[ found command:" << command << "]]";
-        controller()->executeCommand( command );
+    // A command is found
+    if (match == QKeySequence::ExactMatch) {
+        // qlog_info() << "[[[ found command:" << command << "]]";
+        controller()->executeCommand(command);
 
         lastKeySequence_ = QKeySequence();
         return;
@@ -300,77 +294,66 @@ void TextEditorComponent::keyPressEvent(QKeyEvent* event)
     // not partial, not found, clear the mark
     lastKeySequence_ = QKeySequence();
 
-
     // else replace the selection if there's a text
     QString text = event->text();
     bool specialKey = (modifiers&(Qt::MetaModifier|Qt::ControlModifier))
                   && ((modifiers!=(Qt::AltModifier|Qt::ControlModifier)) || (!text.isEmpty() && text.at(0).isUpper()));
-    if( !text.isEmpty() && !specialKey ) {
+
+    if (!text.isEmpty() && !specialKey) {
         // last character is used for "undo-group after" space support
-        if( this->config()->undoGroupPerSpace() ) {
-            if( text.compare(" ") == 0 && lastCharacter_.compare(" ") != 0  ) {
+        if (config()->undoGroupPerSpace()) {
+            if (text.compare(" ") == 0 && lastCharacter_.compare(" ") != 0 ) {
                 textDocument()->textUndoStack()->resetAllLastCoalesceIds();
             }
         }
 
         lastCharacter_ = text;
-        controller()->replaceSelection( text, CoalesceId_AppendChar );
+        controller()->replaceSelection(text, CoalesceId_AppendChar);
         controller()->updateStatusText();
         emit textKeyPressed();
 
     } else {
         QWidget::keyPressEvent(event);
     }
-
 }
 
 
 /// the key release event
-void TextEditorComponent::keyReleaseEvent(QKeyEvent *event)
+void TextEditorComponent::keyReleaseEvent(QKeyEvent* event)
 {
     QWidget::keyReleaseEvent(event);
 }
 
 
 /// input method event
-// When receiving an input method event, the text widget has to performs the following steps:
-// 1. If the widget has selected text, the selected text should get removed.
+/// When receiving an input method event, the text widget has to performs the following steps:
+/// 1. If the widget has selected text, the selected text should get removed.
 ///
-// 2. Remove the text starting at replacementStart() with length replacementLength() and replace it by the commitString().
-//     If replacementLength() is 0, replacementStart() gives the insertion position for the commitString().
-//  .  When doing replacement the area of the preedit string is ignored, thus a replacement starting at -1 with a length of 2 will remove the
-//     last character before the preedit string and the first character afterwards, and insert the commit string directly before the preedit string.
-// .   If the widget implements undo/redo, this operation gets added to the undo stack.
-//
-// 3 If there is no current preedit string, insert the preeditString() at the current cursor position; otherwise
-//     replace the previous preeditString with the one received from this event.
-//     If the widget implements undo/redo, the preeditString() should not influence the undo/redo stack in any way.
-//     The widget should examine the list of attributes to apply to the preedit string. It has to understand at least the
-//     TextFormat and Cursor attributes and render them as specified.
-
-void TextEditorComponent::inputMethodEvent( QInputMethodEvent* m )
+/// 2. Remove the text starting at replacementStart() with length replacementLength() and replace it by the commitString().
+///     If replacementLength() is 0, replacementStart() gives the insertion position for the commitString().
+///  .  When doing replacement the area of the preedit string is ignored, thus a replacement starting at -1 with a length of 2 will remove the
+///     last character before the preedit string and the first character afterwards, and insert the commit string directly before the preedit string.
+/// .   If the widget implements undo/redo, this operation gets added to the undo stack.
+///
+/// 3 If there is no current preedit string, insert the preeditString() at the current cursor position; otherwise
+///     replace the previous preeditString with the one received from this event.
+///     If the widget implements undo/redo, the preeditString() should not influence the undo/redo stack in any way.
+///     The widget should examine the list of attributes to apply to the preedit string. It has to understand at least the
+///     TextFormat and Cursor attributes and render them as specified.
+void TextEditorComponent::inputMethodEvent(QInputMethodEvent* m)
 {
-/// TODO: https://doc.qt.io/qt-5/qinputmethodevent.html
-/// Analyize how to implement this. The preeditString should NOT alter the undo-buffer
+    /// TODO: https://doc.qt.io/qt-5/qinputmethodevent.html
+    /// Analyize how to implement this. The preeditString should NOT alter the undo-buffer
 
     // replace the selection with an empty text (only if there's content to replace)
-    if( textSelection()->hasSelection() && (!m->preeditString().isEmpty() || !m->commitString().isEmpty())) {
-        controller()->replaceSelection("",false);
+    if (textSelection()->hasSelection() && (!m->preeditString().isEmpty() || !m->commitString().isEmpty())) {
+        controller()->replaceSelection("", false);
     }
 
-/*
-    /// TODO: Honer the arguments
-    QString str;
-    foreach( QInputMethodEvent::Attribute attr, m->attributes() ) {
-        str.append( QStringLiteral("[%1,%2-%3,%4]").arg(attr.type).arg(attr.start).arg(attr.length).arg(attr.value.toString()) );
-    }
-//    qlog_info() << "inputMethodEvent: commitStr=" << m->commitString() << ", preEditStr=" << m->preeditString() << ", start=" << m->replacementStart() << ", length" << m->replacementStart()  << " | " << str;
-*/
-
-    if( !m->preeditString().isEmpty() ) {
-        controller()->replaceSelection(m->preeditString(),false, true);
+    if (!m->preeditString().isEmpty()) {
+        controller()->replaceSelection(m->preeditString(), false, true);
     } else {
-        controller()->replaceSelection(m->commitString(),false);
+        controller()->replaceSelection(m->commitString(), false);
     }
 
     m->accept();
@@ -378,7 +361,7 @@ void TextEditorComponent::inputMethodEvent( QInputMethodEvent* m )
 
 
 /// currently unused ?!
-QVariant TextEditorComponent::inputMethodQuery( Qt::InputMethodQuery p ) const
+QVariant TextEditorComponent::inputMethodQuery(Qt::InputMethodQuery p) const
 {
     Q_UNUSED(p);
     return QVariant();
@@ -388,7 +371,7 @@ QVariant TextEditorComponent::inputMethodQuery( Qt::InputMethodQuery p ) const
 void TextEditorComponent::registerClickEvent()
 {
     qint64 currentClickEvent = QDateTime::currentMSecsSinceEpoch();
-    if( currentClickEvent - lastClickEvent_ <=TRIPLE_CLICK_DELAY_IN_MS ) {
+    if (currentClickEvent - lastClickEvent_ <=TRIPLE_CLICK_DELAY_IN_MS) {
         clickCount_ += 1;
     } else {
         clickCount_ = 1;
@@ -409,38 +392,35 @@ void TextEditorComponent::registerClickEvent()
 /// @param event the mouse event
 void TextEditorComponent::mousePressEvent(QMouseEvent* event)
 {
-    if( event->button() == Qt::LeftButton || event->button() == Qt::MiddleButton ) {
+    if (event->button() == Qt::LeftButton || event->button() == Qt::MiddleButton) {
         TextRenderer* renderer = textRenderer();
 
-//        int x = renderer->widgetXToXpos( event->x() + horizontalScrollBar()->value() );
-//        int y = renderer->widgetYToYpos( event->y() + verticalScrollBar()->value() );
         int x = event->pos().x();
         int y = event->pos().y();
 
-
         size_t line = renderer->rawLineIndexForYpos(y);
-        int col = renderer->columnIndexForXpos(line, x);
+        size_t col = renderer->columnIndexForXpos(line, x);
 
-        if( event->button() == Qt::LeftButton ) {
+        if (event->button() == Qt::LeftButton) {
             registerClickEvent();
-            if( clickCount_ > 1 ) {
-                if( clickCount_ == 3) {
-                    SelectionCommand toggleWordSelectionAtCommand( SelectionCommand::SelectFullLine, 0);
-                    controller()->executeCommand( &toggleWordSelectionAtCommand );
+            if (clickCount_ > 1) {
+                if (clickCount_ == 3) {
+                    SelectionCommand toggleWordSelectionAtCommand(SelectionCommand::SelectFullLine, 0);
+                    controller()->executeCommand(&toggleWordSelectionAtCommand);
                     clickRange_ = textSelection()->range(0);
                 }
                 return;
             }
 
             if (event->modifiers()&Qt::ControlModifier) {
-                controller()->addCaretAt( line, col );
+                controller()->addCaretAt(line, col );
             } else {
-                controller()->moveCaretTo( line, col, event->modifiers()&Qt::ShiftModifier );
+                controller()->moveCaretTo(line, col, event->modifiers()&Qt::ShiftModifier);
             }
         }
-        if( QApplication::clipboard()->supportsSelection() && event->button() == Qt::MiddleButton ) { // X11 / linux support middle button paste
+        if (QApplication::clipboard()->supportsSelection() && event->button() == Qt::MiddleButton) { // X11 / linux support middle button paste
             controller()->moveCaretTo(line, col, false); // clear actual selection and put cursor under mouse
-            controller()->replaceSelection( QApplication::clipboard()->text(QClipboard::Selection), CoalesceId_Paste );
+            controller()->replaceSelection(QApplication::clipboard()->text(QClipboard::Selection), CoalesceId_Paste);
             controller()->updateStatusText();
         }
     }
@@ -453,13 +433,13 @@ void TextEditorComponent::mousePressEvent(QMouseEvent* event)
 /// Only used to copy selection to selection clipboard for X11 / linux systems
 ///
 /// @param event the mouse event
-void TextEditorComponent::mouseReleaseEvent(QMouseEvent *event)
+void TextEditorComponent::mouseReleaseEvent(QMouseEvent* event)
 {
-    if( QApplication::clipboard()->supportsSelection() && event->button() == Qt::LeftButton ) {
-        if( controller()->textSelection()->rangeCount() == 1 ) {
+    if (QApplication::clipboard()->supportsSelection() && event->button() == Qt::LeftButton) {
+        if (controller()->textSelection()->rangeCount() == 1) {
             QString selection;
             selection = controller()->textSelection()->getSelectedText();
-            if( !selection.isEmpty() ) {
+            if (!selection.isEmpty()) {
                 QApplication::clipboard()->setText(selection, QClipboard::Selection);
             }
         }
@@ -470,31 +450,31 @@ void TextEditorComponent::mouseReleaseEvent(QMouseEvent *event)
 
 /// A mouse double click happens
 /// @param event the mouse double click that occured
-void TextEditorComponent::mouseDoubleClickEvent( QMouseEvent* event )
+void TextEditorComponent::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    if( event->button() == Qt::LeftButton ) {
+    if (event->button() == Qt::LeftButton) {
         registerClickEvent();
-        if( clickCount_ > 2 ) {
+        if (clickCount_ > 2) {
             return;
         }
 
 
-        if( event->modifiers()&Qt::ControlModifier ) {
+        if (event->modifiers() & Qt::ControlModifier) {
             // get the location of the double
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
             auto eventPos = event->pos();
 #else
             auto eventPos = event->position().toPoint();
 #endif
-            int line = textRenderer()->rawLineIndexForYpos( eventPos.y() );
-            int col = textRenderer()->columnIndexForXpos( line, eventPos.x() );
+            size_t line = textRenderer()->rawLineIndexForYpos(eventPos.y());
+            size_t col = textRenderer()->columnIndexForXpos(line, eventPos.x());
 
             // add the word there
-            SelectionCommand toggleWordSelectionAtCommand( SelectionCommand::ToggleWordSelectionAt, textDocument()->offsetFromLineAndColumn(line,col) );
-            controller()->executeCommand( &toggleWordSelectionAtCommand );
+            SelectionCommand toggleWordSelectionAtCommand(SelectionCommand::ToggleWordSelectionAt, static_cast<ptrdiff_t>(textDocument()->offsetFromLineAndColumn(line, col)));
+            controller()->executeCommand(&toggleWordSelectionAtCommand);
         } else {
-            static SelectionCommand selectWord( SelectionCommand::SelectWord );
-            controller()->executeCommand( &selectWord  );
+            static SelectionCommand selectWord(SelectionCommand::SelectWord);
+            controller()->executeCommand(&selectWord);
             clickRange_ = textSelection()->range(0);
         }
         return;
@@ -506,9 +486,9 @@ void TextEditorComponent::mouseDoubleClickEvent( QMouseEvent* event )
 
 /// A mouse move event
 /// @param event the mouse event
-void TextEditorComponent::mouseMoveEvent(QMouseEvent* event )
+void TextEditorComponent::mouseMoveEvent(QMouseEvent* event)
 {
-    if( event->buttons() & Qt::LeftButton ) {
+    if (event->buttons() & Qt::LeftButton) {
         TextRenderer* renderer = textRenderer();
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -517,14 +497,14 @@ void TextEditorComponent::mouseMoveEvent(QMouseEvent* event )
         auto eventPos = event->position().toPoint();
 #endif
         size_t line = renderer->rawLineIndexForYpos(eventPos.y());
-        int col = 0;
-        if( line >= 0 ) { col = renderer->columnIndexForXpos( line, eventPos.x() ); }
-        if( line < 0 ) { line = 0; }
+        size_t col = 0;
+        if (line >= 0) { col = renderer->columnIndexForXpos(line, eventPos.x()); }
+        if (line < 0) { line = 0; }
 
-        if( clickCount_ == 2 ) {
+        if (clickCount_ == 2) {
             TextRange range = textSelection()->range(0);
 
-            int newOffset = textDocument()->offsetFromLineAndColumn(line, col);
+            size_t newOffset = textDocument()->offsetFromLineAndColumn(line, col);
             range.moveCaretToWordBoundaryAtOffset(textDocument(), newOffset);
             range.minVar() = qMin(clickRange_.min(), range.min());
             range.maxVar() = qMax(clickRange_.max(), range.max());
@@ -532,14 +512,14 @@ void TextEditorComponent::mouseMoveEvent(QMouseEvent* event )
 
             controller()->moveCaretAndAnchorToOffset(range.caret(), range.anchor());
             return;
-        } else if( clickCount_ == 3 ) {
+        } else if (clickCount_ == 3) {
             TextRange range = textSelection()->range(0);  // copy range
 
-            int clickLine = textDocument()->lineFromOffset(clickRange_.min());
+            size_t clickLine = textDocument()->lineFromOffset(clickRange_.min());
             if(line < clickLine ) {
-                range.set( textDocument()->offsetFromLine(line), clickRange_.max());
+                range.set(textDocument()->offsetFromLine(line), clickRange_.max());
             } else {
-                range.set(clickRange_.min(), textDocument()->offsetFromLine(line+1));
+                range.set(clickRange_.min(), textDocument()->offsetFromLine(line + 1));
             }
 
             controller()->moveCaretAndAnchorToOffset(range.caret(), range.anchor());
@@ -547,10 +527,10 @@ void TextEditorComponent::mouseMoveEvent(QMouseEvent* event )
         }
 
 
-        if( event->modifiers() & Qt::ControlModifier) {
-            controller()->moveCaretTo( line, col, true, controller()->textSelection()->rangeCount() - 1 );
+        if (event->modifiers() & Qt::ControlModifier) {
+            controller()->moveCaretTo(line, col, true, controller()->textSelection()->rangeCount() - 1);
         } else {
-            controller()->moveCaretTo( line, col, true );
+            controller()->moveCaretTo(line, col, true);
         }
     }
     QWidget::mouseMoveEvent(event);
@@ -580,14 +560,14 @@ void TextEditorComponent::contextMenuEvent(QContextMenuEvent* event)
     Q_UNUSED(event)
 
     QMenu* menu = new QMenu();
-    menu->addAction( controller()->createAction("cut", tr("Cut") ) );
-    menu->addAction( controller()->createAction("copy", tr("Copy") ) );
-    menu->addAction( controller()->createAction("paste", tr("Paste") ) );
+    menu->addAction(controller()->createAction("cut", tr("Cut")));
+    menu->addAction(controller()->createAction("copy", tr("Copy")));
+    menu->addAction(controller()->createAction("paste", tr("Paste")));
     menu->addSeparator();
-    menu->addAction( controller()->createAction("sel_all", tr("Select All") ) );
+    menu->addAction(controller()->createAction("sel_all", tr("Select All")));
 
     // contextmenu can always be placed under the current cursosr
-    menu->exec( QCursor::pos() );
+    menu->exec(QCursor::pos());
     qDeleteAll(menu->actions());
     delete menu;
 }
@@ -598,23 +578,25 @@ void TextEditorComponent::repaintCarets()
 {
     bool visible = textRenderer()->isCaretVisible();
     bool focus = hasFocus();
-    if( focus != visible ) {
+
+    if (focus != visible) {
         textRenderer()->setCaretVisible(focus);
     } else {
-        if( !visible ) { return; }
+        if(!visible) { return; }
     }
-//    /// BIG TODO: Optimize so only blinks visible carets
-//        textRenderer()->toggleCaretVisible( );
-//    } else {
-//        textRenderer()->setCaretVisible(false);
-//    }
+
+    // /// BIG TODO: Optimize so only blinks visible carets
+    //     textRenderer()->toggleCaretVisible( );
+    // } else {
+    //     textRenderer()->setCaretVisible(false);
+    // }
 
     // invalidate all 'caret' ranges
     TextSelection* ranges = controllerRef_->textSelection();
-    int rangeCount = ranges->rangeCount();
-    if( rangeCount < 10 ) {  // just a number :P
-        for( int i=0; i<rangeCount; ++i ) {
-            updateAreaAroundOffset( ranges->range(i).caret() );
+    size_t rangeCount = ranges->rangeCount();
+    if (rangeCount < 10) {  // just a number :P
+        for (size_t i = 0; i < rangeCount; ++i) {
+            updateAreaAroundOffset(ranges->range(i).caret());
         }
     } else {
         update();
@@ -626,39 +608,44 @@ void TextEditorComponent::repaintCarets()
 void TextEditorComponent::updateLineAtOffset(size_t offset)
 {
     TextRenderer* renderer = textRenderer();
-    size_t yPos = renderer->yPosForOffset(offset) - textEditorRenderer_->extraPixelsToUpdateAroundLines();
+    int yPos = renderer->yPosForOffset(offset) - textEditorRenderer_->extraPixelsToUpdateAroundLines();
 
-// the text-only line:
-//    viewport()->update( renderer->viewportX(), yPos - renderer->viewportY(), renderer->viewportWidth(), renderer->lineHeight()  );
+    // the text-only line:
+    //viewport()->update( renderer->viewportX(), yPos - renderer->viewportY(), renderer->viewportWidth(), renderer->lineHeight()  );
 
     // the full line inclusive sidebars
-//    viewport()->update( renderer->totalViewportX(), yPos - renderer->totalViewportY(), renderer->totalViewportWidth(), renderer->lineHeight()  );
-    update( 0,  yPos - renderer->viewportY(), renderer->viewportWidth(), renderer->lineHeight() + textEditorRenderer_->extraPixelsToUpdateAroundLines()*2  );
+    // viewport()->update( renderer->totalViewportX(), yPos - renderer->totalViewportY(), renderer->totalViewportWidth(), renderer->lineHeight()  );
+    update(
+        0,
+        yPos - renderer->viewportY(),
+        renderer->viewportWidth(),
+        renderer->lineHeight() + textEditorRenderer_->extraPixelsToUpdateAroundLines() * 2
+    );
 }
 
 
 /// updates the character before and at the given offset
-void TextEditorComponent::updateAreaAroundOffset(int offset, int width )
+void TextEditorComponent::updateAreaAroundOffset(size_t offset, int width )
 {
     TextRenderer* ren = textRenderer();
-    update( ren->xPosForOffset(offset)-width/2, ren->yPosForOffset(offset)-textEditorRenderer_->extraPixelsToUpdateAroundLines(), width, ren->lineHeight()+textEditorRenderer_->extraPixelsToUpdateAroundLines()*2 );
-/*
-    int yPos = renderer->yPosToWidgetY( renderer->yPosForOffset( offset ) );
-    int xPos = renderer->xPosToWidgetX( renderer->xPosForOffset( offset ) - width/2 );
-    viewport()->update( xPos - renderer->totalViewportX(), yPos - renderer->totalViewportY(), width, renderer->lineHeight()  );
-*/
+    update(
+        ren->xPosForOffset(offset) - width / 2,
+        ren->yPosForOffset(offset) - textEditorRenderer_->extraPixelsToUpdateAroundLines(),
+        width,
+        ren->lineHeight() + textEditorRenderer_->extraPixelsToUpdateAroundLines() * 2
+    );
 }
 
 
 /// This method invalidates the given lines
 /// @param line the first line to update
 /// @param length the number of lines to update
-void TextEditorComponent::updateLine(int line, int length)
+void TextEditorComponent::updateLine(size_t line, size_t length)
 {
     TextRenderer* ren = textRenderer();
-    int startY = ren->yPosForLine( line ) - textEditorRenderer_->extraPixelsToUpdateAroundLines();
-    int endY   = ren->yPosForLine( line + length ) + textEditorRenderer_->extraPixelsToUpdateAroundLines();
-    update( 0, startY, width(), endY );
+    int startY = ren->yPosForLine(line) - textEditorRenderer_->extraPixelsToUpdateAroundLines();
+    int endY   = ren->yPosForLine(line + length) + textEditorRenderer_->extraPixelsToUpdateAroundLines();
+    update(0, startY, width(), endY);
 }
 
 

--- a/edbee-lib/edbee/views/components/texteditorcomponent.h
+++ b/edbee-lib/edbee/views/components/texteditorcomponent.h
@@ -55,20 +55,20 @@ protected:
     virtual void keyPressEvent( QKeyEvent* event );
     virtual void keyReleaseEvent ( QKeyEvent* event );
     void inputMethodEvent( QInputMethodEvent* m );
-    QVariant inputMethodQuery( Qt::InputMethodQuery p ) const;
+    QVariant inputMethodQuery( Qt::InputMethodQuery p) const;
     void registerClickEvent();
-    virtual void mousePressEvent( QMouseEvent* event );
-    virtual void mouseReleaseEvent( QMouseEvent* event );
-    virtual void mouseDoubleClickEvent( QMouseEvent* event );
-    virtual void mouseMoveEvent( QMouseEvent* event );
-    virtual void focusInEvent( QFocusEvent* event );
-    virtual void focusOutEvent( QFocusEvent* event );
+    virtual void mousePressEvent(QMouseEvent* event);
+    virtual void mouseReleaseEvent(QMouseEvent* event);
+    virtual void mouseDoubleClickEvent(QMouseEvent* event);
+    virtual void mouseMoveEvent(QMouseEvent* event );
+    virtual void focusInEvent(QFocusEvent* event);
+    virtual void focusOutEvent(QFocusEvent* event);
     virtual void contextMenuEvent(QContextMenuEvent* event);
 
 public slots:
 
     void repaintCarets();
-    virtual void updateLineAtOffset(int offset);
+    virtual void updateLineAtOffset(size_t offset);
     virtual void updateAreaAroundOffset(int offset, int width=8);
     virtual void updateLine( int line, int length );
 

--- a/edbee-lib/edbee/views/components/texteditorcomponent.h
+++ b/edbee-lib/edbee/views/components/texteditorcomponent.h
@@ -29,7 +29,7 @@ class EDBEE_EXPORT TextEditorComponent : public QWidget
 {
     Q_OBJECT
 public:
-    explicit TextEditorComponent( TextEditorController* controller, QWidget *parent = 0);
+    explicit TextEditorComponent(TextEditorController* controller, QWidget *parent = nullptr);
     virtual ~TextEditorComponent();
 
     TextEditorCommandMap* commandMap();
@@ -40,7 +40,7 @@ public:
     TextSelection* textSelection();
 
     TextEditorRenderer* textEditorRenderer() { return textEditorRenderer_; }
-    void giveTextEditorRenderer( TextEditorRenderer* renderer );
+    void giveTextEditorRenderer(TextEditorRenderer* renderer);
 
     void resetCaretTime();
     void fullUpdate();
@@ -48,14 +48,14 @@ public:
     virtual QSize sizeHint() const;
 
 protected:
-    virtual void paintEvent( QPaintEvent* paintEvent );
-    virtual void moveEvent( QMoveEvent* moveEvent );
-    virtual void hideEvent( QHideEvent* hideEvent );
-    virtual bool event( QEvent* event );
-    virtual void keyPressEvent( QKeyEvent* event );
-    virtual void keyReleaseEvent ( QKeyEvent* event );
-    void inputMethodEvent( QInputMethodEvent* m );
-    QVariant inputMethodQuery( Qt::InputMethodQuery p) const;
+    virtual void paintEvent(QPaintEvent* paintEvent);
+    virtual void moveEvent(QMoveEvent* moveEvent);
+    virtual void hideEvent(QHideEvent* hideEvent);
+    virtual bool event(QEvent* event );
+    virtual void keyPressEvent(QKeyEvent* event);
+    virtual void keyReleaseEvent(QKeyEvent* event);
+    void inputMethodEvent(QInputMethodEvent* m);
+    QVariant inputMethodQuery(Qt::InputMethodQuery p) const;
     void registerClickEvent();
     virtual void mousePressEvent(QMouseEvent* event);
     virtual void mouseReleaseEvent(QMouseEvent* event);
@@ -69,28 +69,27 @@ public slots:
 
     void repaintCarets();
     virtual void updateLineAtOffset(size_t offset);
-    virtual void updateAreaAroundOffset(int offset, int width=8);
-    virtual void updateLine( int line, int length );
+    virtual void updateAreaAroundOffset(size_t offset, int width=8);
+    virtual void updateLine(size_t line, size_t length );
 
 signals:
     void textKeyPressed();
-
 
 private:
 
     TextRenderer* textRenderer() const;
 
-    QTimer* caretTimer_;                ///< A timer for updating the carets
+    QTimer* caretTimer_;                     ///< A timer for updating the carets
 
-    QKeySequence lastKeySequence_;              ///< the last key sequence
-    QString lastCharacter_;                     ///< The last added character. (for undo-group per space support)
+    QKeySequence lastKeySequence_;           ///< the last key sequence
+    QString lastCharacter_;                  ///< The last added character. (for undo-group per space support)
 
-    TextEditorController* controllerRef_;       ///< A reference to the controller
-    TextEditorRenderer* textEditorRenderer_;    /// A text-editor renderer
+    TextEditorController* controllerRef_;    ///< A reference to the controller
+    TextEditorRenderer* textEditorRenderer_; /// A text-editor renderer
 
-    int clickCount_;        ///< The number of clicks
-    TextRange clickRange_;  ///< The initial click range (to keep the first word/line selected)
-    qint64 lastClickEvent_; ///< Last click event time
+    int clickCount_;                         ///< The number of clicks
+    TextRange clickRange_;                   ///< The initial click range (to keep the first word/line selected)
+    qint64 lastClickEvent_;                  ///< Last click event time
 };
 
 } // edbee

--- a/edbee-lib/edbee/views/components/texteditorrenderer.cpp
+++ b/edbee-lib/edbee/views/components/texteditorrenderer.cpp
@@ -78,7 +78,7 @@ void TextEditorRenderer::renderLineBackground(QPainter *painter,int line)
 }
 
 
-void TextEditorRenderer::renderLineSelection(QPainter *painter,int line)
+void TextEditorRenderer::renderLineSelection(QPainter *painter, int line)
 {
 //PROF_BEGIN_NAMED("render-selection")
     TextDocument* doc = renderer()->textDocument();
@@ -86,18 +86,17 @@ void TextEditorRenderer::renderLineSelection(QPainter *painter,int line)
     int lineHeight = renderer()->lineHeight();
 
 
-    int firstRangeIdx=0;
-    int lastRangeIdx=0;
+    size_t firstRangeIdx = 0;
+    size_t lastRangeIdx = 0;
 /// TODO: iprove ranges at line by calling rangesForOffsets first for only the visible offsets!
-    if( sel->rangesAtLine( line, firstRangeIdx, lastRangeIdx ) ) {
-
+    if (sel->rangesAtLine(line, firstRangeIdx, lastRangeIdx)) {
         TextLayout* textLayout = renderer()->textLayoutForLine(line);
         QRectF rect = textLayout->boundingRect();
 
         int lastLineColumn = doc->lineLength(line);
 
         // draw all 'ranges' on this line
-        for( int rangeIdx = firstRangeIdx; rangeIdx <= lastRangeIdx; ++rangeIdx ) {
+        for (size_t rangeIdx = firstRangeIdx; rangeIdx <= lastRangeIdx; ++rangeIdx ) {
             TextRange& range = sel->range(rangeIdx);
             int startColumn = doc->columnFromOffsetAndLine( range.min(), line );
             int endColumn   = doc->columnFromOffsetAndLine( range.max(), line );
@@ -126,10 +125,10 @@ void TextEditorRenderer::renderLineBorderedRanges(QPainter *painter,int line)
 //    QBrush brush(themeRef_->findHighlightBackgroundColor());
     painter->setRenderHint(QPainter::Antialiasing);
 
-    int firstRangeIdx=0;
-    int lastRangeIdx=0;
+    size_t firstRangeIdx=0;
+    size_t lastRangeIdx=0;
 /// TODO: improve ranges at line by calling rangesForOffsets first for only the visible offsets!
-    if( sel->rangesAtLine( line, firstRangeIdx, lastRangeIdx ) ) {
+    if (sel->rangesAtLine(line, firstRangeIdx, lastRangeIdx)) {
 
         TextLayout* textLayout = renderer()->textLayoutForLine(line);
         QRectF rect = textLayout->boundingRect();

--- a/edbee-lib/edbee/views/components/texteditorrenderer.cpp
+++ b/edbee-lib/edbee/views/components/texteditorrenderer.cpp
@@ -14,24 +14,24 @@
 #include "edbee/views/textselection.h"
 #include "edbee/views/textrenderer.h"
 #include "edbee/views/textlayout.h"
-#include "edbee/util/simpleprofiler.h"
+// #include "edbee/util/simpleprofiler.h"
 
 #include "edbee/debug.h"
 
 
 namespace edbee {
 
-static const int ShadowWidth=5;
+static const int ShadowWidth = 5;
 
 
-TextEditorRenderer::TextEditorRenderer( TextRenderer *renderer )
+TextEditorRenderer::TextEditorRenderer(TextRenderer* renderer)
     : rendererRef_(renderer)
-    , themeRef_(0)
-    , shadowGradient_(0)
+    , themeRef_(nullptr)
+    , shadowGradient_(nullptr)
 {
-    shadowGradient_ = new QLinearGradient( 0, 0, ShadowWidth, 0 );
-    shadowGradient_ ->setColorAt(0, QColor( 0x00, 0x00, 0x00, 0x99 ));
-    shadowGradient_ ->setColorAt(1, QColor( 0x00, 0x00, 0x00, 0x00 ));
+    shadowGradient_ = new QLinearGradient(0, 0, ShadowWidth, 0);
+    shadowGradient_ ->setColorAt(0, QColor(0x00, 0x00, 0x00, 0x99));
+    shadowGradient_ ->setColorAt(1, QColor(0x00, 0x00, 0x00, 0x00));
 
 }
 
@@ -45,42 +45,40 @@ int TextEditorRenderer::preferedWidth()
     return renderer()->totalWidth();
 }
 
-void TextEditorRenderer::render(QPainter *painter)
+void TextEditorRenderer::render(QPainter* painter)
 {
-    int startLine = renderer()->startLine();
-    int endLine   = renderer()->endLine();
+    size_t startLine = renderer()->startLine();
+    size_t endLine   = renderer()->endLine();
 
-//    TextDocument* doc = renderer()->textDocument();
+    // TextDocument* doc = renderer()->textDocument();
     themeRef_ = renderer()->theme();
-    painter->setBackground( themeRef_->backgroundColor() );
-    painter->setPen( themeRef_->foregroundColor() );
-    painter->fillRect( *renderer()->clipRect(), themeRef_->backgroundColor() );
+    painter->setBackground(themeRef_->backgroundColor());
+    painter->setPen(themeRef_->foregroundColor());
+    painter->fillRect(*renderer()->clipRect(), themeRef_->backgroundColor());
 
     // process the items
-    for( int line = startLine; line <= endLine; ++line  ) {
-        renderLineBackground( painter, line );
-        renderLineSelection( painter, line );
-        renderLineSeparator( painter, line );
-        renderLineText( painter, line );
-        renderLineBorderedRanges( painter, line );
+    for (size_t line = startLine; line <= endLine; ++line) {
+        renderLineBackground(painter, line);
+        renderLineSelection(painter, line);
+        renderLineSeparator(painter, line);
+        renderLineText(painter, line );
+        renderLineBorderedRanges(painter, line);
     }
 
     renderCarets(painter);
-//    renderShade( painter, *renderer()->clipRect() );        /// TODO, deze renderShade moet misschien in de viewport render-code gebreuren
-
 }
 
 
-void TextEditorRenderer::renderLineBackground(QPainter *painter,int line)
+void TextEditorRenderer::renderLineBackground(QPainter* painter, size_t line)
 {
     Q_UNUSED(line);
     Q_UNUSED(painter);
 }
 
 
-void TextEditorRenderer::renderLineSelection(QPainter *painter, int line)
+void TextEditorRenderer::renderLineSelection(QPainter* painter, size_t line)
 {
-//PROF_BEGIN_NAMED("render-selection")
+    //PROF_BEGIN_NAMED("render-selection")
     TextDocument* doc = renderer()->textDocument();
     TextSelection* sel = renderer()->textSelection();
     int lineHeight = renderer()->lineHeight();
@@ -88,32 +86,38 @@ void TextEditorRenderer::renderLineSelection(QPainter *painter, int line)
 
     size_t firstRangeIdx = 0;
     size_t lastRangeIdx = 0;
-/// TODO: iprove ranges at line by calling rangesForOffsets first for only the visible offsets!
+    /// TODO: iprove ranges at line by calling rangesForOffsets first for only the visible offsets!
     if (sel->rangesAtLine(line, firstRangeIdx, lastRangeIdx)) {
         TextLayout* textLayout = renderer()->textLayoutForLine(line);
         QRectF rect = textLayout->boundingRect();
 
-        int lastLineColumn = doc->lineLength(line);
+        size_t lastLineColumn = doc->lineLength(line);
 
         // draw all 'ranges' on this line
         for (size_t rangeIdx = firstRangeIdx; rangeIdx <= lastRangeIdx; ++rangeIdx ) {
             TextRange& range = sel->range(rangeIdx);
-            int startColumn = doc->columnFromOffsetAndLine( range.min(), line );
-            int endColumn   = doc->columnFromOffsetAndLine( range.max(), line );
+            size_t startColumn = doc->columnFromOffsetAndLine(range.min(), line);
+            size_t endColumn   = doc->columnFromOffsetAndLine(range.max(), line);
 
-            int startX = textLayout->cursorToX(startColumn);
-            int endX   = textLayout->cursorToX(endColumn);
+            int startX = qRound(textLayout->cursorToX(startColumn));
+            int endX   = qRound(textLayout->cursorToX(endColumn));
 
-            if( range.length() > 0 && endColumn+1 >= lastLineColumn) endX += 3;
+            if (range.length() > 0 && endColumn + 1 >= lastLineColumn) endX += 3;
 
-            painter->fillRect(startX, line*lineHeight + rect.top(), endX - startX, rect.height(),  themeRef_->selectionColor() ); //QColor::fromRgb(0xDD, 0x88, 0xEE) );
+            painter->fillRect(
+                startX,
+                static_cast<int>(line) * lineHeight + qRound(rect.top()),
+                endX - startX,
+                qRound(rect.height()),
+                themeRef_->selectionColor()
+            );
         }
     }
-//PROF_END
+    //PROF_END
 }
 
 
-void TextEditorRenderer::renderLineBorderedRanges(QPainter *painter,int line)
+void TextEditorRenderer::renderLineBorderedRanges(QPainter *painter, size_t line)
 {
 //PROF_BEGIN_NAMED("render-selection")
     TextDocument* doc = renderer()->textDocument();
@@ -121,141 +125,136 @@ void TextEditorRenderer::renderLineBorderedRanges(QPainter *painter,int line)
     int lineHeight = renderer()->lineHeight();
 
     QPen pen(themeRef_->foregroundColor(), 0.5);
-//    QPen pen(themeRef_->findHighlightForegroundColor(), 0.5);
-//    QBrush brush(themeRef_->findHighlightBackgroundColor());
     painter->setRenderHint(QPainter::Antialiasing);
 
     size_t firstRangeIdx=0;
     size_t lastRangeIdx=0;
-/// TODO: improve ranges at line by calling rangesForOffsets first for only the visible offsets!
-    if (sel->rangesAtLine(line, firstRangeIdx, lastRangeIdx)) {
 
+    /// TODO: improve ranges at line by calling rangesForOffsets first for only the visible offsets!
+    if (sel->rangesAtLine(line, firstRangeIdx, lastRangeIdx)) {
         TextLayout* textLayout = renderer()->textLayoutForLine(line);
         QRectF rect = textLayout->boundingRect();
 
-        int lastLineColumn = doc->lineLength(line);
+        size_t lastLineColumn = doc->lineLength(line);
 
         // draw all 'ranges' on this line
-        for( int rangeIdx = firstRangeIdx; rangeIdx <= lastRangeIdx; ++rangeIdx ) {
+        for (size_t rangeIdx = firstRangeIdx; rangeIdx <= lastRangeIdx; ++rangeIdx) {
             TextRange& range = sel->range(rangeIdx);
-            int startColumn = doc->columnFromOffsetAndLine( range.min(), line );
-            int endColumn   = doc->columnFromOffsetAndLine( range.max(), line );
+            size_t startColumn = doc->columnFromOffsetAndLine(range.min(), line);
+            size_t endColumn   = doc->columnFromOffsetAndLine(range.max(), line);
 
             qreal startX = textLayout->cursorToX( startColumn );
             qreal endX   = textLayout->cursorToX( endColumn );
 
-            if( range.length() > 0 && endColumn+1 >= lastLineColumn) endX += 3;
+            if (range.length() > 0 && endColumn + 1 >= lastLineColumn) endX += 3;
 
             QPainterPath path;
-            path.addRoundedRect(startX, line*lineHeight + rect.top(), endX - startX, rect.height(),5,5);
-//            painter->fillPath(path, brush);
+            path.addRoundedRect(
+                startX,
+                static_cast<int>(line) * lineHeight + rect.top(),
+                endX - startX,
+                rect.height(),
+                5,
+                5
+            );
             painter->strokePath(path, pen);
         }
     }
-//PROF_END
+    //PROF_END
 }
 
 
 
-void TextEditorRenderer::renderLineSeparator(QPainter *painter,int line)
+void TextEditorRenderer::renderLineSeparator(QPainter* painter, size_t line)
 {
-//PROF_BEGIN_NAMED("render-selection")
+    //PROF_BEGIN_NAMED("render-selection")
     TextEditorConfig* config = renderer()->config();
     int lineHeight = renderer()->lineHeight();
-//    int viewportX = renderer()->viewportX();
-//    int viewportWidth = renderer()->vie\wportWidth();
-    QRect visibleRect( renderer()->viewport() );
+    QRect visibleRect(renderer()->viewport());
 
-    if( config->useLineSeparator() ) {
+    if (config->useLineSeparator()) {
         const QPen& pen = config->lineSeparatorPen();
-        painter->setPen( pen );
-        int y = (line+1)*lineHeight; // - pen.width();
-//        p.drawLine( viewportX(), y, viewportWidth(), y );
-        painter->drawLine( visibleRect.left(), y, visibleRect.right(), y ); // draw from 0 to allow correct rendering of dotted lines
+        painter->setPen(pen);
+        int y = (static_cast<int>(line) + 1) * lineHeight; // - pen.width();
+        painter->drawLine(visibleRect.left(), y, visibleRect.right(), y); // draw from 0 to allow correct rendering of dotted lines
     }
-//PROF_END
+    //PROF_END
 }
 
 
-void TextEditorRenderer::renderLineText(QPainter *painter, int line)
+void TextEditorRenderer::renderLineText(QPainter* painter, size_t line)
 {
-//PROF_BEGIN_NAMED("render-line-text")
+    //PROF_BEGIN_NAMED("render-line-text")
     TextLayout* textLayout = renderer()->textLayoutForLine(line);
 
     // draw the text layout
-    QPoint lineStartPos(0, line*renderer()->lineHeight() );
-//PROF_BEGIN_NAMED("fetch-formats")
-//    QVector<QTextLayout::FormatRange>& formats = renderer()->themeStyler()->getLineFormatRanges( line );
+    QPoint lineStartPos(0, static_cast<int>(line) * renderer()->lineHeight());
+    //PROF_BEGIN_NAMED("fetch-formats")
+    // QVector<QTextLayout::FormatRange>& formats = renderer()->themeStyler()->getLineFormatRanges( line );
     QVector<QTextLayout::FormatRange> formats;
-//PROF_END
+    //PROF_END
 
-//painter->setClipping(false);
-//painter->setPen( QPen( QColor( 0,0,200), 2 ));
-//QRect clipDrawRect( renderer()->translatedClipRect() );
-//clipDrawRect.adjust(2,2,-2,-2);
-//painter->drawRect( clipDrawRect );
-//painter->setClipping(true);
+    //painter->setClipping(false);
+    //painter->setPen( QPen( QColor( 0,0,200), 2 ));
+    //QRect clipDrawRect( renderer()->translatedClipRect() );
+    //clipDrawRect.adjust(2,2,-2,-2);
+    //painter->drawRect( clipDrawRect );
+    //painter->setClipping(true);
 
-//PROF_BEGIN_NAMED("draw-texts")
+    //PROF_BEGIN_NAMED("draw-texts")
     painter->setPen( themeRef_->foregroundColor() );
     textLayout->draw( painter, lineStartPos, formats, *renderer()->clipRect() );
-//PROF_END
-
-//PROF_END
+    //PROF_END
 }
 
+
 // This method renders all carets
-void TextEditorRenderer::renderCarets(QPainter *painter)
+void TextEditorRenderer::renderCarets(QPainter* painter)
 {
-//PROF_BEGIN_NAMED("render-carets")
-
-    if( renderer()->shouldRenderCaret() ) {
-        TextDocument* doc= renderer()->textDocument();
+    //PROF_BEGIN_NAMED("render-carets")
+    if (renderer()->shouldRenderCaret()) {
+        TextDocument* doc = renderer()->textDocument();
         TextRangeSet* sel = renderer()->textSelection();
-        painter->setPen( themeRef_->caretColor() );
+        painter->setPen(themeRef_->caretColor());
 
-        int startLine = renderer()->startLine();
-        int endLine = renderer()->endLine();
+        size_t startLine = renderer()->startLine();
+        size_t endLine = renderer()->endLine();
         int caretWidth = renderer()->config()->caretWidth();
 
-        for( int line = startLine; line <= endLine; ++line  ) {
-
+        for (size_t line = startLine; line <= endLine; ++line) {
             QPoint lineStartPos(0, renderer()->yPosForLine(line));
 
             TextLayout* textLayout = renderer()->textLayoutForLine(line);
-            for( int caret = 0, rangeCount=sel->rangeCount(); caret < rangeCount; ++caret ) {
-
+            for (size_t caret = 0, rangeCount = sel->rangeCount(); caret < rangeCount; ++caret) {
                 TextRange& range = sel->range(caret);
-                int caretLine = doc->lineFromOffset( range.caret() );
-                if( caretLine == line ) {
-                    int caretCol = doc->columnFromOffsetAndLine( range.caret(), caretLine );
-                    textLayout->drawCursor( painter, lineStartPos, caretCol, caretWidth );
+                size_t caretLine = doc->lineFromOffset(range.caret());
+                if (caretLine == line) {
+                    size_t caretCol = doc->columnFromOffsetAndLine(range.caret(), caretLine);
+                    textLayout->drawCursor(painter, lineStartPos, caretCol, caretWidth);
                 }
             }
         }
     }
-//PROF_END
+    //PROF_END
 }
 
 
-void TextEditorRenderer::renderShade(QPainter *painter, const QRect& rect )
+void TextEditorRenderer::renderShade(QPainter *painter, const QRect& rect)
 {
-    // render a shade
-    if( renderer()->viewportX()) {
+    if (renderer()->viewportX()) {
         int shadowStart = renderer()->viewportX();
-        painter->setPen( Qt::NoPen );
+        painter->setPen(Qt::NoPen);
         QBrush oldBrush = painter->brush();
-        painter->setBrushOrigin(shadowStart, rect.y() );
-        painter->setBrush( *shadowGradient_ );
+        painter->setBrushOrigin(shadowStart, rect.y());
+        painter->setBrush(*shadowGradient_);
 
         QRect shadowRect(shadowStart, rect.y(), ShadowWidth, rect.height());
-        painter->drawRect( shadowRect.intersected( *renderer()->clipRect() ) );
+        painter->drawRect(shadowRect.intersected( *renderer()->clipRect()));
 
         painter->setBrush(oldBrush);
     }
-
-
 }
+
 
 /// should return the extra pixels to update when updating a line
 /// This way it is possible to render margins around the lines

--- a/edbee-lib/edbee/views/components/texteditorrenderer.h
+++ b/edbee-lib/edbee/views/components/texteditorrenderer.h
@@ -16,18 +16,18 @@ class TextTheme;
 
 class EDBEE_EXPORT TextEditorRenderer {
 public:
-    TextEditorRenderer( TextRenderer *renderer );
+    TextEditorRenderer(TextRenderer *renderer);
     virtual ~TextEditorRenderer();
 
     virtual int preferedWidth();
     virtual void render(QPainter* painter);
-    virtual void renderLineBackground(QPainter *painter, int line);
-    virtual void renderLineSelection(QPainter *painter, int line);
-    virtual void renderLineBorderedRanges(QPainter *painter, int line);
-    virtual void renderLineSeparator(QPainter *painter, int line);
-    virtual void renderLineText(QPainter *painter, int line);
+    virtual void renderLineBackground(QPainter *painter, size_t line);
+    virtual void renderLineSelection(QPainter *painter, size_t line);
+    virtual void renderLineBorderedRanges(QPainter *painter, size_t line);
+    virtual void renderLineSeparator(QPainter *painter, size_t line);
+    virtual void renderLineText(QPainter *painter, size_t line);
     virtual void renderCarets(QPainter *painter);
-    virtual void renderShade(QPainter *painter, const QRect& rect );
+    virtual void renderShade(QPainter *painter, const QRect& rect);
 
     virtual int extraPixelsToUpdateAroundLines();
 
@@ -37,7 +37,6 @@ private:
     TextRenderer* rendererRef_;       ///< the renderere reference
     TextTheme* themeRef_;             ///< A theem reference used while rendering
     QLinearGradient* shadowGradient_; ///< The shadow gradient to draw
-
 };
 
 } // edbee

--- a/edbee-lib/edbee/views/components/textmargincomponent.cpp
+++ b/edbee-lib/edbee/views/components/textmargincomponent.cpp
@@ -34,10 +34,11 @@ TextMarginComponentDelegate::TextMarginComponentDelegate()
 {
 }
 
+
 /// The default text (of course) is the line-number
-QString TextMarginComponentDelegate::lineText(int line)
+QString TextMarginComponentDelegate::lineText(size_t line)
 {
-    return QStringLiteral("%1").arg(line+1);
+    return QStringLiteral("%1").arg(line + 1);
 }
 
 /// The extra space required before the line-number
@@ -47,8 +48,9 @@ int TextMarginComponentDelegate::widthBeforeLineNumber()
     return 5;
 }
 
+
 /// Custom rendering before the line-numbers etc are drawn
-void TextMarginComponentDelegate::renderBefore(QPainter *painter, int startLine, int endLine, int width)
+void TextMarginComponentDelegate::renderBefore(QPainter *painter, size_t startLine, size_t endLine, int width)
 {
     Q_UNUSED(painter)
     Q_UNUSED(startLine)
@@ -56,14 +58,16 @@ void TextMarginComponentDelegate::renderBefore(QPainter *painter, int startLine,
     Q_UNUSED(width)
 }
 
+
 /// The delegate can berform custom rendering on a given line
-void TextMarginComponentDelegate::renderAfter(QPainter* painter, int startLine, int endLine, int width)
+void TextMarginComponentDelegate::renderAfter(QPainter* painter, size_t startLine, size_t endLine, int width)
 {
     Q_UNUSED(painter)
     Q_UNUSED(startLine)
     Q_UNUSED(endLine)
     Q_UNUSED(width)
 }
+
 
 /// Make this method return true to enable mouse tracking
 bool TextMarginComponentDelegate::requiresMouseTracking()
@@ -71,35 +75,38 @@ bool TextMarginComponentDelegate::requiresMouseTracking()
     return true;
 }
 
+
 /// This method is called when the mouse is moved over a certain line
 /// To use it you MUST manually call setMouseTracking() on the TextMarginComponent
-void TextMarginComponentDelegate::mouseMoveEvent(int line, QMouseEvent* event)
+void TextMarginComponentDelegate::mouseMoveEvent(size_t line, QMouseEvent* event)
 {
     Q_UNUSED(line)
     Q_UNUSED(event)
-    if( event->buttons() & Qt::LeftButton ) {
-        if( line >= 0 ) {
+    if (event->buttons() & Qt::LeftButton) {
+        if (line >= 0) {
             TextEditorController* controller = marginComponent()->editorWidget()->controller();
-            if( line < startLine_ ) {
-                controller->moveCaretTo(startLine_+1,0,false);
-                controller->moveCaretTo(line,0,true);
+            if (line < startLine_) {
+                controller->moveCaretTo(startLine_ + 1, 0, false);
+                controller->moveCaretTo(line, 0, true);
             } else {
-                controller->moveCaretTo(line+1,0,true);
+                controller->moveCaretTo(line + 1, 0, true);
             }
         }
     }
 }
 
-void TextMarginComponentDelegate::mousePressEvent(int line, QMouseEvent* event)
+
+void TextMarginComponentDelegate::mousePressEvent(size_t line, QMouseEvent* event)
 {
     Q_UNUSED(event)
-    if( line >= 0 ) {
+    if (line >= 0) {
         TextEditorController* controller = marginComponent()->editorWidget()->controller();
-        controller->moveCaretTo(line,0,false);
-        controller->moveCaretTo(line+1,0,true);
+        controller->moveCaretTo(line, 0, false);
+        controller->moveCaretTo(line + 1, 0, true);
         startLine_ = line;
     }
 }
+
 
 void TextMarginComponentDelegate::leaveEvent(QEvent* event)
 {
@@ -115,18 +122,18 @@ void TextMarginComponentDelegate::leaveEvent(QEvent* event)
 /// @param editor the editor this component is connceted to
 /// @param parent the parent widget
 TextMarginComponent::TextMarginComponent(TextEditorWidget* editor, QWidget* parent)
-    : QWidget( parent )
+    : QWidget(parent)
     , top_(0)
     , width_(-1)
-    , lastLineCount_(-1)
+    , lastLineCount_(std::string::npos)
     , marginFont_(nullptr)
-    , editorRef_( editor )
+    , editorRef_(editor)
     , delegate_(nullptr)
     , delegateRef_(nullptr)
 {
-    this->setFocusPolicy( Qt::NoFocus );
-    this->setAutoFillBackground(false);
-    this->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Expanding );
+    setFocusPolicy(Qt::NoFocus);
+    setAutoFillBackground(false);
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 }
 
 
@@ -138,13 +145,13 @@ TextMarginComponent::~TextMarginComponent()
 }
 
 
-/// initalizes this component
+/// Initalizes this component
 void TextMarginComponent::init()
 {
-    giveDelegate( new TextMarginComponentDelegate() );
+    giveDelegate(new TextMarginComponentDelegate());
     updateMarginFont();
-    connect( editorRef_->textRenderer(), SIGNAL(themeChanged(TextTheme*)), SLOT(updateFont()));
-    connect( editorRef_->config(), SIGNAL(configChanged()), SLOT(updateFont()));
+    connect(editorRef_->textRenderer(), SIGNAL(themeChanged(TextTheme*)), SLOT(updateFont()));
+    connect(editorRef_->config(), SIGNAL(configChanged()), SLOT(updateFont()));
     connectScrollBar();
 }
 
@@ -156,8 +163,8 @@ void TextMarginComponent::updateMarginFont()
 
     const QFont& font = editorWidget()->config()->font();
     marginFont_ = new QFont(font.family());
-    if( font.pointSizeF() > 0 ) marginFont_->setPointSizeF( font.pointSizeF() );
-    if( font.pixelSize() > 0 ) marginFont_->setPixelSize( font.pixelSize() );
+    if (font.pointSizeF() > 0) marginFont_->setPointSizeF(font.pointSizeF());
+    if (font.pixelSize() > 0) marginFont_->setPixelSize(font.pixelSize());
 }
 
 
@@ -165,23 +172,23 @@ void TextMarginComponent::updateMarginFont()
 int TextMarginComponent::widthHint() const
 {
     TextDocument* doc = renderer()->textDocument();
-    int lineCount = doc->lineCount();
-    if( lastLineCount_ != lineCount ) {
+    size_t lineCount = doc->lineCount();
+    if (lastLineCount_ != lineCount) {
         lastLineCount_ = lineCount;
 
         // count the number of characters required
         int decimals = 0;
-        int decimalValue = 1;
+        size_t decimalValue = 1;
         do {
             ++decimals;
             decimalValue *= 10;
         }
-        while( decimalValue <= lineCount );
+        while (decimalValue <= lineCount);
 
         // we at least reserve space for 2 decimals
-        decimals = qMax(decimals,2);
+        decimals = decimals > 1 ? decimals : 2;
 
-        width_ = qMax( renderer()->nrWidth(), 10 ) * ( decimals ) + LineNumberRightPadding + MarginPaddingRight;
+        width_ = static_cast<int>(static_cast<int>(qMax(renderer()->nrWidth(), 10)) * (decimals) + LineNumberRightPadding + MarginPaddingRight);
         width_ += delegate()->widthBeforeLineNumber();
     }
     return width_;
@@ -191,9 +198,7 @@ int TextMarginComponent::widthHint() const
 /// This method returns the size hint
 QSize TextMarginComponent::sizeHint() const
 {
-//    QSize size = QWidget::sizeHint();
-    return QSize( widthHint(), 78 );
-    //return QSize(widthHint(), renderer()->totalHeight() );
+    return QSize(widthHint(), 78);
 }
 
 
@@ -224,19 +229,21 @@ void TextMarginComponent::setDelegate(TextMarginComponentDelegate* delegate)
 {
     delete delegate_;
     delegate_ = nullptr;
-    if( delegate == nullptr ) { delegate = new TextMarginComponentDelegate(); }
+    if (delegate == nullptr) { delegate = new TextMarginComponentDelegate(); }
     delegateRef_ = delegate;
 
     // perform some updates
-    delegateRef_->setMarginCompenent( this );
-    setMouseTracking( delegateRef_->requiresMouseTracking() );
+    delegateRef_->setMarginCompenent(this);
+    setMouseTracking(delegateRef_->requiresMouseTracking());
 }
+
 
 void TextMarginComponent::giveDelegate(TextMarginComponentDelegate* delegate)
 {
-    setDelegate( delegate );
+    setDelegate(delegate);
     delegate_ = delegate;
 }
+
 
 void TextMarginComponent::paintEvent(QPaintEvent* event)
 {
@@ -247,29 +254,26 @@ void TextMarginComponent::paintEvent(QPaintEvent* event)
     painter.translate(0, -top_);
 
     QRect paintRect = event->rect();
-//    QRect translatedRect( clipRect.x()+offsetX, clipRect.y()+offsetY, clipRect.width(), clipRect.height() );
-    paintRect.adjust(0,top_,0,top_);
-    renderer()->renderBegin( paintRect );
+    paintRect.adjust(0, top_, 0, top_);
+    renderer()->renderBegin(paintRect);
 
 
-    int startLine     = renderer()->startLine();
-    int endLine       = renderer()->endLine();
+    size_t startLine = renderer()->startLine();
+    size_t endLine = renderer()->endLine();
     const QSize& size = this->size();
 
-    QRect totalRect( 0, 0, size.width(), size.height()+top_ );
-    QRect rect( totalRect.intersected( *renderer()->clipRect() ) );
-
-//qlog_info()<< "** top:"<<top_<<", total:"<<totalRect<<", paintRect: "<<paintRect<<" => rect: " << rect;
+    QRect totalRect(0, 0, size.width(), size.height() + top_);
+    QRect rect(totalRect.intersected( *renderer()->clipRect()));
 
     // fill the backgound
-    painter.fillRect( rect,  renderer()->theme()->backgroundColor() );
+    painter.fillRect(rect, renderer()->theme()->backgroundColor());
 
-    delegate()->renderBefore( &painter, startLine, endLine, size.width() );
-    renderCaretMarkers( &painter, startLine, endLine, size.width() );
-    renderLineNumber( &painter, startLine, endLine, size.width() );
-    delegate()->renderAfter( &painter, startLine, endLine, size.width() );
+    delegate()->renderBefore(&painter, startLine, endLine, size.width());
+    renderCaretMarkers(&painter, startLine, endLine, size.width());
+    renderLineNumber(&painter, startLine, endLine, size.width());
+    delegate()->renderAfter(&painter, startLine, endLine, size.width());
 
-    renderer()->renderEnd( paintRect );
+    renderer()->renderEnd(paintRect);
     painter.translate(0, top_);
 
 }
@@ -280,23 +284,23 @@ void TextMarginComponent::paintEvent(QPaintEvent* event)
 /// @param startLine the first line to render
 /// @param endLine the last line to render
 /// @param width the width for rendering
-void TextMarginComponent::renderCaretMarkers(QPainter* painter, int startLine, int endLine , int width)
+void TextMarginComponent::renderCaretMarkers(QPainter* painter, size_t startLine, size_t endLine , int width)
 {
     TextDocument* doc = renderer()->textDocument();
     TextSelection* sel = renderer()->textSelection();
     QColor lineColor = renderer()->theme()->lineHighlightColor();
     int lineHeight = renderer()->lineHeight();
 
-    QRect marginRect(0,0,width-MarginPaddingRight,lineHeight);
-    for( int i=0,cnt=sel->rangeCount(); i<cnt; ++i ) {
+    QRect marginRect(0, 0, width - MarginPaddingRight, lineHeight);
+    for (size_t i = 0, cnt = sel->rangeCount(); i < cnt; ++i) {
 
         TextRange& range = sel->range(i);
-        int line = doc->lineFromOffset(range.caret());
-        if( startLine <= line ) {
-            if( line > endLine ) { break; }
+        size_t line = doc->lineFromOffset(range.caret());
+        if (startLine <= line) {
+            if (line > endLine) { break; }
             int y = renderer()->yPosForLine(line);
             marginRect.moveTop(y);
-            painter->fillRect( marginRect, lineColor );
+            painter->fillRect(marginRect, lineColor);
         }
     }
 }
@@ -307,7 +311,7 @@ void TextMarginComponent::renderCaretMarkers(QPainter* painter, int startLine, i
 /// @param startLine the first line to render
 /// @param endLine the last line to render
 /// @param width the width for rendering
-void TextMarginComponent::renderLineNumber(QPainter* painter, int startLine, int endLine , int width)
+void TextMarginComponent::renderLineNumber(QPainter* painter, size_t startLine, size_t endLine , int width)
 {
     painter->setFont(*marginFont_);
     QColor selectedPenColor = renderer()->theme()->foregroundColor();
@@ -315,20 +319,20 @@ void TextMarginComponent::renderLineNumber(QPainter* painter, int startLine, int
     penColor.setAlphaF(0.5);
 
     int lineHeight = renderer()->lineHeight();
-    int textWidth =  width-LineNumberRightPadding-MarginPaddingRight - delegate()->widthBeforeLineNumber();
+    int textWidth =  width-LineNumberRightPadding - MarginPaddingRight - delegate()->widthBeforeLineNumber();
 
-    for (int line=startLine; line<=endLine; ++line) {
+    for (size_t line = startLine; line <= endLine; ++line) {
         int y = renderer()->yPosForLine(line);
 
         // highlight the selected lines
         size_t firstIndex = 0, lastIndex = 0;
-        if( renderer()->textSelection()->rangesAtLineExclusiveEnd(line, firstIndex, lastIndex) ) {
+        if(renderer()->textSelection()->rangesAtLineExclusiveEnd(line, firstIndex, lastIndex)) {
 
         } else {
             painter->setPen(penColor);
         }
 
-        painter->drawText( delegate()->widthBeforeLineNumber(), y+2, textWidth, lineHeight, Qt::AlignRight, delegate()->lineText( line) );
+        painter->drawText(delegate()->widthBeforeLineNumber(), y + 2, textWidth, lineHeight, Qt::AlignRight, delegate()->lineText(line));
     }
 }
 
@@ -341,7 +345,7 @@ void TextMarginComponent::mouseMoveEvent(QMouseEvent* event)
 #else
     int y = event->position().toPoint().y() + top_;
 #endif
-    int line = renderer()->lineIndexForYpos( y );
+    size_t line = renderer()->lineIndexForYpos(y);
     delegate()->mouseMoveEvent(line, event);
     QWidget::mouseMoveEvent(event);
 }
@@ -356,23 +360,21 @@ void TextMarginComponent::mousePressEvent(QMouseEvent* event)
 #else
     int y = event->position().toPoint().y() + top_;
 #endif
-    int line = renderer()->lineIndexForYpos( y );
-    delegate()->mousePressEvent( line, event );
+    size_t line = renderer()->lineIndexForYpos( y );
+    delegate()->mousePressEvent(line, event);
     QWidget::mousePressEvent(event);
 
-    if(!editorWidget()->textEditorComponent()->hasFocus()) {
+    if (!editorWidget()->textEditorComponent()->hasFocus()) {
         editorWidget()->textEditorComponent()->setFocus();
     }
 }
 
 
-/// A double click
 void TextMarginComponent::mouseDoubleClickEvent(QMouseEvent *)
 {
 }
 
 
-/// The mouse leave
 void TextMarginComponent::leaveEvent(QEvent* event)
 {
     delegate()->leaveEvent(event);
@@ -382,30 +384,29 @@ void TextMarginComponent::leaveEvent(QEvent* event)
 /// forward the mouse wheel event to the scrollbar so you can use the mouse wheel on this component
 void TextMarginComponent::wheelEvent(QWheelEvent* event)
 {
-//    if( event->orientation() == Qt::Vertical) {
-    if( event->angleDelta().y() != 0 ) {
-        QApplication::sendEvent( editorRef_->textScrollArea()->verticalScrollBar(), event );
+    // if( event->orientation() == Qt::Vertical) {
+    if (event->angleDelta().y() != 0) {
+        QApplication::sendEvent(editorRef_->textScrollArea()->verticalScrollBar(), event);
     }
 }
 
 
 /// updates the given line so it will be repainted
-void TextMarginComponent::updateLineAtOffset(int offset)
+void TextMarginComponent::updateLineAtOffset(size_t offset)
 {
-    int yPos = renderer()->yPosForOffset( offset ) - top_;
-
-    update( 0,  yPos, width(), renderer()->lineHeight()  );
+    int yPos = renderer()->yPosForOffset(offset) - top_;
+    update(0, yPos, width(), renderer()->lineHeight());
 }
 
 
 /// This method repaints the given lines
-void TextMarginComponent::updateLine(int line, int length)
+void TextMarginComponent::updateLine(size_t line, size_t length)
 {
     TextRenderer* ren = renderer();
-    int startY = ren->yPosForLine( line ) - top_;
-    int endY   = ren->yPosForLine( line + length ) - top_;
+    int startY = ren->yPosForLine(line) - top_;
+    int endY   = ren->yPosForLine(line + length) - top_;
 
-    update( 0, startY, width(), endY-startY );
+    update(0, startY, width(), endY - startY);
 }
 
 
@@ -419,14 +420,14 @@ void TextMarginComponent::topChanged(int value)
 /// You must reconnect the scrollbars when scrollbars are changed
 void TextMarginComponent::connectScrollBar()
 {
-    connect( editorRef_->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(topChanged(int)) );
+    connect(editorRef_->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(topChanged(int)));
 }
+
 
 void TextMarginComponent::updateFont()
 {
     updateMarginFont();
 }
-
 
 
 } // edbee

--- a/edbee-lib/edbee/views/components/textmargincomponent.cpp
+++ b/edbee-lib/edbee/views/components/textmargincomponent.cpp
@@ -317,13 +317,13 @@ void TextMarginComponent::renderLineNumber(QPainter* painter, int startLine, int
     int lineHeight = renderer()->lineHeight();
     int textWidth =  width-LineNumberRightPadding-MarginPaddingRight - delegate()->widthBeforeLineNumber();
 
-    for( int line=startLine; line<=endLine; ++line ) {
+    for (int line=startLine; line<=endLine; ++line) {
         int y = renderer()->yPosForLine(line);
 
         // highlight the selected lines
-        int firstIndex=0, lastIndex=0;
+        size_t firstIndex = 0, lastIndex = 0;
         if( renderer()->textSelection()->rangesAtLineExclusiveEnd(line, firstIndex, lastIndex) ) {
-            painter->setPen(selectedPenColor);
+
         } else {
             painter->setPen(penColor);
         }

--- a/edbee-lib/edbee/views/components/textmargincomponent.h
+++ b/edbee-lib/edbee/views/components/textmargincomponent.h
@@ -27,23 +27,23 @@ public:
     TextMarginComponentDelegate();
     virtual ~TextMarginComponentDelegate() {}
 
-    virtual QString lineText( int line );
+    virtual QString lineText(size_t line);
 
     virtual int widthBeforeLineNumber();
-    virtual void renderBefore( QPainter* painter, int startLine, int endLine, int width );
-    virtual void renderAfter( QPainter* painter, int startLine, int endLine, int width );
+    virtual void renderBefore(QPainter* painter, size_t startLine, size_t endLine, int width);
+    virtual void renderAfter(QPainter* painter, size_t startLine, size_t endLine, int width);
 
     virtual bool requiresMouseTracking();
-    virtual void mouseMoveEvent( int line, QMouseEvent* event );
-    virtual void mousePressEvent( int line, QMouseEvent* event );
+    virtual void mouseMoveEvent(size_t line, QMouseEvent* event);
+    virtual void mousePressEvent(size_t line, QMouseEvent* event);
     virtual void leaveEvent( QEvent* event );
 
     TextMarginComponent* marginComponent() { return marginComponentRef_; }
-    void setMarginCompenent( TextMarginComponent* comp ) { marginComponentRef_ = comp; }
+    void setMarginCompenent(TextMarginComponent* comp) { marginComponentRef_ = comp; }
 
 private:
-    TextMarginComponent* marginComponentRef_;           ///< A reference to the margincomponent
-    int startLine_;                                     ///< The line which starts the selection
+    TextMarginComponent* marginComponentRef_;  ///< A reference to the margincomponent
+    size_t startLine_;                         ///< The line which starts the selection
 };
 
 
@@ -54,7 +54,7 @@ class EDBEE_EXPORT TextMarginComponent : public QWidget
     Q_OBJECT
 
 public:
-    TextMarginComponent( TextEditorWidget* editorWidget, QWidget* parent);
+    TextMarginComponent(TextEditorWidget* editorWidget, QWidget* parent);
     virtual ~TextMarginComponent();
 
     void init();
@@ -69,14 +69,14 @@ public:
     TextRenderer* renderer() const;
 
     TextMarginComponentDelegate* delegate() const { return delegateRef_; }
-    void setDelegate( TextMarginComponentDelegate* delegate );
-    void giveDelegate( TextMarginComponentDelegate* delegate );
+    void setDelegate(TextMarginComponentDelegate* delegate);
+    void giveDelegate(TextMarginComponentDelegate* delegate);
 
 protected:
 
-    virtual void paintEvent( QPaintEvent* event );
-    virtual void renderCaretMarkers( QPainter* painter, int startLine, int endLine, int width );
-    virtual void renderLineNumber( QPainter* painter, int startLine, int endLine, int width );
+    virtual void paintEvent(QPaintEvent* event);
+    virtual void renderCaretMarkers(QPainter* painter, size_t startLine, size_t endLine, int width);
+    virtual void renderLineNumber(QPainter* painter, size_t startLine, size_t endLine, int width);
 
     virtual void mouseMoveEvent(QMouseEvent* event);
     virtual void mousePressEvent(QMouseEvent* event);
@@ -85,8 +85,8 @@ protected:
     virtual void wheelEvent(QWheelEvent* event);
 
 public:
-    virtual void updateLineAtOffset(int offset);
-    virtual void updateLine(int line, int length);
+    virtual void updateLineAtOffset(size_t offset);
+    virtual void updateLine(size_t line, size_t length);
 
 protected slots:
 
@@ -100,7 +100,7 @@ private:
     /// the width of the sidebar
     int top_;                                   ///< The first pixel that needs to been shown
     mutable int width_;
-    mutable int lastLineCount_;
+    mutable size_t lastLineCount_;
     QFont* marginFont_;                         ///< the font used for the margin
     TextEditorWidget* editorRef_;               ///< The text-editor widget
     TextMarginComponentDelegate* delegate_;     ///< The 'owned' text delegate

--- a/edbee-lib/edbee/views/textcaretcache.cpp
+++ b/edbee-lib/edbee/views/textcaretcache.cpp
@@ -15,7 +15,7 @@
 namespace edbee {
 
 /// The text document cache
-TextCaretCache::TextCaretCache(TextDocument* doc, TextRenderer* renderer )
+TextCaretCache::TextCaretCache(TextDocument* doc, TextRenderer* renderer)
     : textDocumentRef_(doc)
     , textRendererRef_(renderer)
 {
@@ -24,86 +24,80 @@ TextCaretCache::TextCaretCache(TextDocument* doc, TextRenderer* renderer )
 
 void TextCaretCache::clear()
 {
-//    qlog_info() << "[CACHE:clear]";
     xPosCache_.clear();
 }
 
-void TextCaretCache::fill( TextRangeSet& selection)
+void TextCaretCache::fill(TextRangeSet& selection)
 {
     clear();
-//    qlog_info() << "[CACHE:fill]";
-    for( int i=0,cnt=selection.rangeCount(); i<cnt; ++i ) {
+    for (size_t i = 0, cnt = selection.rangeCount(); i<cnt; ++i) {
         TextRange& range = selection.range(i);
-        add( range.caret() );
-        if( range.hasSelection() ) {
-            add( range.anchor() );
+        add(range.caret());
+        if (range.hasSelection()) {
+            add(range.anchor());
         }
     }
 //    dump();
 }
 
-/// This method replaces all cached content with the one given
+/// Replaces all cached content with the one given
 void TextCaretCache::replaceAll(TextCaretCache& cache)
 {
-//    qlog_info() << "[CACHE:replaceAll]";
     xPosCache_ = cache.xPosCache_;
-//    dump();
 }
 
 
-int TextCaretCache::xpos(int offset)
+size_t TextCaretCache::xpos(size_t offset)
 {
-//    qlog_info() << "xpos-cache: " << this->xPosCache_.size();
-//    qlog_info() << "[CACHE:xpos]" << offset << " >> " << xPosCache_.contains(offset);
 #ifdef STRICT_CHECK_ON_CACHE
-    Q_ASSERT( xPosCache_.contains(offset) );
+    Q_ASSERT(xPosCache_.contains(offset));
 #endif
 
     // when not in debug-mode fallback to calculating the position!
-    if( !xPosCache_.contains(offset) ) {
+    if (!xPosCache_.contains(offset)) {
         add(offset);
     }
     return xPosCache_.value(offset);
 }
 
+
 /// Adds an xposition for the given offset
-void TextCaretCache::add(int offset, int xpos)
+void TextCaretCache::add(size_t offset, size_t xpos)
 {
-//    qlog_info() << "[CACHE:add]" << offset<< " => " << xpos;
     xPosCache_.insert(offset,xpos);
 }
 
+
 /// Adds the given offset by calculating the position
-void TextCaretCache::add(int offset)
+void TextCaretCache::add(size_t offset)
 {
-    int line = textDocumentRef_->lineFromOffset(offset);
-    int col  = textDocumentRef_->columnFromOffsetAndLine(offset,line);
-    int xpos = textRendererRef_->xPosForColumn(line,col);
-    add( offset, xpos );
+    size_t line = textDocumentRef_->lineFromOffset(offset);
+    size_t col  = textDocumentRef_->columnFromOffsetAndLine(offset, line);
+    size_t xpos = textRendererRef_->xPosForColumn(line, col);
+    add(offset, xpos);
 }
 
-/// This method should be called if the caret moves
-void TextCaretCache::caretMovedFromOldOffsetToNewOffset(int oldOffset, int newOffset)
+/// Should be called if the caret moves
+void TextCaretCache::caretMovedFromOldOffsetToNewOffset(size_t oldOffset, size_t newOffset)
 {
-//    qlog_info() << "[CACHE:move]" << oldOffset<< " => " << newOffset << " << " << xPosCache_.contains(oldOffset);
-    Q_ASSERT( xPosCache_.contains(oldOffset) );
-    int xpos = xPosCache_.take(oldOffset);
-    xPosCache_.insert( newOffset, xpos );
-
-//    qlog_info() << " CACHE: move " << oldOffset << " to " << newOffset << " => " << xpos;
+    Q_ASSERT(xPosCache_.contains(oldOffset));
+    size_t xpos = xPosCache_.take(oldOffset);
+    xPosCache_.insert(newOffset, xpos);
 }
 
 
-/// This method checks if the cache is filled
+/// Checks if the cache is filled
 bool TextCaretCache::isFilled()
 {
     return !xPosCache_.isEmpty();
 }
 
+
 void TextCaretCache::dump()
 {
     qlog_info() << "DUMP CARET CACHE:" << xPosCache_.size();
-    foreach( int key, xPosCache_.keys() ) {
+    auto localKeys = xPosCache_.keys();
+    foreach (size_t key, localKeys) {
         qlog_info() << " - " << key << ": " << xPosCache_.value(key);
     }
 }

--- a/edbee-lib/edbee/views/textcaretcache.cpp
+++ b/edbee-lib/edbee/views/textcaretcache.cpp
@@ -30,7 +30,7 @@ void TextCaretCache::clear()
 void TextCaretCache::fill(TextRangeSet& selection)
 {
     clear();
-    for (size_t i = 0, cnt = selection.rangeCount(); i<cnt; ++i) {
+    for (size_t i = 0, cnt = selection.rangeCount(); i < cnt; ++i) {
         TextRange& range = selection.range(i);
         add(range.caret());
         if (range.hasSelection()) {
@@ -47,7 +47,7 @@ void TextCaretCache::replaceAll(TextCaretCache& cache)
 }
 
 
-size_t TextCaretCache::xpos(size_t offset)
+int TextCaretCache::xpos(size_t offset)
 {
 #ifdef STRICT_CHECK_ON_CACHE
     Q_ASSERT(xPosCache_.contains(offset));
@@ -62,9 +62,9 @@ size_t TextCaretCache::xpos(size_t offset)
 
 
 /// Adds an xposition for the given offset
-void TextCaretCache::add(size_t offset, size_t xpos)
+void TextCaretCache::add(size_t offset, int xpos)
 {
-    xPosCache_.insert(offset,xpos);
+    xPosCache_.insert(offset, xpos);
 }
 
 
@@ -73,7 +73,7 @@ void TextCaretCache::add(size_t offset)
 {
     size_t line = textDocumentRef_->lineFromOffset(offset);
     size_t col  = textDocumentRef_->columnFromOffsetAndLine(offset, line);
-    size_t xpos = textRendererRef_->xPosForColumn(line, col);
+    int xpos = textRendererRef_->xPosForColumn(line, col);
     add(offset, xpos);
 }
 
@@ -81,7 +81,7 @@ void TextCaretCache::add(size_t offset)
 void TextCaretCache::caretMovedFromOldOffsetToNewOffset(size_t oldOffset, size_t newOffset)
 {
     Q_ASSERT(xPosCache_.contains(oldOffset));
-    size_t xpos = xPosCache_.take(oldOffset);
+    int xpos = xPosCache_.take(oldOffset);
     xPosCache_.insert(newOffset, xpos);
 }
 

--- a/edbee-lib/edbee/views/textcaretcache.h
+++ b/edbee-lib/edbee/views/textcaretcache.h
@@ -24,8 +24,8 @@ public:
     void fill(TextRangeSet& selection);
     void replaceAll(TextCaretCache& cache);
 
-    size_t xpos(size_t offset);
-    void add(size_t offset, size_t xpos);
+    int xpos(size_t offset);
+    void add(size_t offset, int xpos);
     void add(size_t offset);
 
     void caretMovedFromOldOffsetToNewOffset(size_t oldOffset, size_t newOffset);
@@ -35,9 +35,9 @@ public:
 
 private:
 
-    TextDocument* textDocumentRef_;   ///< A reference to the current buffer
-    TextRenderer* textRendererRef_;   ///< A reference to the renderer
-    QHash<size_t, size_t> xPosCache_; ///< The x-pos cache
+    TextDocument* textDocumentRef_; ///< A reference to the current buffer
+    TextRenderer* textRendererRef_; ///< A reference to the renderer
+    QHash<size_t, int> xPosCache_;  ///< The x-pos cache
 };
 
 } // edbee

--- a/edbee-lib/edbee/views/textcaretcache.h
+++ b/edbee-lib/edbee/views/textcaretcache.h
@@ -18,29 +18,26 @@ class TextRangeSet;
 /// A special cache. For remembering the x-coordinates of the carets
 class EDBEE_EXPORT TextCaretCache {
 public:
-    TextCaretCache( TextDocument* doc, TextRenderer* renderer );
+    TextCaretCache( TextDocument* doc, TextRenderer* renderer);
 
     void clear();
-    void fill( TextRangeSet& selection );
-    void replaceAll( TextCaretCache& cache );
+    void fill(TextRangeSet& selection);
+    void replaceAll(TextCaretCache& cache);
 
-    int xpos( int offset );
-    void add( int offset, int xpos );
-    void add( int offset );
+    size_t xpos(size_t offset);
+    void add(size_t offset, size_t xpos);
+    void add(size_t offset);
 
-    void caretMovedFromOldOffsetToNewOffset( int oldOffset, int newOffset );
+    void caretMovedFromOldOffsetToNewOffset(size_t oldOffset, size_t newOffset);
 
     bool isFilled();
-
-
     void dump();
 
 private:
 
-    TextDocument* textDocumentRef_; ///< A reference to the current buffer
-    TextRenderer* textRendererRef_; ///< A reference to the renderer
-//    QVector<int> xPosCache_;        ///< The xpos cache for the carets
-    QHash<int,int> xPosCache_;      ///< The x-pos cache
+    TextDocument* textDocumentRef_;   ///< A reference to the current buffer
+    TextRenderer* textRendererRef_;   ///< A reference to the renderer
+    QHash<size_t, size_t> xPosCache_; ///< The x-pos cache
 };
 
 } // edbee

--- a/edbee-lib/edbee/views/textlayout.cpp
+++ b/edbee-lib/edbee/views/textlayout.cpp
@@ -96,10 +96,10 @@ void TextLayout::draw(QPainter *p, const QPointF &pos, const QVector<QTextLayout
 }
 
 
-void TextLayout::drawCursor(QPainter *painter, const QPointF &position, size_t cursorPosition, size_t width) const
+void TextLayout::drawCursor(QPainter *painter, const QPointF &position, size_t cursorPosition, int width) const
 {
     size_t virtualCursorPosition = toVirtualCursorPosition(cursorPosition);
-    qtextLayout_->drawCursor(painter, position, static_cast<int>(virtualCursorPosition), static_cast<int>(width));
+    qtextLayout_->drawCursor(painter, position, static_cast<int>(virtualCursorPosition), width);
 }
 
 

--- a/edbee-lib/edbee/views/textlayout.cpp
+++ b/edbee-lib/edbee/views/textlayout.cpp
@@ -184,7 +184,7 @@ void TextLayoutBuilder::replace(size_t index, size_t length, const QString repla
     QTextLayout::FormatRange formatRange;
     formatRange.format = format;
     formatRange.start = static_cast<int>(index);
-    formatRange.length = static_cast<qsizetype>(replacement.length());
+    formatRange.length = static_cast<int>(replacement.length());
     baseFormatRanges_.append(formatRange);
 }
 

--- a/edbee-lib/edbee/views/textlayout.h
+++ b/edbee-lib/edbee/views/textlayout.h
@@ -42,7 +42,7 @@ public:
 
 
     void draw(QPainter *p, const QPointF &pos, const QVector<QTextLayout::FormatRange> &selections = QVector<QTextLayout::FormatRange>(), const QRectF &clip = QRectF()) const;
-    void drawCursor(QPainter *painter, const QPointF &position, size_t cursorPosition, size_t width) const;
+    void drawCursor(QPainter *painter, const QPointF &position, size_t cursorPosition, int width) const;
 
     void setFormats(const QVector<QTextLayout::FormatRange> &formats);
     void setText(const QString &string);

--- a/edbee-lib/edbee/views/textlayout.h
+++ b/edbee-lib/edbee/views/textlayout.h
@@ -37,43 +37,42 @@ public:
 
     void buildLayout();
 
-    int toVirtualCursorPosition(int cursor) const;
-    int fromVirtualCursorPosition(int cursor) const;
+    size_t toVirtualCursorPosition(size_t cursor) const;
+    size_t fromVirtualCursorPosition(size_t cursor) const;
 
 
     void draw(QPainter *p, const QPointF &pos, const QVector<QTextLayout::FormatRange> &selections = QVector<QTextLayout::FormatRange>(), const QRectF &clip = QRectF()) const;
-    void drawCursor(QPainter *painter, const QPointF &position, int cursorPosition, int width) const;
+    void drawCursor(QPainter *painter, const QPointF &position, size_t cursorPosition, size_t width) const;
 
     void setFormats(const QVector<QTextLayout::FormatRange> &formats);
     void setText(const QString &string);
 
     void useSingleCharRanges();
     TextRangeSet* singleCharRanges() const;
-    void addSingleCharRange(int index, int length);
+    void addSingleCharRange(size_t index, size_t length);
 
 
     /// These calculations manipulate the cursor position. ..
     /// We assume the SOURCE character is 1... (TODO: store the orginal number of replace characters)
-    qreal cursorToX(int cursorPos, QTextLine::Edge edge = QTextLine::Leading) const;
-    int xToCursor(qreal x, QTextLine::CursorPosition cpos = QTextLine::CursorBetweenCharacters) const;
+    qreal cursorToX(size_t cursorPos, QTextLine::Edge edge = QTextLine::Leading) const;
+    size_t xToCursor(qreal x, QTextLine::CursorPosition cpos = QTextLine::CursorBetweenCharacters) const;
 
 protected:
     QTextLayout *qtextLayout_;
     TextDocument *textDocumentRef_;
-    TextRangeSet *singleCharRanges_;         ///< A list textRanges_ used by TextLayout. Every range in this list is treatet as a single character for cusor-movement etc
+    TextRangeSet *singleCharRanges_; ///< A list textRanges_ used by TextLayout. Every range in this list is treatet as a single character for cusor-movement etc
     QTextLine qtextLine_;
 };
 
 
 //=================================================
 
+
 class TextLayoutBuilder
 {
 public:
     TextLayoutBuilder(TextLayout* textLayout, QString & baseString, QVector<QTextLayout::FormatRange> & baseFormatRanges);
-
-    void replace(int index, int length, const QString replacement, QTextCharFormat format);
-
+    void replace(size_t index, size_t length, const QString replacement, QTextCharFormat format);
 
 protected:
     TextLayout* textLayoutRef_;                                ///< A reference to the textlayout

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -327,7 +327,7 @@ TextLayout *TextRenderer::textLayoutForLineForPlaceholder(size_t line)
 }
 
 
-TextLayout *TextRenderer::textLayoutForLineNormal(size_t line)
+TextLayout* TextRenderer::textLayoutForLineNormal(size_t line)
 {
     /// FIXME:  Invalide TextLayout cache when required!!!
     TextDocument* doc = textDocument();
@@ -360,7 +360,7 @@ TextLayout *TextRenderer::textLayoutForLineNormal(size_t line)
             textFormat.setBackground(Qt::red); //QBrush(QColor::red()));
             textFormat.setForeground(Qt::white); //QBrush(QColor::red()));
 
-            for (int i=0; i<text.size(); ++i) {
+            for (int i = 0; i < text.size(); ++i) {
                 QChar c = text.at(i);
                 if( isControlCharacter(c) ) {
                   QString str = QString("[U+%1]").arg(QString::number(c.unicode(),16));
@@ -381,7 +381,7 @@ TextLayout *TextRenderer::textLayoutForLineNormal(size_t line)
                   formatRange.format.setToolTip(str);
                   formatRanges.append(formatRange);
                   */
-                  textLayoutBuilder.replace(i, 1, str, textFormat);
+                  textLayoutBuilder.replace(static_cast<size_t>(i), 1, str, textFormat);
                 }
             }
         }
@@ -439,11 +439,11 @@ void TextRenderer::renderBegin(const QRect& rect)
     int yPos = y + rect.height();
     Q_ASSERT(yPos >= 0);
 
-    size_t calculatedEndLine = rawLineIndexForYpos(static_cast<size_t>(yPos)) + 1;   // add 1 line extra (for half visible lines)
+    size_t calculatedEndLine = rawLineIndexForYpos(yPos) + 1;   // add 1 line extra (for half visible lines)
 
     // assign the 'work' variables
     size_t lineCount = doc->lineCount();
-    startLine_   = qBound(0u, rawLineIndexForYpos(static_cast<size_t>(y)), lineCount - 1);
+    startLine_   = qBound(0u, rawLineIndexForYpos(y), lineCount - 1);
     endLine_     = qBound(0u, calculatedEndLine, lineCount - 1 );
 
     Q_ASSERT( startLine_ <= endLine_ );

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -11,7 +11,7 @@
 #include <QTextLayout>
 
 #include "edbee/models/textlinedata.h"
-#include "edbee/util/simpleprofiler.h"
+//#include "edbee/util/simpleprofiler.h"
 
 #include "edbee/models/chardocument/chartextdocument.h"
 #include "edbee/models/textdocument.h"
@@ -79,25 +79,26 @@ void TextRenderer::reset()
 
 
 /// This method returns the (maximum) line-height in pixels
-size_t TextRenderer::lineHeight()
+int TextRenderer::lineHeight()
 {
     QFontMetrics fm = textWidget()->fontMetrics();
-    return static_cast<size_t>(fm.ascent() + fm.descent() + fm.leading() + config()->extraLineSpacing()); // (the 1 is for the base line).
+    return fm.ascent() + fm.descent() + fm.leading() + config()->extraLineSpacing(); // (the 1 is for the base line).
 }
 
 
 /// This method converts the give y position to a line index
 /// Warning this returns a RAW line index, which means it can be an invalid line
 /// @param y the y position
-size_t TextRenderer::rawLineIndexForYpos(size_t y)
+size_t TextRenderer::rawLineIndexForYpos(int y)
 {
-    return y / lineHeight();
+    Q_ASSERT(y >= 0);
+    return static_cast<size_t>(y / lineHeight());
 }
 
 
 /// This method returns a valid line index for the given y-pos
 /// If the y-position isn't on a line it returns std::string::npos
-size_t TextRenderer::lineIndexForYpos(size_t y)
+size_t TextRenderer::lineIndexForYpos(int y)
 {
     size_t line = rawLineIndexForYpos(y);
     if(line >= textDocument()->lineCount()) return std::string::npos;
@@ -136,9 +137,9 @@ int TextRenderer::totalWidth()
 
 
 /// This method returns the total height
-size_t TextRenderer::totalHeight()
+int TextRenderer::totalHeight()
 {
-    return textDocument()->lineCount() * lineHeight() + lineHeight();
+    return static_cast<int>(textDocument()->lineCount()) * lineHeight() + lineHeight();
 }
 
 
@@ -162,7 +163,7 @@ size_t TextRenderer::viewHeightInLines()
 {
     ptrdiff_t height = viewportHeight();
     Q_ASSERT(height >= 0);
-    size_t result = static_cast<size_t>(viewportHeight()) / lineHeight() - 1;
+    size_t result = static_cast<size_t>(viewportHeight()) / static_cast<size_t>(lineHeight()) - 1;
     return result;
 }
 
@@ -172,12 +173,12 @@ size_t TextRenderer::firstVisibleLine()
 {
     if (viewportY() < 0) return 0;
     size_t y = static_cast<size_t>(viewportY());
-    return y / lineHeight();
+    return y / static_cast<size_t>(lineHeight());
 }
 
 
 /// Returns the (closet) valid column for the given x-position
-size_t TextRenderer::columnIndexForXpos(size_t line, size_t x )
+size_t TextRenderer::columnIndexForXpos(size_t line, int x )
 {
     TextLayout* layout = textLayoutForLine(line);
     if (!layout) return 0;
@@ -187,22 +188,22 @@ size_t TextRenderer::columnIndexForXpos(size_t line, size_t x )
 
 
 /// Returns the x position for the given column
-size_t TextRenderer::xPosForColumn(size_t line, size_t column)
+int TextRenderer::xPosForColumn(size_t line, size_t column)
 {
     TextLayout* layout = textLayoutForLine(line);
     qreal x = 0;
     if (layout) {
         x += layout->cursorToX(column);
     }
-    return static_cast<size_t>(qRound(x));
+    return qRound(x);
 }
 
 
 /// Returns the x-coordinate for the given offset
-size_t TextRenderer::xPosForOffset(size_t offset)
+int TextRenderer::xPosForOffset(size_t offset)
 {
     size_t line = textDocument()->lineFromOffset(offset);
-    size_t x = 0;
+    int x = 0;
 
     size_t lineStartOffset = textDocument()->offsetFromLine(line);
     size_t col = offset - lineStartOffset;
@@ -212,14 +213,14 @@ size_t TextRenderer::xPosForOffset(size_t offset)
 
 
 /// Returns the y position for the given line
-size_t TextRenderer::yPosForLine(size_t line)
+int TextRenderer::yPosForLine(size_t line)
 {
-    return line * lineHeight();
+    return static_cast<int>(line) * lineHeight();
 }
 
 
 /// Returns the offset position for the given line
-size_t TextRenderer::yPosForOffset(size_t offset)
+int TextRenderer::yPosForOffset(size_t offset)
 {
     size_t line = textDocument()->lineFromOffset(offset);
     return yPosForLine(line);

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -389,7 +389,11 @@ TextLayout* TextRenderer::textLayoutForLineNormal(size_t line)
         // append some extra formatting (if available)
         edbee::LineAppendTextLayoutFormatListData* formatRangeLineData = dynamic_cast<edbee::LineAppendTextLayoutFormatListData*>(textDocument()->getLineData(line, edbee::LineAppendTextLayoutFormatListField));
         if (formatRangeLineData) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             formatRanges.append(formatRangeLineData->value());
+#else
+            formatRanges.append(formatRangeLineData->value().toVector());
+#endif
         }
 
         textLayout->setFormats(formatRanges);
@@ -443,8 +447,8 @@ void TextRenderer::renderBegin(const QRect& rect)
 
     // assign the 'work' variables
     size_t lineCount = doc->lineCount();
-    startLine_   = qBound(0u, rawLineIndexForYpos(y), lineCount - 1);
-    endLine_     = qBound(0u, calculatedEndLine, lineCount - 1 );
+    startLine_   = qBound(static_cast<size_t>(0u), rawLineIndexForYpos(y), lineCount - 1);
+    endLine_     = qBound(static_cast<size_t>(0u), calculatedEndLine, lineCount - 1 );
 
     Q_ASSERT( startLine_ <= endLine_ );
     startOffset_ = doc->offsetFromLine(startLine_);

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -31,7 +31,6 @@
 
 namespace edbee {
 
-
 /// The default textrenderer constructor
 TextRenderer::TextRenderer(TextEditorController* controller)
     : QObject(nullptr)
@@ -45,9 +44,9 @@ TextRenderer::TextRenderer(TextEditorController* controller)
     , endOffset_(0)
     , startLine_(0)
     , endLine_(0)
-    , placeHolderDocument_(0)
+    , placeHolderDocument_(nullptr)
 {
-    connect( controller, SIGNAL(textDocumentChanged(edbee::TextDocument*,edbee::TextDocument*)), this, SLOT(textDocumentChanged(edbee::TextDocument*,edbee::TextDocument*)));
+    connect(controller, SIGNAL(textDocumentChanged(edbee::TextDocument*,edbee::TextDocument*)), this, SLOT(textDocumentChanged(edbee::TextDocument*,edbee::TextDocument*)));
     textThemeStyler_ = new TextThemeStyler(controller);
     placeHolderDocument_ = new CharTextDocument();
 }
@@ -80,30 +79,28 @@ void TextRenderer::reset()
 
 
 /// This method returns the (maximum) line-height in pixels
-int TextRenderer::lineHeight()
+size_t TextRenderer::lineHeight()
 {
-
-/// TODO: cache the height :-)
     QFontMetrics fm = textWidget()->fontMetrics();
-    return fm.ascent() + fm.descent() + fm.leading() + config()->extraLineSpacing(); // (the 1 is for the base line).
+    return static_cast<size_t>(fm.ascent() + fm.descent() + fm.leading() + config()->extraLineSpacing()); // (the 1 is for the base line).
 }
 
 
 /// This method converts the give y position to a line index
 /// Warning this returns a RAW line index, which means it can be an invalid line
 /// @param y the y position
-int TextRenderer::rawLineIndexForYpos(int y)
+size_t TextRenderer::rawLineIndexForYpos(size_t y)
 {
     return y / lineHeight();
 }
 
 
 /// This method returns a valid line index for the given y-pos
-/// If the y-position isn't on a line it returns a value < 0
-int TextRenderer::lineIndexForYpos(int y)
+/// If the y-position isn't on a line it returns std::string::npos
+size_t TextRenderer::lineIndexForYpos(size_t y)
 {
-    int line = rawLineIndexForYpos(y);
-    if( line >= textDocument()->lineCount() ) return -1;
+    size_t line = rawLineIndexForYpos(y);
+    if(line >= textDocument()->lineCount()) return std::string::npos;
     return line;
 }
 
@@ -112,12 +109,11 @@ int TextRenderer::lineIndexForYpos(int y)
 /// This method takes the maximum line length and multiplies it with the widest character.
 int TextRenderer::totalWidth()
 {
-    if( !totalWidthCache_ ) {
-        for( int line=0,cnt=textDocument()->lineCount(); line<cnt; ++line ) {
-            TextLayout* layout = textLayoutForLine( line );
-            totalWidthCache_ = qMax( qRound(layout->boundingRect().right()+0.5), totalWidthCache_ );
+    if (!totalWidthCache_) {
+        for (size_t line = 0, cnt = textDocument()->lineCount(); line < cnt; ++line) {
+            TextLayout* layout = textLayoutForLine(line);
+            totalWidthCache_ = qMax(qRound(layout->boundingRect().right() + 0.5), totalWidthCache_);
         }
-
     }
     return totalWidthCache_;
 
@@ -201,39 +197,37 @@ int TextRenderer::xPosForColumn(int line, int column)
 
 
 /// This method returns the x-coordinate for the given offset
-int TextRenderer::xPosForOffset(int offset)
+size_t TextRenderer::xPosForOffset(size_t offset)
 {
-    int line = textDocument()->lineFromOffset(offset);
-    int x = 0;
-    if( line >= 0 )
-    {
-        int lineStartOffset = textDocument()->offsetFromLine(line);
-        int col = offset - lineStartOffset;
-        x += xPosForColumn( line, col );
-    }
+    size_t line = textDocument()->lineFromOffset(offset);
+    size_t x = 0;
+
+    size_t lineStartOffset = textDocument()->offsetFromLine(line);
+    size_t col = offset - lineStartOffset;
+    x += xPosForColumn(line, col);
     return x;
 }
 
 
-/// This method returns the y position for the given line
-int TextRenderer::yPosForLine(int line)
+/// Returns the y position for the given line
+size_t TextRenderer::yPosForLine(size_t line)
 {
     return line * lineHeight();
 }
 
 
-/// This method returns the offset position for the given line
-int TextRenderer::yPosForOffset(int offset)
+/// Returns the offset position for the given line
+size_t TextRenderer::yPosForOffset(size_t offset)
 {
-    int line = textDocument()->lineFromOffset(offset);
+    size_t line = textDocument()->lineFromOffset(offset);
     return yPosForLine(line);
 }
 
-/// This method returns the textlayout for the given line
-TextLayout *TextRenderer::textLayoutForLine(int line)
+/// Returns the textlayout for the given line
+TextLayout *TextRenderer::textLayoutForLine(size_t line)
 {
-    Q_ASSERT( line >= 0 );
-/// FIXME:  Invalide TextLayout cache when required!!!
+    Q_ASSERT(line >= 0);
+    /// FIXME:  Invalide TextLayout cache when required!!!
     if( controller()->textDocument()->length() == 0){
         return textLayoutForLineForPlaceholder(line);
     } else {
@@ -279,28 +273,26 @@ static bool isControlCharacter(QChar charCode)
  }
 
 
-TextLayout *TextRenderer::textLayoutForLineForPlaceholder(int line)
+TextLayout *TextRenderer::textLayoutForLineForPlaceholder(size_t line)
 {
-    Q_ASSERT( line >= 0 );
-/// FIXME:  Invalide TextLayout cache when required!!!
-
+    /// FIXME:  Invalide TextLayout cache when required!!!
     TextDocument* doc = textDocument();
-    if( line >= doc->lineCount() ) return nullptr;
+    if (line >= doc->lineCount()) return nullptr;
 
     TextLayout* textLayout = cachedTextLayoutList_.object(line);
-    if( !textLayout ) {
+    if (!textLayout) {
         textLayout = new TextLayout(textDocument());
         textLayout->setCacheEnabled(true);
         int tabWidth = controllerRef_->widget()->fontMetrics().horizontalAdvance('M');
 
         QTextOption option;
         option.setTabStopDistance(config()->indentSize() * tabWidth);
-        if( config()->showWhitespaceMode() == TextEditorConfig::ShowWhitespaces ) {
-            option.setFlags( QTextOption::ShowTabsAndSpaces );        /// TODO: Make an option to show spaces and tabs
+        if (config()->showWhitespaceMode() == TextEditorConfig::ShowWhitespaces) {
+            option.setFlags( QTextOption::ShowTabsAndSpaces );  /// TODO: Make an option to show spaces and tabs
         }
 
-        textLayout->qTextLayout()->setFont( textWidget()->font() );
-        textLayout->qTextLayout()->setTextOption( option );
+        textLayout->qTextLayout()->setFont(textWidget()->font());
+        textLayout->qTextLayout()->setTextOption(option);
 
         // add extra format (no format)
         QTextCharFormat format;
@@ -309,13 +301,12 @@ TextLayout *TextRenderer::textLayoutForLineForPlaceholder(int line)
         color.setAlpha(180);
         format.setForeground(color);
 
-
         QString text = doc->lineWithoutNewline(line);
 
         QVector<QTextLayout::FormatRange> formatRanges;
         QTextLayout::FormatRange formatRange;
         formatRange.start = 0;
-        formatRange.length = text.length();
+        formatRange.length = static_cast<int>(text.length());
         formatRange.format = format;
         formatRanges.append(formatRange);
 
@@ -324,27 +315,23 @@ TextLayout *TextRenderer::textLayoutForLineForPlaceholder(int line)
         textLayout->buildLayout();
 
         // update the width cache
-        totalWidthCache_ = qMax( totalWidthCache_, qRound(textLayout->boundingRect().width()+0.5));
+        totalWidthCache_ = qMax(totalWidthCache_, qRound(textLayout->boundingRect().width() + 0.5));
 
         // add to the cache
-        cachedTextLayoutList_.insert( line, textLayout );
-//qlog_info() << "Cache Line: " << line;
-
+        cachedTextLayoutList_.insert(line, textLayout);
     }
     return textLayout;
 }
 
 
-TextLayout *TextRenderer::textLayoutForLineNormal(int line)
+TextLayout *TextRenderer::textLayoutForLineNormal(size_t line)
 {
-    Q_ASSERT( line >= 0 );
-/// FIXME:  Invalide TextLayout cache when required!!!
-
+    /// FIXME:  Invalide TextLayout cache when required!!!
     TextDocument* doc = textDocument();
-    if( line >= doc->lineCount() ) return nullptr;
+    if (line >= doc->lineCount()) return nullptr;
 
     TextLayout* textLayout = cachedTextLayoutList_.object(line);
-    if( !textLayout ) {
+    if (!textLayout) {
         textLayout = new TextLayout(textDocument());
         textLayout->setCacheEnabled(true);
         int tabWidth = controllerRef_->widget()->fontMetrics().horizontalAdvance('M');
@@ -352,12 +339,11 @@ TextLayout *TextRenderer::textLayoutForLineNormal(int line)
         QTextOption option;
         option.setTabStopDistance(config()->indentSize() * tabWidth);
 
-        if( config()->showWhitespaceMode() == TextEditorConfig::ShowWhitespaces ) {
-            option.setFlags( QTextOption::ShowTabsAndSpaces );        /// TODO: Make an option to show spaces and tabs
+        if (config()->showWhitespaceMode() == TextEditorConfig::ShowWhitespaces) {
+            option.setFlags( QTextOption::ShowTabsAndSpaces ); /// TODO: Make an option to show spaces and tabs
         }
 
         textLayout->qTextLayout()->setFont( textWidget()->font() );
-        //qlog_info() << "font: " <<   textWidget()->font().pointSizeF();
         textLayout->qTextLayout()->setTextOption( option );
 
         // add extra format
@@ -366,16 +352,14 @@ TextLayout *TextRenderer::textLayoutForLineNormal(int line)
 
         TextLayoutBuilder textLayoutBuilder(textLayout, text, formatRanges);
 
-        if( config()->renderBidiContolCharacters() ) {
-
+        if (config()->renderBidiContolCharacters()) {
             QTextCharFormat textFormat;
             textFormat.setBackground(Qt::red); //QBrush(QColor::red()));
             textFormat.setForeground(Qt::white); //QBrush(QColor::red()));
 
-            for( int i=0; i<text.size(); ++i ) {
+            for (int i=0; i<text.size(); ++i) {
                 QChar c = text.at(i);
                 if( isControlCharacter(c) ) {
-
                   QString str = QString("[U+%1]").arg(QString::number(c.unicode(),16));
                   //QString newString = "⚠️";
                   // text.replace(i, 1, str);
@@ -395,7 +379,6 @@ TextLayout *TextRenderer::textLayoutForLineNormal(int line)
                   formatRanges.append(formatRange);
                   */
                   textLayoutBuilder.replace(i, 1, str, textFormat);
-
                 }
             }
         }
@@ -427,70 +410,61 @@ TextLayout *TextRenderer::textLayoutForLineNormal(int line)
             }
         }
 #endif
-
-
-
-        textLayout->setText( text );
+        textLayout->setText(text);
         textLayout->buildLayout();
 
         // update the width cache
-        totalWidthCache_ = qMax( totalWidthCache_, qRound(textLayout->boundingRect().width()+0.5));
+        totalWidthCache_ = qMax(totalWidthCache_, qRound(textLayout->boundingRect().width() + 0.5));
 
         // add to the cache
-        cachedTextLayoutList_.insert( line, textLayout );
-
-//qlog_info() << "Cache Line: " << line;
-
+        cachedTextLayoutList_.insert(line, textLayout);
     }
     return textLayout;
 }
 
 
 /// This method starts rendering
-void TextRenderer::renderBegin( const QRect& rect )
+void TextRenderer::renderBegin(const QRect& rect)
 {
-
-//PROF_BEGIN
     TextDocument* doc = textDocument();
 
     clipRectRef_ = &rect;
 
-    int y = rect.y();
-
     // the first line to render
-    int calculatedEndLine = rawLineIndexForYpos( y + rect.height() ) + 1;   // add 1 line extra (for half visible lines)
+    int y = rect.y();
+    Q_ASSERT(y >= 0);
+    int yPos = y + rect.height();
+    Q_ASSERT(yPos >= 0);
+
+    size_t calculatedEndLine = rawLineIndexForYpos(static_cast<size_t>(yPos)) + 1;   // add 1 line extra (for half visible lines)
 
     // assign the 'work' variables
-    int lineCount = doc->lineCount();
-    startLine_   = qBound( 0, rawLineIndexForYpos( y ), lineCount-1 );
-    endLine_     = qBound( 0, calculatedEndLine, lineCount-1 );
+    size_t lineCount = doc->lineCount();
+    startLine_   = qBound(0u, rawLineIndexForYpos(static_cast<size_t>(y)), lineCount - 1);
+    endLine_     = qBound(0u, calculatedEndLine, lineCount - 1 );
 
     Q_ASSERT( startLine_ <= endLine_ );
-
-//    qlog_info() << ">> render startLine" << startLine_ << " t/m endLine=" << endLine_  << "  ==> " << ( endLine_ - startLine_ ) << " y="<<y<<",height="<<rect.height()<<"-------------------" ;
     startOffset_ = doc->offsetFromLine(startLine_);
-    endOffset_   = doc->offsetFromLine(endLine_+1);
-
+    endOffset_   = doc->offsetFromLine(endLine_ + 1);
 
     // Make sure  the cache-data is filled
-//PROF_BEGIN_NAMED("layouts")
-    for( int line = startLine_; line <= endLine_; ++line  ) {
-        textLayoutForLine( line );  // make sure the cache is filled
+    //PROF_BEGIN_NAMED("layouts")
+    for (size_t line = startLine_; line <= endLine_; ++line) {
+        textLayoutForLine(line);  // make sure the cache is filled
     }
-//PROF_END
+    //PROF_END
 
-/// TODO: move this lexing stuff to the controller
+    /// TODO: move this lexing stuff to the controller
     // prepare the style
-    if( textDocument()->textLexer() ) {
-//PROF_BEGIN_NAMED("lexer")
-        textDocument()->textLexer()->lexRange( startOffset_, endOffset_ );
-//PROF_END
+    if (textDocument()->textLexer()) {
+        //PROF_BEGIN_NAMED("lexer")
+        textDocument()->textLexer()->lexRange(startOffset_, endOffset_);
+        //PROF_END
     }
-
 }
 
 /// This method starts rendering
-void TextRenderer::renderEnd( const QRect& rect )
+void TextRenderer::renderEnd(const QRect& rect)
 {
     Q_UNUSED(rect)
 }
@@ -499,7 +473,7 @@ void TextRenderer::renderEnd( const QRect& rect )
 /// This method returns the document
 TextDocument* TextRenderer::textDocument()
 {
-    if( controllerRef_->textDocument()->length() == 0 ){
+    if (controllerRef_->textDocument()->length() == 0){
         // return placeholder textdocument
         return placeHolderDocument_;
     }
@@ -550,7 +524,7 @@ void TextRenderer::setViewport(const QRect& viewport)
 /// sets the caret time on 0
 void TextRenderer::resetCaretTime()
 {
-    if( caretTime_ >= 0 ) {
+    if (caretTime_ >= 0) {
         caretTime_ = QDateTime::currentMSecsSinceEpoch();
     }
 }
@@ -559,8 +533,8 @@ void TextRenderer::resetCaretTime()
 /// this method returns true if the caret is visible
 bool TextRenderer::shouldRenderCaret()
 {
-    if( caretTime_ < 0 ) { return false; }
-    if( !caretBlinkRate_ ) { return true; }
+    if (caretTime_ < 0) { return false; }
+    if (!caretBlinkRate_) { return true; }
     qint64 time = QDateTime::currentMSecsSinceEpoch() - caretTime_;
     return (time % caretBlinkRate_) < (caretBlinkRate_>> 1);
 }
@@ -607,7 +581,7 @@ void TextRenderer::setThemeByName(const QString& name)
 /// @param theme the them to set
 void TextRenderer::setTheme(TextTheme* theme)
 {
-    textThemeStyler_->setTheme( theme );
+    textThemeStyler_->setTheme(theme);
     invalidateCaches();
     emit themeChanged(theme);
 }
@@ -632,20 +606,19 @@ void TextRenderer::textDocumentChanged(edbee::TextDocument *oldDocument, edbee::
 void TextRenderer::textChanged(edbee::TextBufferChange change, QString oldText)
 {
     Q_UNUSED(oldText)
-    int lineCount = qMax( change.lineCount(), change.newLineCount()) + 1;
+    size_t lineCount = qMax(change.lineCount(), change.newLineCount()) + 1;
 
     // Unfortunately when the line-count is changed we need to invalidate all
     // because we cannot move the cached layouts easy in the layout list
-    if( change.lineCount() - change.newLineCount() ) {
+    if (change.lineCount() - change.newLineCount()) {
         cachedTextLayoutList_.clear();
     } else {
-
         // invalidate all if there are to many lines
-        if( lineCount > cachedTextLayoutList_.size()/2 ) {
+        if (lineCount > static_cast<size_t>(cachedTextLayoutList_.size()) / 2) {
             cachedTextLayoutList_.clear();
         } else {
-            for( int i=0,cnt=lineCount; i<cnt; ++i ) {
-                cachedTextLayoutList_.remove( change.line() + i );
+            for(size_t i = 0, cnt = lineCount; i < cnt; ++i) {
+                cachedTextLayoutList_.remove(change.line() + i);
             }
         }
     }
@@ -656,19 +629,18 @@ void TextRenderer::textChanged(edbee::TextBufferChange change, QString oldText)
 void TextRenderer::lastScopedOffsetChanged(size_t previousOffset, size_t newOffset)
 {
     Q_UNUSED(newOffset)
-    int lastValidLine = textDocument()->lineFromOffset(previousOffset);
+    size_t lastValidLine = textDocument()->lineFromOffset(previousOffset);
     invalidateTextLayoutCaches(lastValidLine);
 }
 
 
 /// Invalidates the QTextLayout caches
-void TextRenderer::invalidateTextLayoutCaches(int fromLine)
+void TextRenderer::invalidateTextLayoutCaches(size_t fromLine)
 {
-//qlog_info() << "** invalidateTextLayoutCache("<<fromLine<<") **";
-    if( fromLine ) {
-        QList<int> keys = cachedTextLayoutList_.keys();
-        foreach( int key, keys ) {
-            if( key >= fromLine) {
+    if (fromLine) {
+        QList<size_t> keys = cachedTextLayoutList_.keys();
+        foreach (size_t key, keys) {
+            if (key >= fromLine) {
                 cachedTextLayoutList_.remove(key);
             }
         }

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -136,7 +136,7 @@ int TextRenderer::totalWidth()
 
 
 /// This method returns the total height
-int TextRenderer::totalHeight()
+size_t TextRenderer::totalHeight()
 {
     return textDocument()->lineCount() * lineHeight() + lineHeight();
 }
@@ -157,46 +157,48 @@ int TextRenderer::nrWidth()
 }
 
 
-/// This method returns the number of lines
-int TextRenderer::viewHeightInLines()
+/// Returns the number of lines
+size_t TextRenderer::viewHeightInLines()
 {
-    int result = viewportHeight() / lineHeight() -1;
+    ptrdiff_t height = viewportHeight();
+    Q_ASSERT(height >= 0);
+    size_t result = static_cast<size_t>(viewportHeight()) / lineHeight() - 1;
     return result;
 }
 
 
-/// This method returns the first visible line
-int TextRenderer::firstVisibleLine()
+/// Returns the first visible line
+size_t TextRenderer::firstVisibleLine()
 {
-    return viewportY() / lineHeight();
+    if (viewportY() < 0) return 0;
+    size_t y = static_cast<size_t>(viewportY());
+    return y / lineHeight();
 }
 
 
-/// This method returns the (closet) valid column for the given x-position
-int TextRenderer::columnIndexForXpos(int line, int x )
+/// Returns the (closet) valid column for the given x-position
+size_t TextRenderer::columnIndexForXpos(size_t line, size_t x )
 {
-    TextLayout* layout = textLayoutForLine( line );
-    if(!layout) return 0;
+    TextLayout* layout = textLayoutForLine(line);
+    if (!layout) return 0;
 
-    //x -= sideBarLeftWidth();
-
-    return layout->xToCursor( x );
+    return layout->xToCursor(static_cast<qreal>(x));
 }
 
 
-/// This method returns the x position for the given column
-int TextRenderer::xPosForColumn(int line, int column)
+/// Returns the x position for the given column
+size_t TextRenderer::xPosForColumn(size_t line, size_t column)
 {
-    TextLayout* layout = textLayoutForLine( line );
-    qreal x = 0;// sideBarLeftWidth();
-    if(layout) {
+    TextLayout* layout = textLayoutForLine(line);
+    qreal x = 0;
+    if (layout) {
         x += layout->cursorToX(column);
     }
-    return qRound(x);
+    return static_cast<size_t>(qRound(x));
 }
 
 
-/// This method returns the x-coordinate for the given offset
+/// Returns the x-coordinate for the given offset
 size_t TextRenderer::xPosForOffset(size_t offset)
 {
     size_t line = textDocument()->lineFromOffset(offset);

--- a/edbee-lib/edbee/views/textrenderer.cpp
+++ b/edbee-lib/edbee/views/textrenderer.cpp
@@ -623,8 +623,8 @@ void TextRenderer::textDocumentChanged(edbee::TextDocument *oldDocument, edbee::
     reset();
 
     // connect with the new dpcument
-    connect( newDocument, SIGNAL(textChanged(edbee::TextBufferChange, QString)), this, SLOT(textChanged(edbee::TextBufferChange, QString)));
-    connect( newDocument, SIGNAL(lastScopedOffsetChanged(int,int)), this, SLOT(lastScopedOffsetChanged(int,int)) );
+    connect(newDocument, SIGNAL(textChanged(edbee::TextBufferChange,QString)), this, SLOT(textChanged(edbee::TextBufferChange,QString)));
+    connect(newDocument, SIGNAL(lastScopedOffsetChanged(size_t,size_t)), this, SLOT(lastScopedOffsetChanged(size_t,size_t)));
 }
 
 
@@ -653,13 +653,11 @@ void TextRenderer::textChanged(edbee::TextBufferChange change, QString oldText)
 
 
 /// The scoped to offset has been changed
-void TextRenderer::lastScopedOffsetChanged(int previousOffset, int newOffset)
+void TextRenderer::lastScopedOffsetChanged(size_t previousOffset, size_t newOffset)
 {
-//qlog_info() << "** lastScopedOffsetChanged("<<previousOffset<<","<<newOffset<<") **";
     Q_UNUSED(newOffset)
     int lastValidLine = textDocument()->lineFromOffset(previousOffset);
-    invalidateTextLayoutCaches( lastValidLine );
-        //    textWidget()->fullUpdate();
+    invalidateTextLayoutCaches(lastValidLine);
 }
 
 

--- a/edbee-lib/edbee/views/textrenderer.h
+++ b/edbee-lib/edbee/views/textrenderer.h
@@ -42,9 +42,9 @@ public:
     virtual void reset();
 
 // calculation functions
-    int lineHeight();
-    int rawLineIndexForYpos( int y );
-    int lineIndexForYpos( int y );
+    size_t lineHeight();
+    size_t rawLineIndexForYpos(size_t y);
+    size_t lineIndexForYpos(size_t y);
     int totalWidth();
     int totalHeight();
     int emWidth();
@@ -54,18 +54,18 @@ public:
 
     int columnIndexForXpos( int line, int x );
     int xPosForColumn( int line, int column );
-    int xPosForOffset( int offset );
-    int yPosForLine( int line );
-    int yPosForOffset( int offset );
+    size_t xPosForOffset(size_t offset);
+    size_t yPosForLine(size_t line);
+    size_t yPosForOffset(size_t offset);
 
 // Document access functions (Document vs Placeholder text)
     int lineCount();
     QString getLine(int index);
 
 // caching
-    TextLayout* textLayoutForLine( int line );
-    TextLayout* textLayoutForLineForPlaceholder( int line );
-    TextLayout* textLayoutForLineNormal( int line );
+    TextLayout* textLayoutForLine(size_t line);
+    TextLayout* textLayoutForLineForPlaceholder(size_t line);
+    TextLayout* textLayoutForLineNormal(size_t line);
 
 // rendering
     void renderBegin(const QRect& rect );
@@ -101,14 +101,14 @@ public:
     void setTheme( TextTheme* theme );
 
 // temporary getters only valid while rendering!!
-    const QRect* clipRect() { return clipRectRef_; }                ///< This method is valid only while rendering!
-    int startOffset() { return startOffset_; }                      ///< This method is valid only while rendering!
-    int endOffset() { return endOffset_; }                          ///< This method is valid only while rendering!
-    int startLine() { return startLine_; }                          ///< This method is valid only while rendering!
-    int endLine() { return endLine_; }                              ///< This method is valid only while rendering!
+    const QRect* clipRect() { return clipRectRef_; } ///< This method is valid only while rendering!
+    size_t startOffset() { return startOffset_; }  ///< This method is valid only while rendering!
+    size_t endOffset() { return endOffset_; }      ///< This method is valid only while rendering!
+    size_t startLine() { return startLine_; }      ///< This method is valid only while rendering!
+    size_t endLine() { return endLine_; }          ///< This method is valid only while rendering!
 
 private:
-    void updateWidthCacheForRange( int offset, int length );
+    void updateWidthCacheForRange(int offset, int length);
 
 protected slots:
 
@@ -119,7 +119,7 @@ protected slots:
 
 public slots:
 
-    void invalidateTextLayoutCaches(int fromLine=0);
+    void invalidateTextLayoutCaches(size_t fromLine = 0);
     void invalidateCaches();
 
 signals:
@@ -128,23 +128,23 @@ signals:
 
 private:
 
-    TextEditorController* controllerRef_;    ///< A reference to the widget it is rendering
+    TextEditorController* controllerRef_;   ///< A reference to the widget it is rendering
     qint64 caretTime_;                      ///< The current time of the caret. -1 means that the caret is disabled
     qint64 caretBlinkRate_;                 ///< The caret blink rate
 
-    QCache<int,TextLayout> cachedTextLayoutList_;   ///< A list of cached text layouts
+    QCache<size_t, TextLayout> cachedTextLayoutList_;   ///< A list of cached text layouts
 
-    QRect viewport_;                                ///< The current (total) viewport. (This is updated from the window)
-    int totalWidthCache_;                           ///< The total width cache
+    QRect viewport_;                    ///< The current (total) viewport. (This is updated from the window)
+    int totalWidthCache_;               ///< The total width cache
 
-    TextThemeStyler* textThemeStyler_;              ///< The current theme styler
+    TextThemeStyler* textThemeStyler_;  ///< The current theme styler
 
     // temporary variables only valid the int the current context
-    const QRect* clipRectRef_;                ///< A reference to the clipping rectangle
-    int startOffset_;                         ///< The start offset that needs rendering
-    int endOffset_;                           ///< The end opffset that needs rendering
-    int startLine_;                           ///< The first line that needs rendering
-    int endLine_;                             ///< The last line that needs rendering
+    const QRect* clipRectRef_; ///< A reference to the clipping rectangle
+    size_t startOffset_;       ///< The start offset that needs rendering
+    size_t endOffset_;         ///< The end opffset that needs rendering
+    size_t startLine_;         ///< The first line that needs rendering
+    size_t endLine_;           ///< The last line that needs rendering
 
     TextDocument* placeHolderDocument_;
 };

--- a/edbee-lib/edbee/views/textrenderer.h
+++ b/edbee-lib/edbee/views/textrenderer.h
@@ -46,21 +46,17 @@ public:
     size_t rawLineIndexForYpos(size_t y);
     size_t lineIndexForYpos(size_t y);
     int totalWidth();
-    int totalHeight();
+    size_t totalHeight();
     int emWidth();
     int nrWidth();
-    int viewHeightInLines();
-    int firstVisibleLine();
+    size_t viewHeightInLines();
+    size_t firstVisibleLine();
 
-    int columnIndexForXpos( int line, int x );
-    int xPosForColumn( int line, int column );
+    size_t columnIndexForXpos(size_t line, size_t x);
+    size_t xPosForColumn(size_t line, size_t column);
     size_t xPosForOffset(size_t offset);
     size_t yPosForLine(size_t line);
     size_t yPosForOffset(size_t offset);
-
-// Document access functions (Document vs Placeholder text)
-    int lineCount();
-    QString getLine(int index);
 
 // caching
     TextLayout* textLayoutForLine(size_t line);
@@ -135,7 +131,7 @@ private:
     QCache<size_t, TextLayout> cachedTextLayoutList_;   ///< A list of cached text layouts
 
     QRect viewport_;                    ///< The current (total) viewport. (This is updated from the window)
-    int totalWidthCache_;               ///< The total width cache
+    int totalWidthCache_;            ///< The total width cache
 
     TextThemeStyler* textThemeStyler_;  ///< The current theme styler
 

--- a/edbee-lib/edbee/views/textrenderer.h
+++ b/edbee-lib/edbee/views/textrenderer.h
@@ -42,21 +42,21 @@ public:
     virtual void reset();
 
 // calculation functions
-    size_t lineHeight();
-    size_t rawLineIndexForYpos(size_t y);
-    size_t lineIndexForYpos(size_t y);
+    int lineHeight();
+    size_t rawLineIndexForYpos(int y);
+    size_t lineIndexForYpos(int y);
     int totalWidth();
-    size_t totalHeight();
+    int totalHeight();
     int emWidth();
     int nrWidth();
     size_t viewHeightInLines();
     size_t firstVisibleLine();
 
-    size_t columnIndexForXpos(size_t line, size_t x);
-    size_t xPosForColumn(size_t line, size_t column);
-    size_t xPosForOffset(size_t offset);
-    size_t yPosForLine(size_t line);
-    size_t yPosForOffset(size_t offset);
+    size_t columnIndexForXpos(size_t line, int x);
+    int xPosForColumn(size_t line, size_t column);
+    int xPosForOffset(size_t offset);
+    int yPosForLine(size_t line);
+    int yPosForOffset(size_t offset);
 
 // caching
     TextLayout* textLayoutForLine(size_t line);
@@ -75,7 +75,7 @@ public:
     TextEditorController* controller();
     TextEditorWidget* textWidget();
 
-    void setViewport( const QRect& viewport );
+    void setViewport(const QRect& viewport);
 
     void resetCaretTime();
     bool shouldRenderCaret();

--- a/edbee-lib/edbee/views/textrenderer.h
+++ b/edbee-lib/edbee/views/textrenderer.h
@@ -112,10 +112,10 @@ private:
 
 protected slots:
 
-    void textDocumentChanged( edbee::TextDocument* oldDocument, edbee::TextDocument* newDocument );
-    void textChanged( edbee::TextBufferChange change, QString oldText = QString() );
+    void textDocumentChanged(edbee::TextDocument* oldDocument, edbee::TextDocument* newDocument);
+    void textChanged(edbee::TextBufferChange change, QString oldText = QString());
 
-    void lastScopedOffsetChanged( int previousOffset, int newOffset );
+    void lastScopedOffsetChanged(size_t previousOffset, size_t newOffset);
 
 public slots:
 

--- a/edbee-lib/edbee/views/textselection.cpp
+++ b/edbee-lib/edbee/views/textselection.cpp
@@ -9,16 +9,16 @@
 #include "edbee/views/textrenderer.h"
 #include "edbee/views/textcaretcache.h"
 
-
 #include "edbee/debug.h"
+
 
 namespace edbee {
 
 /// Constructs the textextselection object
 /// @param controller the controller this selection is for
 TextSelection::TextSelection(TextEditorController* controller)
-    : TextRangeSet( controller->textDocument())
-    , textControllerRef_( controller )
+    : TextRangeSet(controller->textDocument())
+    , textControllerRef_(controller)
 {
 }
 
@@ -26,7 +26,7 @@ TextSelection::TextSelection(TextEditorController* controller)
 /// A copy constructor for copying a text-selection
 TextSelection::TextSelection(const TextSelection& selection)
     : TextRangeSet(selection)
-    , textControllerRef_( selection.textControllerRef_ )
+    , textControllerRef_(selection.textControllerRef_)
 {
 }
 
@@ -59,12 +59,12 @@ void TextSelection::moveCaretsByLine(TextEditorController* controller, TextRange
         TextRange& range = rangeSet->range(rangeIdx);
 
         size_t caret = range.caret();
-        int xpos  = cache->xpos(caret);   // the (original) caret x-position
+        size_t xpos  = cache->xpos(caret);   // the (original) caret x-position
 
         // change the line
         ptrdiff_t sline = static_cast<ptrdiff_t>(doc->lineFromOffset(caret)) + amount;
         if (sline < 0) { sline = 0; }
-        size_t line = sline;
+        size_t line = static_cast<size_t>(sline);
         //if( line >= doc->lineCount() ) { line = doc->lineCount()-1; }
 
         // calculate the correct column
@@ -93,11 +93,11 @@ void TextSelection::moveCaretsByPage(TextEditorController* controller, TextRange
 {
     TextRenderer* renderer = controller->textRenderer();
     TextDocument* doc      = controller->textDocument();
-    int linesPerPage = renderer->viewHeightInLines();
+    size_t linesPerPage = renderer->viewHeightInLines();
     for (size_t rangeIdx = rangeSet->rangeCount() - 1; rangeIdx != std::string::npos; --rangeIdx) {
         TextRange& range = rangeSet->range(rangeIdx);
-        ptrdiff_t line = doc->lineFromOffset(range.caret());
-        line += linesPerPage * amount;
+        ptrdiff_t line = static_cast<ptrdiff_t>(doc->lineFromOffset(range.caret()));
+        line += static_cast<ptrdiff_t>(linesPerPage) * amount;
         if (line < 0) { line = 0; }
         size_t offset = doc->offsetFromLine(static_cast<size_t>(line));
         range.setCaretBounded(doc, offset);
@@ -112,8 +112,6 @@ void TextSelection::addRangesByLine(TextEditorController* controller, TextRangeS
 {
     TextDocument* doc      = controller->textDocument();
     TextRenderer* renderer = controller->textRenderer();
-
-
     TextCaretCache* cache = controller->textCaretCache();
 
     if (!cache->isFilled()) {
@@ -129,14 +127,15 @@ void TextSelection::addRangesByLine(TextEditorController* controller, TextRangeS
         size_t xpos = cache->xpos(offset);   // the (original) caret x-position
 
         // change the line
-        ptrdiff_t line = static_cast<ptrdiff_t>(doc->lineFromOffset(offset)) + amount;
-        if (line >= 0) {
+        ptrdiff_t sline = static_cast<ptrdiff_t>(doc->lineFromOffset(offset)) + amount;
+        if (sline >= 0) {
+            size_t line = static_cast<size_t>(sline);
 
             // calculate the correct column
-            int col = renderer->columnIndexForXpos(line, xpos);
+            size_t col = renderer->columnIndexForXpos(line, xpos);
             size_t lineOffset = doc->offsetFromLine(line);
             size_t offsetNextLine = doc->offsetFromLine(line + 1);
-            int newLinesToRemove = line + 1 < doc->lineCount() ? 1 : 0;
+            size_t newLinesToRemove = line + 1 < doc->lineCount() ? 1 : 0;
 
             offset = qMin(lineOffset + col, offsetNextLine - newLinesToRemove);
             if (offset >= 0 && offset <= doc->length()) {
@@ -158,7 +157,7 @@ TextEditorController* TextSelection::textEditorController() const
 
 
 /// This method process the changes if required
-void TextSelection::processChangesIfRequired( bool joinBorders)
+void TextSelection::processChangesIfRequired(bool joinBorders)
 {
     TextRangeSet::processChangesIfRequired(joinBorders);
     if (!changing()) {

--- a/edbee-lib/edbee/views/textselection.cpp
+++ b/edbee-lib/edbee/views/textselection.cpp
@@ -59,7 +59,7 @@ void TextSelection::moveCaretsByLine(TextEditorController* controller, TextRange
         TextRange& range = rangeSet->range(rangeIdx);
 
         size_t caret = range.caret();
-        size_t xpos  = cache->xpos(caret);   // the (original) caret x-position
+        int xpos  = cache->xpos(caret);   // the (original) caret x-position
 
         // change the line
         ptrdiff_t sline = static_cast<ptrdiff_t>(doc->lineFromOffset(caret)) + amount;
@@ -124,7 +124,7 @@ void TextSelection::addRangesByLine(TextEditorController* controller, TextRangeS
         TextRange& range = rangeSet->range(rangeIdx);
 
         size_t offset = amount > 0 ? range.max() : range.min();
-        size_t xpos = cache->xpos(offset);   // the (original) caret x-position
+        int xpos = cache->xpos(offset);   // the (original) caret x-position
 
         // change the line
         ptrdiff_t sline = static_cast<ptrdiff_t>(doc->lineFromOffset(offset)) + amount;

--- a/edbee-lib/edbee/views/textselection.cpp
+++ b/edbee-lib/edbee/views/textselection.cpp
@@ -68,11 +68,11 @@ void TextSelection::moveCaretsByLine(TextEditorController* controller, TextRange
         //if( line >= doc->lineCount() ) { line = doc->lineCount()-1; }
 
         // calculate the correct column
-        int col = renderer->columnIndexForXpos(line,xpos);
-        int offset = doc->offsetFromLine(line);
-        int offsetNextLine = doc->offsetFromLine(line+1);
-        int newLinesToRemove = line+1 < doc->lineCount() ? 1 : 0;
-        range.setCaretBounded( doc, qMin( offset + col, offsetNextLine - newLinesToRemove ) );
+        size_t col = renderer->columnIndexForXpos(line, xpos);
+        size_t offset = doc->offsetFromLine(line);
+        size_t offsetNextLine = doc->offsetFromLine(line+1);
+        size_t newLinesToRemove = line + 1 < doc->lineCount() ? 1 : 0;
+        range.setCaretBounded(doc, qMin(offset + col, offsetNextLine - newLinesToRemove));
 
 //        cache->caretMovedFromOldOffsetToNewOffset( caret, range.caret() );  // when having multiple caret this doesn't work !
         newCache.add( range.caret(), xpos );
@@ -100,8 +100,8 @@ void TextSelection::moveCaretsByPage( TextEditorController* controller, TextRang
         TextRange& range = rangeSet->range(rangeIdx );
         int line   = doc->lineFromOffset( range.caret() );
         line += linesPerPage * amount;
-        int offset = doc->offsetFromLine(line);
-        range.setCaretBounded( doc, offset );
+        size_t offset = doc->offsetFromLine(line);
+        range.setCaretBounded(doc, offset);
 
     }
     rangeSet->processChangesIfRequired();

--- a/edbee-lib/edbee/views/textselection.cpp
+++ b/edbee-lib/edbee/views/textselection.cpp
@@ -16,8 +16,8 @@ namespace edbee {
 
 /// Constructs the textextselection object
 /// @param controller the controller this selection is for
-TextSelection::TextSelection( TextEditorController* controller )
-    : TextRangeSet( controller->textDocument() )
+TextSelection::TextSelection(TextEditorController* controller)
+    : TextRangeSet( controller->textDocument())
     , textControllerRef_( controller )
 {
 }
@@ -25,10 +25,9 @@ TextSelection::TextSelection( TextEditorController* controller )
 
 /// A copy constructor for copying a text-selection
 TextSelection::TextSelection(const TextSelection& selection)
-    : TextRangeSet( selection )
+    : TextRangeSet(selection)
     , textControllerRef_( selection.textControllerRef_ )
 {
-
 }
 
 /// The text selection destructor
@@ -44,44 +43,43 @@ TextSelection::~TextSelection()
 /// @param controller the controller for this operation
 /// @param rangeSet the rangeset to apply this operation on
 /// @param amount the number of lines to move
-void TextSelection::moveCaretsByLine(TextEditorController* controller, TextRangeSet* rangeSet, int amount )
+void TextSelection::moveCaretsByLine(TextEditorController* controller, TextRangeSet* rangeSet, ptrdiff_t amount)
 {
     TextDocument* doc      = controller->textDocument();
     TextRenderer* renderer = controller->textRenderer();
 
     TextCaretCache* cache = controller->textCaretCache();
-    if( !cache->isFilled() ) {
-        cache->fill( *rangeSet );
+    if (!cache->isFilled()) {
+        cache->fill(*rangeSet);
     }
 
     // next move all lines
-    TextCaretCache newCache( doc, renderer );
-    for( int rangeIdx=rangeSet->rangeCount()-1; rangeIdx >= 0; --rangeIdx ) {
+    TextCaretCache newCache(doc, renderer);
+    for (size_t rangeIdx = rangeSet->rangeCount() - 1; rangeIdx != std::string::npos; --rangeIdx) {
         TextRange& range = rangeSet->range(rangeIdx);
 
-        int caret = range.caret();
+        size_t caret = range.caret();
         int xpos  = cache->xpos(caret);   // the (original) caret x-position
 
         // change the line
-        int line = doc->lineFromOffset( caret ) + amount;
-        if( line < 0 ) { line = 0; }
+        ptrdiff_t sline = static_cast<ptrdiff_t>(doc->lineFromOffset(caret)) + amount;
+        if (sline < 0) { sline = 0; }
+        size_t line = sline;
         //if( line >= doc->lineCount() ) { line = doc->lineCount()-1; }
 
         // calculate the correct column
         size_t col = renderer->columnIndexForXpos(line, xpos);
         size_t offset = doc->offsetFromLine(line);
-        size_t offsetNextLine = doc->offsetFromLine(line+1);
+        size_t offsetNextLine = doc->offsetFromLine(line + 1);
         size_t newLinesToRemove = line + 1 < doc->lineCount() ? 1 : 0;
         range.setCaretBounded(doc, qMin(offset + col, offsetNextLine - newLinesToRemove));
-
 //        cache->caretMovedFromOldOffsetToNewOffset( caret, range.caret() );  // when having multiple caret this doesn't work !
-        newCache.add( range.caret(), xpos );
+        newCache.add(range.caret(), xpos);
     }
     cache->replaceAll(newCache);
 
 //    rangeSet->processChangesIfRequiredKeepCaretCache();
     rangeSet->processChangesIfRequired();
-
 }
 
 
@@ -91,71 +89,64 @@ void TextSelection::moveCaretsByLine(TextEditorController* controller, TextRange
 /// @param controller the controller for this operation
 /// @param rangeSet the rangeset to apply this operation
 /// @param amount the number of pages
-void TextSelection::moveCaretsByPage( TextEditorController* controller, TextRangeSet* rangeSet, int amount )
+void TextSelection::moveCaretsByPage(TextEditorController* controller, TextRangeSet* rangeSet, ptrdiff_t amount)
 {
     TextRenderer* renderer = controller->textRenderer();
     TextDocument* doc      = controller->textDocument();
     int linesPerPage = renderer->viewHeightInLines();
-    for( int rangeIdx=rangeSet->rangeCount()-1; rangeIdx >= 0; --rangeIdx ) {
-        TextRange& range = rangeSet->range(rangeIdx );
-        int line   = doc->lineFromOffset( range.caret() );
+    for (size_t rangeIdx = rangeSet->rangeCount() - 1; rangeIdx != std::string::npos; --rangeIdx) {
+        TextRange& range = rangeSet->range(rangeIdx);
+        ptrdiff_t line = doc->lineFromOffset(range.caret());
         line += linesPerPage * amount;
-        size_t offset = doc->offsetFromLine(line);
+        if (line < 0) { line = 0; }
+        size_t offset = doc->offsetFromLine(static_cast<size_t>(line));
         range.setCaretBounded(doc, offset);
 
     }
     rangeSet->processChangesIfRequired();
-    //    processChangesIfRequiredKeepCaretCache();
 }
 
 
 /// This method adds the ranges by line
-void TextSelection::addRangesByLine( TextEditorController* controller, TextRangeSet* rangeSet, int amount)
+void TextSelection::addRangesByLine(TextEditorController* controller, TextRangeSet* rangeSet, ptrdiff_t amount)
 {
     TextDocument* doc      = controller->textDocument();
     TextRenderer* renderer = controller->textRenderer();
 
-//    qlog_info() << "=========== change ========== ";
 
     TextCaretCache* cache = controller->textCaretCache();
-//    cache->dump();
 
-    if( !cache->isFilled() ) {
-        cache->fill( *rangeSet );
-//        cache->dump();
+    if (!cache->isFilled()) {
+        cache->fill(*rangeSet);
     }
 
     // next move all lines
     rangeSet->beginChanges(); // prevent the clearing of the range cache
-    for( int rangeIdx=rangeSet->rangeCount()-1; rangeIdx >= 0; --rangeIdx ) {
-        TextRange& range = rangeSet->range( rangeIdx );
+    for (size_t rangeIdx=rangeSet->rangeCount() - 1; rangeIdx != std::string::npos; --rangeIdx) {
+        TextRange& range = rangeSet->range(rangeIdx);
 
-        int offset = amount > 0 ? range.max() : range.min();
-        int xpos  = cache->xpos( offset );   // the (original) caret x-position
+        size_t offset = amount > 0 ? range.max() : range.min();
+        size_t xpos = cache->xpos(offset);   // the (original) caret x-position
 
         // change the line
-        int line = doc->lineFromOffset( offset ) + amount;
-        if( line >= 0 ) {
+        ptrdiff_t line = static_cast<ptrdiff_t>(doc->lineFromOffset(offset)) + amount;
+        if (line >= 0) {
 
             // calculate the correct column
-            int col = renderer->columnIndexForXpos(line,xpos);
-            int lineOffset = doc->offsetFromLine(line);
-            int offsetNextLine = doc->offsetFromLine(line+1);
-            int newLinesToRemove = line+1 < doc->lineCount() ? 1 : 0;
+            int col = renderer->columnIndexForXpos(line, xpos);
+            size_t lineOffset = doc->offsetFromLine(line);
+            size_t offsetNextLine = doc->offsetFromLine(line + 1);
+            int newLinesToRemove = line + 1 < doc->lineCount() ? 1 : 0;
 
-            offset = qMin( lineOffset + col, offsetNextLine - newLinesToRemove );
-            if( offset >= 0 && offset <= doc->length() ) {
-                rangeSet->addRange( offset, offset );
-                cache->add( offset, xpos ); // add the original xpos
+            offset = qMin(lineOffset + col, offsetNextLine - newLinesToRemove);
+            if (offset >= 0 && offset <= doc->length()) {
+                rangeSet->addRange(offset, offset);
+                cache->add(offset, xpos); // add the original xpos
             }
         }
     }
-//    cache->dump();
     rangeSet->endChanges();
-
     rangeSet->processChangesIfRequired();
-//    processChangesIfRequiredKeepCaretCache();
-
 }
 
 
@@ -167,20 +158,19 @@ TextEditorController* TextSelection::textEditorController() const
 
 
 /// This method process the changes if required
-void TextSelection::processChangesIfRequired( bool joinBorders )
+void TextSelection::processChangesIfRequired( bool joinBorders)
 {
     TextRangeSet::processChangesIfRequired(joinBorders);
-    if( !changing() ) {
+    if (!changing()) {
         textEditorController()->textCaretCache()->clear();
     }
 }
 
 
 /// This method process the changes if required
-void TextSelection::processChangesIfRequiredKeepCaretCache( bool joinBorders)
+void TextSelection::processChangesIfRequiredKeepCaretCache(bool joinBorders)
 {
     Q_UNUSED(joinBorders);
-//    TextRangeSet::processChangesIfRequiredKeepCaretCache(joinBorders);
 }
 
 } // edbee

--- a/edbee-lib/edbee/views/textselection.h
+++ b/edbee-lib/edbee/views/textselection.h
@@ -24,30 +24,23 @@ class TextEditorController;
 class EDBEE_EXPORT TextSelection : public TextRangeSet
 {
 public:
-    TextSelection( TextEditorController* controller );
-    TextSelection( const TextSelection& selection );
+    TextSelection(TextEditorController* controller);
+    TextSelection(const TextSelection& selection);
     virtual ~TextSelection();
 
-    static void moveCaretsByLine( TextEditorController* controller, TextRangeSet* rangeSet, int amount );
-    static void moveCaretsByPage( TextEditorController* controller, TextRangeSet* rangeSet, int amount );
-    static void addRangesByLine( TextEditorController* controller, TextRangeSet* rangeSet, int amount );
+    static void moveCaretsByLine(TextEditorController* controller, TextRangeSet* rangeSet, ptrdiff_t amount);
+    static void moveCaretsByPage(TextEditorController* controller, TextRangeSet* rangeSet, ptrdiff_t amount);
+    static void addRangesByLine(TextEditorController* controller, TextRangeSet* rangeSet, ptrdiff_t amount);
 
-
-    virtual
-
-  // getters
-    TextEditorController* textEditorController() const;
+    virtual TextEditorController* textEditorController() const;
 
 protected:
-    virtual void processChangesIfRequired( bool joinBorders=false );
-    virtual void processChangesIfRequiredKeepCaretCache( bool joinBorders=false );
-
+    virtual void processChangesIfRequired(bool joinBorders = false);
+    virtual void processChangesIfRequiredKeepCaretCache(bool joinBorders = false);
 
 private:
 
     TextEditorController* textControllerRef_;         ///< A reference to the controller
-
-
 };
 
 

--- a/edbee-lib/edbee/views/texttheme.cpp
+++ b/edbee-lib/edbee/views/texttheme.cpp
@@ -11,7 +11,7 @@
 #include <QVector>
 
 #include "edbee/io/tmthemeparser.h"
-#include "edbee/models/textbuffer.h"
+//#include "edbee/models/textbuffer.h"
 #include "edbee/models/textdocument.h"
 #include "edbee/models/textdocumentscopes.h"
 #include "edbee/texteditorcontroller.h"
@@ -23,10 +23,10 @@ namespace edbee {
 
 
 TextThemeRule::TextThemeRule(const QString& name, const QString& selector, QColor foreground, QColor background, bool bold, bool italic, bool underline)
-    : name_( name )
-    , scopeSelector_(0)
-    , foregroundColor_( foreground )
-    , backgroundColor_( background )
+    : name_(name)
+    , scopeSelector_(nullptr)
+    , foregroundColor_(foreground)
+    , backgroundColor_(background)
     , bold_(bold)
     , italic_(italic)
     , underline_(underline)
@@ -42,16 +42,16 @@ TextThemeRule::~TextThemeRule()
 /// This method checks if the given scopelist matches the scope selector
 bool TextThemeRule::matchesScopeList(const TextScopeList* scopes)
 {
-    return ( scopeSelector_->calculateMatchScore( scopes ) >= 0 ) ;
+    return (scopeSelector_->calculateMatchScore(scopes) >= 0);
 }
 
 void TextThemeRule::fillFormat(QTextCharFormat* format)
 {
-    if( foregroundColor_.isValid() ) { format->setForeground(foregroundColor_ ); }
-    if( backgroundColor_.isValid() ) { format->setBackground(backgroundColor_ ); }
-    if( bold_ ) { format->setFontWeight( QFont::Bold ); }  //QFont::Black
-    if( italic_) { format->setFontItalic(true); }
-    if( underline_ ) { format->setFontUnderline(true); }
+    if (foregroundColor_.isValid()) { format->setForeground(foregroundColor_); }
+    if (backgroundColor_.isValid()) { format->setBackground(backgroundColor_); }
+    if (bold_) { format->setFontWeight(QFont::Bold); }  //QFont::Black
+    if (italic_) { format->setFontItalic(true); }
+    if (underline_) { format->setFontUnderline(true); }
 }
 
 //=================================================
@@ -60,42 +60,24 @@ void TextThemeRule::fillFormat(QTextCharFormat* format)
 TextTheme::TextTheme()
     : name_("Default Theme")
     , uuid_("")
-    , backgroundColor_( 0xffeeeeee )
-    , caretColor_( 0xff000000  )
-    , foregroundColor_( 0xff222222 )
-    , lineHighlightColor_(0xff999999 )
-    , selectionColor_( 0xff9999ff)
-
-    // thTheme settings
-//    , backgroundColor_(0xff272822)
-//    , caretColor_(0xffF8F8F0)
-//    , foregroundColor_(0xffF8F8F2)
-//    , invisiblesColor_(0xff3B3A32)
-//    , lineHighlightColor_(0xff3E3D32)
-//    , selectionColor_(0xff49483E)
-//    , findHighlightBackgroundColor_(0xffFFE792)
-//    , findHighlightForegroundColor_(0xff000000)
-//    , selectionBorderColor_(0xff222218)
-//    , activeGuideColor_(0x9D550FB0)
-//    , bracketForegroundColor_(0xF8F8F2A5)
-//    , bracketOptions_("underline")
-//    , bracketContentsForegroundColor_(0xF8F8F2A5)
-//    , bracketContentsOptions_("underline")
-//    , tagsOptions_("stippled_underline")
-
+    , backgroundColor_(0xffeeeeee)
+    , caretColor_(0xff000000  )
+    , foregroundColor_(0xff222222)
+    , lineHighlightColor_(0xff999999)
+    , selectionColor_(0xff9999ff)
 {
     QPalette pal = QApplication::palette();
-    backgroundColor_ = pal.color( QPalette::Window);
-    foregroundColor_ = pal.color( QPalette::WindowText );
-    selectionColor_ = pal.color( QPalette::Highlight );
-//    giveThemeRule( new TextThemeRule("Comment","comment", QColor("#75715E") ));
-//    giveThemeRule( new TextThemeRule("String","string", QColor("#E6DB74") ));
+    backgroundColor_ = pal.color(QPalette::Window);
+    foregroundColor_ = pal.color(QPalette::WindowText);
+    selectionColor_ = pal.color(QPalette::Highlight);
 }
+
 
 TextTheme::~TextTheme()
 {
     qDeleteAll(themeRules_);
 }
+
 
 /// The text theme
 void TextTheme::giveThemeRule(TextThemeRule* rule)
@@ -103,17 +85,14 @@ void TextTheme::giveThemeRule(TextThemeRule* rule)
     themeRules_.append(rule);
 }
 
-void TextTheme::fillFormatForTextScopeList( const TextScopeList* scopeList, QTextCharFormat* format)
-{
-//    format->setForeground( foregroundColor() );
-//    format->setBackground( backgroundColor() );
 
-    foreach( TextThemeRule* rule, themeRules_ ) {
-        if( rule->matchesScopeList( scopeList ) ) {
+void TextTheme::fillFormatForTextScopeList(const TextScopeList* scopeList, QTextCharFormat* format)
+{
+    foreach (TextThemeRule* rule, themeRules_) {
+        if (rule->matchesScopeList(scopeList)) {
             rule->fillFormat(format);
         }
     }
-
 }
 
 
@@ -122,13 +101,13 @@ void TextTheme::fillFormatForTextScopeList( const TextScopeList* scopeList, QTex
 
 /// Constructs the theme styler
 /// @param controller the controller to use this styler for
-TextThemeStyler::TextThemeStyler( TextEditorController* controller )
-    : controllerRef_( controller )
+TextThemeStyler::TextThemeStyler(TextEditorController* controller)
+    : controllerRef_(controller)
     , themeName_()
-    , themeRef_(0)
+    , themeRef_(nullptr)
 {
-    connect( controller, SIGNAL(textDocumentChanged(edbee::TextDocument*,edbee::TextDocument*)), SLOT(textDocumentChanged(edbee::TextDocument*,edbee::TextDocument*)) );
-    connect( Edbee::instance()->themeManager(), SIGNAL(themePointerChanged(QString,TextTheme*,TextTheme*)), SLOT(themePointerChanged(QString,TextTheme*,TextTheme*)) );
+    connect(controller, SIGNAL(textDocumentChanged(edbee::TextDocument*,edbee::TextDocument*)), SLOT(textDocumentChanged(edbee::TextDocument*,edbee::TextDocument*)));
+    connect(Edbee::instance()->themeManager(), SIGNAL(themePointerChanged(QString,TextTheme*,TextTheme*)), SLOT(themePointerChanged(QString,TextTheme*,TextTheme*)));
     themeRef_ = Edbee::instance()->themeManager()->fallbackTheme();
 }
 
@@ -145,7 +124,7 @@ TextThemeStyler::~TextThemeStyler()
 ///
 /// @param lineIdx the line index
 /// @return the array of ranges
-QVector<QTextLayout::FormatRange> TextThemeStyler::getLineFormatRanges( int lineIdx )
+QVector<QTextLayout::FormatRange> TextThemeStyler::getLineFormatRanges(size_t lineIdx)
 {
     TextDocumentScopes* scopes = controller()->textDocument()->scopes();
 
@@ -154,7 +133,7 @@ QVector<QTextLayout::FormatRange> TextThemeStyler::getLineFormatRanges( int line
 
     // get all textranges on the given line
     ScopedTextRangeList* scopedRanges = scopes->scopedRangesAtLine(lineIdx);
-    if( scopedRanges == 0 || scopedRanges->size() == 0 ) { return formatRangeList; }
+    if (scopedRanges == 0 || scopedRanges->size() == 0) { return formatRangeList; }
 
 
     // build format ranges from these (nested) scope ranges
@@ -166,46 +145,45 @@ QVector<QTextLayout::FormatRange> TextThemeStyler::getLineFormatRanges( int line
     //  [ ][xx][#########][xxxx][ ][kkkkkkk][  ]
     //
     QStack<ScopedTextRange*> activeRanges;
-    activeRanges.append( scopedRanges->at(0) );
+    activeRanges.append(scopedRanges->at(0));
 
-    int lastOffset = 0; //lineStartOffset;
-    for( int i=1, cnt=scopedRanges->size(); i<cnt; ++i ) {
+    size_t lastOffset = 0;
+    for (size_t i = 1, cnt = scopedRanges->size(); i < cnt; ++i) {
         ScopedTextRange* range = scopedRanges->at(i);
-        int min = range->min();  // find the minimum position
+        size_t min = range->min();
 
         // unwind the stack if required
-        while( activeRanges.size() > 1 ) {
+        while (activeRanges.size() > 1) {
             ScopedTextRange* activeRange = activeRanges.last();
-            int activeRangeMax = activeRange->max();
+            size_t activeRangeMax = activeRange->max();
 
             // when the 'min' is behind the end of the textrange on the stack we need to pop the stack
-            if( activeRangeMax <= min ) {
-                appendFormatRange( formatRangeList, lastOffset, activeRangeMax-1, activeRanges );
+            if (activeRangeMax <= min) {
+                appendFormatRange(formatRangeList, lastOffset, activeRangeMax - 1, activeRanges);
                 activeRanges.pop();
                 lastOffset = activeRangeMax;
-                Q_ASSERT( !activeRanges.empty() );
+                Q_ASSERT(!activeRanges.empty());
             } else {
                 break;
             }
         }
 
         // add a new 'range' if a new one is started and there's a 'gap'
-        if( lastOffset < min ) {
-            appendFormatRange( formatRangeList, lastOffset, min-1, activeRanges );
+        if (lastOffset < min)  {
+            appendFormatRange(formatRangeList, lastOffset, min - 1, activeRanges);
             lastOffset = min;
         }
 
         // push the new range to the stack
-        activeRanges.push_back( range );
-
+        activeRanges.push_back(range);
     }
 
     // next we must unwind the stack
-    while( !activeRanges.isEmpty() ) {
+    while (!activeRanges.isEmpty()) {
         ScopedTextRange* activeRange = activeRanges.last();
-        int activeRangeMax = activeRange->max();
-        if( lastOffset < activeRange->max() ) {
-            appendFormatRange(formatRangeList, lastOffset, activeRangeMax-1, activeRanges );
+        size_t activeRangeMax = activeRange->max();
+        if (lastOffset < activeRange->max()) {
+            appendFormatRange(formatRangeList, lastOffset, activeRangeMax-1, activeRanges);
             lastOffset = activeRange->max();
         }
         activeRanges.pop();
@@ -225,7 +203,7 @@ void TextThemeStyler::setThemeByName(const QString& themeName)
     themeRef_= Edbee::instance()->themeManager()->theme(themeName_);
 
     // when no theme is found, fallback to the fallback theme
-    if( !themeRef_) {
+    if (!themeRef_) {
         qlog_warn() << "Theme not set:" << themeName_;
         themeName_ = "";
         themeRef_= Edbee::instance()->themeManager()->fallbackTheme();
@@ -248,7 +226,7 @@ void TextThemeStyler::setTheme(TextTheme* theme)
 {
     themeName_ = QString();
     themeRef_ = theme;
-    if( !themeRef_) {
+    if (!themeRef_) {
         themeName_ = "";
         themeRef_= Edbee::instance()->themeManager()->fallbackTheme();
     }
@@ -263,28 +241,28 @@ TextTheme* TextThemeStyler::theme() const
 
 
 
-/// This method returns the character format for the given text scope
-QTextCharFormat TextThemeStyler::getTextScopeFormat( QVector<ScopedTextRange*>& activeRanges )
+/// Returns the character format for the given text scope
+QTextCharFormat TextThemeStyler::getTextScopeFormat(QVector<ScopedTextRange*>& activeRanges)
 {
 //    ScopedTextRange* range = activeRanges.last();
     QTextCharFormat format;
 
     TextScopeList scopeList(activeRanges);
-    theme()->fillFormatForTextScopeList( &scopeList, &format );
+    theme()->fillFormatForTextScopeList(&scopeList, &format);
     return format;
 }
 
 
 /// helper function to create a format range
-void TextThemeStyler::appendFormatRange(QVector<QTextLayout::FormatRange> &rangeList, int start, int end,  QVector<ScopedTextRange*>& activeRanges )
+void TextThemeStyler::appendFormatRange(QVector<QTextLayout::FormatRange>& rangeList, size_t start, size_t end, QVector<ScopedTextRange*>& activeRanges )
 {
     // only append a format if the lexer style is different then default
-    if( activeRanges.size() > 1  ) {
+    if (activeRanges.size() > 1) {
         QTextLayout::FormatRange formatRange;
-        formatRange.start  = start;
-        formatRange.length = end - start + 1;
-        formatRange.format = getTextScopeFormat( activeRanges );
-        rangeList.append( formatRange );
+        formatRange.start  = static_cast<int>(start);
+        formatRange.length = static_cast<int>(end - start + 1);
+        formatRange.format = getTextScopeFormat(activeRanges);
+        rangeList.append(formatRange);
     }
 }
 
@@ -297,17 +275,15 @@ void TextThemeStyler::textDocumentChanged(edbee::TextDocument *oldDocument, edbe
 /// invalidates all layouts
 void TextThemeStyler::invalidateLayouts()
 {
-    //    formateRangeListCache_.clear();
 }
 
-void TextThemeStyler::themePointerChanged(const QString& name, TextTheme* oldTheme, TextTheme *newTheme)
+void TextThemeStyler::themePointerChanged(const QString& name, TextTheme* oldTheme, TextTheme* newTheme)
 {
-    if( name == themeName_ ) {
+    if (name == themeName_) {
         themeRef_ = newTheme;
     } else {
-        if( oldTheme == themeRef_ ) {
+        if (oldTheme == themeRef_) {
             Q_ASSERT(false && "The old theme is deleted but it's not the same theme name. This shouldn't happen");
-            // If it happens a solution is to set the fallback theme
         }
     }
 }
@@ -362,24 +338,24 @@ void TextThemeManager::listAllThemes(const QString& themePath)
 
 /// Returns the theme name at the given index
 /// @param idx the index of the theme to retrieve
-QString TextThemeManager::themeName(int idx)
+QString TextThemeManager::themeName(qsizetype idx)
 {
     return themeNames_.at(idx);
 }
 
 
-/// This method loads the given theme file.
+/// Loads the given theme file.
 /// The theme manager stays owner of the given theme
 /// @param filename the filename of the theme to load
 /// @param name the name of the theme (if the name isn't given the basenaem of the fileName is used (excluding the .tmTheme extension)
 /// @return the loaded theme or 0 if the theme couldn' be loaded
-TextTheme* TextThemeManager::readThemeFile( const QString& fileName, const QString& nameIn )
+TextTheme* TextThemeManager::readThemeFile(const QString& fileName, const QString& nameIn)
 {
     lastErrorMessage_.clear();
 
     // check if the file exists
     QFile file(fileName);
-    if( file.exists() && file.open(QIODevice::ReadOnly) ) {
+    if (file.exists() && file.open(QIODevice::ReadOnly)) {
 
         // parse the theme
         TmThemeParser parser;
@@ -394,7 +370,7 @@ TextTheme* TextThemeManager::readThemeFile( const QString& fileName, const QStri
 
             setTheme(name,theme);
         } else {
-            lastErrorMessage_ = QObject::tr("Error parsing theme %1:%2").arg(file.fileName()).arg( parser.lastErrorMessage());
+            lastErrorMessage_ = QObject::tr("Error parsing theme %1:%2").arg(file.fileName(), parser.lastErrorMessage());
         }
         file.close();
         return theme;
@@ -416,7 +392,7 @@ TextTheme* TextThemeManager::theme(const QString& name)
     if( name.isEmpty() ) { return 0; }
     TextTheme* theme=themeMap_.value(name);
     if( !theme && !themePath_.isEmpty()) {
-        QString filename = QStringLiteral("%1/%2.tmTheme").arg(themePath_).arg(name);
+        QString filename = QStringLiteral("%1/%2.tmTheme").arg(themePath_, name);
         theme = readThemeFile( filename );
         if( !theme ) {
             qlog_warn() << this->lastErrorMessage();

--- a/edbee-lib/edbee/views/texttheme.h
+++ b/edbee-lib/edbee/views/texttheme.h
@@ -161,7 +161,7 @@ public:
     TextThemeStyler( TextEditorController* controller );
     virtual ~TextThemeStyler();
 
-    QVector<QTextLayout::FormatRange> getLineFormatRanges( int lineIdx );
+    QVector<QTextLayout::FormatRange> getLineFormatRanges(size_t lineIdx);
 
     TextEditorController* controller() { return controllerRef_; }
 
@@ -173,14 +173,14 @@ public:
     TextTheme* theme() const;
 
 private:
-    QTextCharFormat getTextScopeFormat(QVector<ScopedTextRange *> &activeRanges);
-    void appendFormatRange(QVector<QTextLayout::FormatRange>& rangeList, int start, int end,  QVector<edbee::ScopedTextRange *> &activeRanges );
+    QTextCharFormat getTextScopeFormat(QVector<ScopedTextRange*>&activeRanges);
+    void appendFormatRange(QVector<QTextLayout::FormatRange>& rangeList, size_t start, size_t end, QVector<edbee::ScopedTextRange*>& activeRanges);
 
 private slots:
 
     void textDocumentChanged(edbee::TextDocument* oldDocument, edbee::TextDocument* newDocument);
     void invalidateLayouts();
-    void themePointerChanged( const QString& name, TextTheme* oldTheme, TextTheme* newTheme );
+    void themePointerChanged(const QString& name, TextTheme* oldTheme, TextTheme* newTheme);
 
 
 private:
@@ -188,7 +188,6 @@ private:
     TextEditorController* controllerRef_;                                     ///< A reference to the controller
     QString themeName_;                                                       ///< The name of the active theme (when a 'custom' theme active)
     TextTheme* themeRef_;                                                     ///< The active theme
-
 
 };
 
@@ -210,17 +209,17 @@ protected:
 public:
     void clear();
 
-    TextTheme* readThemeFile( const QString& fileName, const QString& name=QString() );
-    void listAllThemes( const QString& themePath=QString() );
-    int themeCount() { return themeNames_.size(); }
-    QString themeName( int idx );
-    TextTheme* theme( const QString& name );
+    TextTheme* readThemeFile(const QString& fileName, const QString& name = QString());
+    void listAllThemes(const QString& themePath = QString());
+    qsizetype themeCount() { return themeNames_.size(); }
+    QString themeName(qsizetype idx );
+    TextTheme* theme(const QString& name);
     TextTheme* fallbackTheme() const { return fallbackTheme_; }
     QString lastErrorMessage() const;
-    void setTheme( const QString& name, TextTheme* theme );
+    void setTheme(const QString& name, TextTheme* theme);
 
 signals:
-    void themePointerChanged( const QString& name, TextTheme* oldTheme, TextTheme* newTheme );
+    void themePointerChanged(const QString& name, TextTheme* oldTheme, TextTheme* newTheme);
 
 
 private:
@@ -232,7 +231,6 @@ private:
     QString lastErrorMessage_;                     ///< The last error message
 
     friend class Edbee;
-
 };
 
 

--- a/edbee-test/edbee/commands/removecommandtest.cpp
+++ b/edbee-test/edbee/commands/removecommandtest.cpp
@@ -21,7 +21,7 @@ RemoveCommandTest::RemoveCommandTest()
 /// test the remove command operation
 void RemoveCommandTest::init()
 {
-    command_ = new RemoveCommand( RemoveCommand::RemoveChar, RemoveCommand::Left );
+    command_ = new RemoveCommand(RemoveCommand::RemoveChar, RemoveCommand::Left);
 }
 
 
@@ -42,28 +42,26 @@ void RemoveCommandTest::testSmartBackspace()
     doc.config()->setIndentSize(2);
     //===========0123456789
     doc.setText("       abcd");
-    testEqual( command_->smartBackspace(&doc,0), 0 );
-    testEqual( command_->smartBackspace(&doc,1), 0 );
-    testEqual( command_->smartBackspace(&doc,2), 0 );
-    testEqual( command_->smartBackspace(&doc,3), 2 );
-    testEqual( command_->smartBackspace(&doc,4), 2 );
-    testEqual( command_->smartBackspace(&doc,5), 4 );
-    testEqual( command_->smartBackspace(&doc,6), 4 );
-    testEqual( command_->smartBackspace(&doc,7), 6 );
-    testEqual( command_->smartBackspace(&doc,8), 7 );   // this is the 'a'
-    testEqual( command_->smartBackspace(&doc,9), 8 );   // this is the 'b'
-
+    testEqual(command_->smartBackspace(&doc, 0), 0);
+    testEqual(command_->smartBackspace(&doc, 1), 0);
+    testEqual(command_->smartBackspace(&doc, 2), 0);
+    testEqual(command_->smartBackspace(&doc, 3), 2);
+    testEqual(command_->smartBackspace(&doc, 4), 2);
+    testEqual(command_->smartBackspace(&doc, 5), 4);
+    testEqual(command_->smartBackspace(&doc, 6), 4);
+    testEqual(command_->smartBackspace(&doc, 7), 6);
+    testEqual(command_->smartBackspace(&doc, 8), 7);   // this is the 'a'
+    testEqual(command_->smartBackspace(&doc, 9), 8);   // this is the 'b'
 
     // extra tabs test
     doc.config()->setIndentSize(4);
     doc.setText("\t \t abcd");
-    testEqual( command_->smartBackspace(&doc,0), 0 );   // 0 => 0
-    testEqual( command_->smartBackspace(&doc,1), 0 );   // "\t" => 0
-    testEqual( command_->smartBackspace(&doc,2), 1 );   // "\t " Directly at the first column which is after the tab char
-    testEqual( command_->smartBackspace(&doc,3), 1 );   // "\t \t" Directly at the first column which is after the tab char
-    testEqual( command_->smartBackspace(&doc,4), 3 );   // "\t \t "
+    testEqual(command_->smartBackspace(&doc, 0), 0);   // 0 => 0
+    testEqual(command_->smartBackspace(&doc, 1), 0);   // "\t" => 0
+    testEqual(command_->smartBackspace(&doc, 2), 1);   // "\t " Directly at the first column which is after the tab char
+    testEqual(command_->smartBackspace(&doc, 3), 1);   // "\t \t" Directly at the first column which is after the tab char
+    testEqual(command_->smartBackspace(&doc, 4), 3);   // "\t \t "
 }
-
 
 
 } // edbee

--- a/edbee-test/edbee/commands/removecommandtest.h
+++ b/edbee-test/edbee/commands/removecommandtest.h
@@ -29,5 +29,5 @@ private:
 
 } // edbee
 
-DECLARE_TEST(edbee::RemoveCommandTest );
+DECLARE_TEST(edbee::RemoveCommandTest);
 

--- a/edbee-test/edbee/models/textbuffertest.cpp
+++ b/edbee-test/edbee/models/textbuffertest.cpp
@@ -16,9 +16,9 @@ namespace edbee {
 /// The marker list is a list of markers, with the end marker closed with a -1
 #define testBuffer( buf, txt, markers ) \
 do { \
-    testEqual( buf->text(), txt );  \
+    testEqual(buf->text(), txt);  \
     QString lineOffsets = buf->lineOffsetsAsString(); \
-    testEqual( lineOffsets, markers ); \
+    testEqual(lineOffsets, markers); \
 } while(false)
 
 
@@ -30,12 +30,12 @@ void TextBufferTest::testlineFromOffset()
 
     // build an initial doc
     buf->appendText("a1\nb2\nc3\n\nd5");
-    testBuffer( buf, "a1\nb2\nc3\n\nd5", "0,3,6,9,10" );
+    testBuffer(buf, "a1\nb2\nc3\n\nd5", "0,3,6,9,10");
 
-    testEqual( buf->lineFromOffset(0), 0 );
-    testEqual( buf->lineFromOffset(1), 0 );
-    testEqual( buf->lineFromOffset(2), 0 );
-    testEqual( buf->lineFromOffset(3), 1 );
+    testEqual(buf->lineFromOffset(0), 0);
+    testEqual(buf->lineFromOffset(1), 0);
+    testEqual(buf->lineFromOffset(2), 0);
+    testEqual(buf->lineFromOffset(3), 1);
 
 
 }
@@ -48,115 +48,115 @@ void TextBufferTest::testColumnFromOffsetAndLine()
     buf->appendText("a1\nbb2\nccc3\n\nd5");
 
     // basic test
-    testEqual( buf->columnFromOffsetAndLine( 0, -1  ), 0 );
-    testEqual( buf->columnFromOffsetAndLine( 1, -1  ), 1 );
-    testEqual( buf->columnFromOffsetAndLine( 2, -1  ), 2 );
-    testEqual( buf->columnFromOffsetAndLine( 3, -1  ), 0 );
+    testEqual(buf->columnFromOffsetAndLine(0, -1), 0);
+    testEqual(buf->columnFromOffsetAndLine(1, -1), 1);
+    testEqual(buf->columnFromOffsetAndLine(2, -1), 2);
+    testEqual(buf->columnFromOffsetAndLine(3, -1), 0);
 
     // when supplying a line offset it should work
-    testEqual( buf->columnFromOffsetAndLine( 0, 0  ), 0 );
-    testEqual( buf->columnFromOffsetAndLine( 2, 0  ), 2 );
-    testEqual( buf->columnFromOffsetAndLine( 3, 0  ), 3 );
-    testEqual( buf->columnFromOffsetAndLine( 4, 0  ), 3 );
+    testEqual(buf->columnFromOffsetAndLine(0, 0), 0);
+    testEqual(buf->columnFromOffsetAndLine(2, 0), 2);
+    testEqual(buf->columnFromOffsetAndLine(3, 0), 3);
+    testEqual(buf->columnFromOffsetAndLine(4, 0), 3);
 
     // another line then 0 should work
-    testEqual( buf->columnFromOffsetAndLine( 3, 1  ), 0 );
-    testEqual( buf->columnFromOffsetAndLine( 4, 1  ), 1 );
-    testEqual( buf->columnFromOffsetAndLine( 5, 1  ), 2 );
+    testEqual(buf->columnFromOffsetAndLine(3, 1), 0);
+    testEqual(buf->columnFromOffsetAndLine(4, 1), 1);
+    testEqual(buf->columnFromOffsetAndLine(5, 1), 2);
 
     // it should sill clamb between the boundries
-    testEqual( buf->columnFromOffsetAndLine( 2, 1  ), 0 );
-    testEqual( buf->columnFromOffsetAndLine( 5, 1  ), 2 );
-    testEqual( buf->columnFromOffsetAndLine( 6, 1  ), 3 );
-    testEqual( buf->columnFromOffsetAndLine( 7, 1  ), 4 );
-    testEqual( buf->columnFromOffsetAndLine( 8, 1  ), 4 );
+    testEqual(buf->columnFromOffsetAndLine(2, 1), 0);
+    testEqual(buf->columnFromOffsetAndLine(5, 1), 2);
+    testEqual(buf->columnFromOffsetAndLine(6, 1), 3);
+    testEqual(buf->columnFromOffsetAndLine(7, 1), 4);
+    testEqual(buf->columnFromOffsetAndLine(8, 1), 4);
 
     // line overflow should return 0
-    testEqual( buf->columnFromOffsetAndLine( 0, 100  ), 0 );
+    testEqual(buf->columnFromOffsetAndLine(0, 100), 0);
 }
 
 
-/// This method tests the replace text method
+/// Tests the replace text method
 void TextBufferTest::testReplaceText()
 {
     // first test. An empty document should be empty!
     CharTextDocument doc;
     TextBuffer* buf = doc.buffer();
-    testBuffer( buf, "", "0" );
+    testBuffer(buf, "", "0");
 
     // test 'global inserting
     //-----------------------
 
-        // Test inserting of plain text
-        buf->replaceText(0,0,"Test");
-        testBuffer( buf, "Test", "0" );
+    // Test inserting of plain text
+    buf->replaceText(0, 0, "Test");
+    testBuffer(buf, "Test", "0");
 
-        // Test the insertation of another string
-        buf->replaceText(0,0,"A");
-        testBuffer( buf, "ATest", "0" );
+    // Test the insertation of another string
+    buf->replaceText(0, 0, "A");
+    testBuffer(buf, "ATest", "0");
 
-        // Test the replacement of a string
-        buf->replaceText(0,2,"XX");
-        testBuffer( buf, "XXest", "0" );
+    // Test the replacement of a string
+    buf->replaceText(0, 2, "XX");
+    testBuffer(buf, "XXest", "0");
 
-        buf->replaceText(1,3,"Y");
-        testBuffer( buf, "XYt", "0" );
+    buf->replaceText(1, 3, "Y");
+    testBuffer(buf, "XYt", "0");
 
-        // replacement over the end should be possible
-        buf->replaceText(0,100,"Zz.");
-        testBuffer( buf, "Zz.", "0" );
+    // replacement over the end should be possible
+    buf->replaceText(0, 100, "Zz.");
+    testBuffer(buf, "Zz.", "0");
 
-        // appending to the end should be possible even at a bigger offset
-        buf->replaceText(10,0,"X");
-        testBuffer( buf, "Zz.X", "0" );
+    // appending to the end should be possible even at a bigger offset
+    buf->replaceText(10, 0, "X");
+    testBuffer(buf, "Zz.X", "0");
 
-        // append over the end from the middle should work
-        buf->replaceText(1,100,"abc");
-        testBuffer( buf, "Zabc", "0" );
+    // append over the end from the middle should work
+    buf->replaceText(1, 100, "abc");
+    testBuffer(buf, "Zabc", "0");
 
-        // inserting a single character
-        buf->replaceText(1,0,"z");
-        testBuffer( buf, "Zzabc", "0" );
+    // inserting a single character
+    buf->replaceText(1, 0, "z");
+    testBuffer(buf, "Zzabc", "0");
 
-        // replacing a single
-        buf->replaceText(1,1,"Y");
-        testBuffer( buf, "ZYabc", "0" );
+    // replacing a single
+    buf->replaceText(1, 1, "Y");
+    testBuffer(buf, "ZYabc", "0");
 
     // test the new line markers
     //--------------------------
 
-        buf->replaceText(0,buf->length(), "");
-        testBuffer( buf, "", "0" );
+    buf->replaceText(0, buf->length(), "");
+    testBuffer(buf, "", "0");
 
-        // are newlines detected correctly on an insert?
-        buf->replaceText(0,buf->length(), "1\n2");
-        testBuffer( buf, "1\n2","0,2");
+    // are newlines detected correctly on an insert?
+    buf->replaceText(0, buf->length(), "1\n2");
+    testBuffer(buf, "1\n2", "0,2");
 
-        // inserting a text should update newline markers after the insertation point
-        buf->replaceText(1,0,"a");
-        testBuffer( buf, "1a\n2","0,3");
+    // inserting a text should update newline markers after the insertation point
+    buf->replaceText(1, 0, "a");
+    testBuffer(buf, "1a\n2", "0,3");
 
-        // inserting a text at the 0th pos should change the 0 pos
-        buf->replaceText(0,0,"b");
-        testBuffer( buf, "b1a\n2","0,4");
+    // inserting a text at the 0th pos should change the 0 pos
+    buf->replaceText(0, 0, "b");
+    testBuffer(buf, "b1a\n2", "0,4");
 
-        // we should be able to add a newline
-        buf->replaceText(0,3,"rick\n");
-        testBuffer( buf, "rick\n\n2","0,5,6");
+    // we should be able to add a newline
+    buf->replaceText(0, 3, "rick\n");
+    testBuffer(buf, "rick\n\n2", "0,5,6");
 
-        // replacing text should fix newlines
-//        LineOffsetVector::debug = true;
-        buf->replaceText(5,100,"a\nb\nc");
-        testBuffer( buf, "rick\na\nb\nc","0,5,7,9");
-//        LineOffsetVector::debug = false;
+    // replacing text should fix newlines
+    //        LineOffsetVector::debug = true;
+    buf->replaceText(5, 100, "a\nb\nc");
+    testBuffer(buf, "rick\na\nb\nc", "0,5,7,9");
+    //        LineOffsetVector::debug = false;
 
-        // inserting a text should change the newlines
-        buf->replaceText(0,5,"");
-        testBuffer( buf, "a\nb\nc","0,2,4");
+    // inserting a text should change the newlines
+    buf->replaceText(0, 5, "");
+    testBuffer(buf, "a\nb\nc", "0,2,4");
 
-        // inserting a text should change the newlines
-        buf->replaceText(0,10,"");
-        testBuffer( buf, "","0");
+    // inserting a text should change the newlines
+    buf->replaceText(0, 10, "");
+    testBuffer(buf, "", "0");
 }
 
 
@@ -171,64 +171,63 @@ void TextBufferTest::testFindCharPosWithinRange()
     QString strAll = "abc \n";
 
     // test invalid search values
-    testEqual( buf->findCharPos(-1, -1, strAll, true), -1 );
-    testEqual( buf->findCharPos(200, -1, strAll, true), -1 );
+    testEqual(buf->findCharPos(-1, -1, strAll, true), std::string::npos);
+    testEqual(buf->findCharPos(std::string::npos, -1, strAll, true), std::string::npos);
+    testEqual(buf->findCharPos(200, -1, strAll, true), std::string::npos);
 
     // test moving out of left and right border
-    testEqual( buf->findCharPos(0, 1, strAll, true), 0 );
-    testEqual( buf->findCharPos(0, -1, strAll, false), -1 );
-    testEqual( buf->findCharPos(5, -1, strAll, false), -1 );
-    testEqual( buf->findCharPos(0, 1, strAll, false), -1 );
+    testEqual(buf->findCharPos(0, 1, strAll, true), 0);
+    testEqual(buf->findCharPos(0, -1, strAll, false), std::string::npos);
+    testEqual(buf->findCharPos(5, -1, strAll, false), std::string::npos);
+    testEqual(buf->findCharPos(0, 1, strAll, false), std::string::npos);
 
-    testEqual( buf->findCharPos(2, 1, strA, true), 2 );
-    testEqual( buf->findCharPos(2, 2, strA, true), 4 );
-    testEqual( buf->findCharPos(2, 4, strA, true), 14 );
-    testEqual( buf->findCharPos(2, -1, strA, true), 2 );
-    testEqual( buf->findCharPos(2, -2, strA, true), 1 );
-    testEqual( buf->findCharPos(2, -3, strA, true), 0 );
-    testEqual( buf->findCharPos(2, -4, strA, true), -1 );
+    testEqual(buf->findCharPos(2, 1, strA, true), 2);
+    testEqual(buf->findCharPos(2, 2, strA, true), 4);
+    testEqual(buf->findCharPos(2, 4, strA, true), 14);
+    testEqual(buf->findCharPos(2, -1, strA, true), 2);
+    testEqual(buf->findCharPos(2, -2, strA, true), 1);
+    testEqual(buf->findCharPos(2, -3, strA, true), 0);
+    testEqual(buf->findCharPos(2, -4, strA, true), std::string::npos);
 
-    testEqual( buf->findCharPos(2, 1, strC, true), 10 );
-    testEqual( buf->findCharPos(2, 2, strC, true), 11 );
+    testEqual(buf->findCharPos(2, 1, strC, true), 10);
+    testEqual(buf->findCharPos(2, 2, strC, true), 11);
 
 
-    testEqual( buf->findCharPosOrClamp(5, -1, "X", true), 0 );
-    testEqual( buf->findCharPosOrClamp(5, 1, "X", true), buf->length() );
+    testEqual(buf->findCharPosOrClamp(5, -1, "X", true), 0);
+    testEqual(buf->findCharPosOrClamp(5, 1, "X", true), buf->length());
 
-    testEqual( buf->findCharPosWithinRangeOrClamp(5, -1, "X", true, 2, 8), 2 );
-    testEqual( buf->findCharPosWithinRangeOrClamp(5, 1, "X", true, 2, 8), 8 );
-
+    testEqual(buf->findCharPosWithinRangeOrClamp(5, -1, "X", true, 2, 8), 2);
+    testEqual(buf->findCharPosWithinRangeOrClamp(5, 1, "X", true, 2, 8), 8);
 }
 
 
-/// This method is for testing the line function
+/// Test the line function
 void TextBufferTest::testLine()
 {
     CharTextDocument doc;
     TextBuffer* buf = doc.buffer();
     buf->appendText("aaa\nbbb\nccc\nddd");
 
-    testEqual( buf->line(0), "aaa\n");
-    testEqual( buf->lineWithoutNewline(0), "aaa" );
+    testEqual(buf->line(0), "aaa\n");
+    testEqual(buf->lineWithoutNewline(0), "aaa");
 
 
-    testEqual( buf->line(3), "ddd");
-    testEqual( buf->lineWithoutNewline(3), "ddd" );
+    testEqual(buf->line(3), "ddd");
+    testEqual(buf->lineWithoutNewline(3), "ddd");
 }
 
 
-/// test method test the working of the lineoffsetvector. (Which fgot corrupted with certain replaces)
+/// The working of the lineoffsetvector. (Which fgot corrupted with certain replaces)
 void TextBufferTest::testReplaceIssue141()
 {
     CharTextDocument doc;
     TextBuffer* buf = doc.buffer();
-//    CharTextBuffer* charBuf = dynamic_cast<CharTextBuffer*>(buf);
     buf->appendText("11\n22\n33");
-    testBuffer( buf, "11\n22\n33", "0,3,6" );
+    testBuffer( buf, "11\n22\n33", "0,3,6");
 
     // append a new line
-    buf->replaceText(1,0,"\n");
-    testBuffer( buf, "1\n1\n22\n33", "0,2,4,7" );
+    buf->replaceText(1, 0, "\n");
+    testBuffer(buf, "1\n1\n22\n33", "0,2,4,7");
 
     // // Before
     // 1|1|22|33
@@ -244,8 +243,8 @@ void TextBufferTest::testReplaceIssue141()
     // 0  3  6  9
 
     // next append the new text
-    buf->replaceText(0,4,"aa\nbb\n");
-    testBuffer( buf, "aa\nbb\n22\n33", "0,3,6,9" );
+    buf->replaceText(0, 4, "aa\nbb\n");
+    testBuffer(buf, "aa\nbb\n22\n33", "0,3,6,9");
 }
 
 

--- a/edbee-test/edbee/models/textdocumentscopestest.cpp
+++ b/edbee-test/edbee/models/textdocumentscopestest.cpp
@@ -16,12 +16,12 @@ void TextDocumentScopesTest::testStartsWith()
     TextScopeManager* sm = Edbee::instance()->scopeManager();
     TextScope* source = sm->refTextScope("aa.bb.cc.dd.ee");
 
-    testTrue( source->startsWith( sm->refTextScope("aa.bb") ) );
-    testTrue( source->startsWith( sm->refTextScope("aa.*") ) );
-    testTrue( source->startsWith( sm->refTextScope("*.bb") ) );
-    testTrue( source->startsWith( sm->refTextScope("*") ) );
-    testFalse( source->startsWith( sm->refTextScope("bb") ) );
-    testFalse( source->startsWith( sm->refTextScope("bb") ) );
+    testTrue(source->startsWith(sm->refTextScope("aa.bb")));
+    testTrue(source->startsWith(sm->refTextScope("aa.*")));
+    testTrue(source->startsWith(sm->refTextScope("*.bb")));
+    testTrue(source->startsWith(sm->refTextScope("*")));
+    testFalse(source->startsWith(sm->refTextScope("bb")));
+    testFalse(source->startsWith(sm->refTextScope("bb")));
 }
 
 
@@ -30,86 +30,16 @@ void TextDocumentScopesTest::testRindexOf()
     TextScopeManager* sm = Edbee::instance()->scopeManager();
     TextScope* source = sm->refTextScope("aa.bb.cc.dd.ee");
 
-    testEqual( source->rindexOf( sm->refTextScope("aa.bb") ), 0 );
-    testEqual( source->rindexOf( sm->refTextScope("cc.dd") ), 2 );
-    testEqual( source->rindexOf( sm->refTextScope("dd.ee") ), 3 );
-    testEqual( source->rindexOf( sm->refTextScope("bb.aa") ), -1 );
+    testEqual(source->rindexOf(sm->refTextScope("aa.bb")), 0);
+    testEqual(source->rindexOf(sm->refTextScope("cc.dd")), 2);
+    testEqual(source->rindexOf(sm->refTextScope("dd.ee")), 3);
+    testEqual(source->rindexOf(sm->refTextScope("bb.aa")), std::string::npos);
 
-    testEqual( source->rindexOf( sm->refTextScope("*.cc.*.ee") ), 1 );
-    testEqual( source->rindexOf( sm->refTextScope("aa.bb.cc.dd.ee") ), 0 );
+    testEqual(source->rindexOf(sm->refTextScope("*.cc.*.ee")), 1);
+    testEqual(source->rindexOf(sm->refTextScope("aa.bb.cc.dd.ee")), 0);
 
-    testEqual( source->rindexOf( sm->refTextScope("*") ), 4 );
+    testEqual(source->rindexOf(sm->refTextScope("*") ), 4);
 }
-
-
-
-/* Orgingal textmate tests:
-class ScopeSelectorTests : public CxxTest::TestSuite
-{
-public:
-    void test_child_selector ()
-    {
-        TS_ASSERT_EQUALS(scope::selector_t("foo fud").does_match("foo bar fud"),   true);
-        TS_ASSERT_EQUALS(scope::selector_t("foo > fud").does_match("foo bar fud"), false);
-        TS_ASSERT_EQUALS(scope::selector_t("foo > foo > fud").does_match("foo foo fud"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("foo > foo > fud").does_match("foo foo fud fud"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("foo > foo > fud").does_match("foo foo fud baz"), true);
-
-        TS_ASSERT_EQUALS(scope::selector_t("foo > foo fud > fud").does_match("foo foo bar fud fud"), true);
-    }
-
-    void test_mixed ()
-    {
-        TS_ASSERT_EQUALS(scope::selector_t("^ foo > bar").does_match("foo bar foo"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("foo > bar $").does_match("foo bar foo"), false);
-        TS_ASSERT_EQUALS(scope::selector_t("bar > foo $").does_match("foo bar foo"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("foo > bar > foo $").does_match("foo bar foo"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("^ foo > bar > foo $").does_match("foo bar foo"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("bar > foo $").does_match("foo bar foo"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("^ foo > bar > baz").does_match("foo bar baz foo bar baz"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("^ foo > bar > baz").does_match("foo foo bar baz foo bar baz"), false);
-
-    }
-
-    void test_anchor ()
-    {
-        TS_ASSERT_EQUALS(scope::selector_t("^ foo").does_match("foo bar"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("^ bar").does_match("foo bar"), false);
-        TS_ASSERT_EQUALS(scope::selector_t("^ foo").does_match("foo bar foo"), true);
-        TS_ASSERT_EQUALS(scope::selector_t("foo $").does_match("foo bar"), false);
-        TS_ASSERT_EQUALS(scope::selector_t("bar $").does_match("foo bar"), true);
-    }
-
-    void test_scope_selector ()
-    {
-        static scope::scope_t const textScope = "text.html.markdown meta.paragraph.markdown markup.bold.markdown";
-        static scope::selector_t const matchingSelectors[] =
-        {
-            "text.* markup.bold",
-            "text markup.bold",
-            "markup.bold",
-            "text.html meta.*.markdown markup",
-            "text.html meta.* markup",
-            "text.html * markup",
-            "text.html markup",
-            "text markup",
-            "markup",
-            "text.html",
-            "text"
-        };
-
-        double lastRank = 1;
-        for(size_t i = 0; i < sizeofA(matchingSelectors); ++i)
-        {
-            double rank;
-            TS_ASSERT(matchingSelectors[i].does_match(textScope, &rank));
-            TS_ASSERT_LESS_THAN(rank, lastRank);
-            lastRank = rank;
-        }
-    }
-};
-*/
-
 
 /// This method tests the score selector
 void TextDocumentScopesTest::testScopeSelectorRanking()
@@ -120,24 +50,24 @@ void TextDocumentScopesTest::testScopeSelectorRanking()
     TextScopeList* multiScope = sm->createTextScopeList("text.html.markdown meta.paragraph.markdown markup.bold.markdown");
 
     QList<TextScopeSelector*> selectors;
-    selectors.append( new TextScopeSelector("text.* markup.bold") );
-    selectors.append( new TextScopeSelector("text markup.bold") );
-    selectors.append( new TextScopeSelector("markup.bold") );
-    selectors.append( new TextScopeSelector("text.html meta.*.markdown markup") );
-    selectors.append( new TextScopeSelector("text.html meta.* markup") );
-    selectors.append( new TextScopeSelector("text.html * markup") );
-    selectors.append( new TextScopeSelector("text.html markup") );
-    selectors.append( new TextScopeSelector("text markup") );
-    selectors.append( new TextScopeSelector("markup") );
-    selectors.append( new TextScopeSelector("text.html") );
-    selectors.append( new TextScopeSelector("text") );
+    selectors.append(new TextScopeSelector("text.* markup.bold"));
+    selectors.append(new TextScopeSelector("text markup.bold"));
+    selectors.append(new TextScopeSelector("markup.bold"));
+    selectors.append(new TextScopeSelector("text.html meta.*.markdown markup"));
+    selectors.append(new TextScopeSelector("text.html meta.* markup"));
+    selectors.append(new TextScopeSelector("text.html * markup"));
+    selectors.append(new TextScopeSelector("text.html markup"));
+    selectors.append(new TextScopeSelector("text markup"));
+    selectors.append(new TextScopeSelector("markup"));
+    selectors.append(new TextScopeSelector("text.html"));
+    selectors.append(new TextScopeSelector("text"));
 
     double lastRank = 1.0;
-    for(int i = 0; i < selectors.size(); ++i)
+    for (qsizetype i = 0; i < selectors.size(); ++i)
     {
         TextScopeSelector* sel = selectors.at(i);
-        double rank = sel->calculateMatchScore( multiScope );
-        if( !(rank < lastRank ) ) {
+        double rank = sel->calculateMatchScore(multiScope);
+        if (!(rank < lastRank)) {
             qlog_info() << "SCOPES: " << multiScope->toString();
             qlog_info() << "  PREV: " << selectors.at(i-1)->toString();
             qlog_info() << "  rank: " << lastRank;
@@ -146,14 +76,11 @@ void TextDocumentScopesTest::testScopeSelectorRanking()
             qlog_info() << "  rank: " << rank;
         }
 
-        testTrue( rank < lastRank );
+        testTrue(rank < lastRank);
         lastRank = rank;
     }
     qDeleteAll(selectors);
     delete multiScope;
 }
-
-
-
 
 } // edbee

--- a/edbee-test/edbee/models/textdocumentscopestest.h
+++ b/edbee-test/edbee/models/textdocumentscopestest.h
@@ -13,14 +13,12 @@ class TextDocumentScopesTest : public edbee::test::TestCase
 Q_OBJECT
 
 private slots:
-
     void testStartsWith();
     void testRindexOf();
 
     void testScopeSelectorRanking();
 
 };
-
 
 } // edbee
 

--- a/edbee-test/edbee/models/textdocumentscopestest.h
+++ b/edbee-test/edbee/models/textdocumentscopestest.h
@@ -17,7 +17,6 @@ private slots:
     void testRindexOf();
 
     void testScopeSelectorRanking();
-
 };
 
 } // edbee

--- a/edbee-test/edbee/models/textdocumenttest.cpp
+++ b/edbee-test/edbee/models/textdocumenttest.cpp
@@ -31,51 +31,51 @@ void TextDocumentTest::testLineData()
     CharTextDocument doc;
     TextBuffer* buf = doc.buffer();
     buf->appendText("aaa\nbbb\nccc");
-    testTrue( doc.getLineData( 0, 0 ) == 0 );
-    testTrue( doc.getLineData( 1, 0 ) == 0 );
-    testTrue( doc.getLineData( 2, 0 ) == 0 );
+    testTrue(doc.getLineData(0, 0) == 0);
+    testTrue(doc.getLineData(1, 0) == 0);
+    testTrue(doc.getLineData(2, 0) == 0);
 
     // set an item at line 1
-    doc.giveLineData( 1, 0, new QStringTextLineData("test") );
-    testTrue( doc.getLineData( 0, 0 ) == 0 );
-    testTrue( doc.getLineData( 1, 0 ) != 0 );
-    testTrue( doc.getLineData( 2, 0 ) == 0 );
+    doc.giveLineData(1, 0, new QStringTextLineData("test"));
+    testTrue(doc.getLineData(0, 0) == 0);
+    testTrue(doc.getLineData(1, 0) != 0);
+    testTrue(doc.getLineData(2, 0) == 0);
 
-    QStringTextLineData* data = dynamic_cast<QStringTextLineData*>( doc.getLineData(1,0) );
-    testEqual( data->value(), "test" );
+    QStringTextLineData* data = dynamic_cast<QStringTextLineData*>(doc.getLineData(1, 0));
+    testEqual(data->value(), "test");
     data->setValue("new-test");
 
     // inserting a line should 'shift' the data to the next line
-    buf->replaceText(1,0, "\n");
-    testBuffer( buf, "a\naa\nbbb\nccc","0,2,5,9");
-    testTrue( doc.getLineData( 0, 0 ) == 0 );
-    testTrue( doc.getLineData( 1, 0 ) == 0 );
-    testTrue( doc.getLineData( 2, 0 ) != 0 );
+    buf->replaceText(1, 0, "\n");
+    testBuffer(buf, "a\naa\nbbb\nccc","0,2,5,9");
+    testTrue(doc.getLineData(0, 0) == 0);
+    testTrue(doc.getLineData(1, 0) == 0);
+    testTrue(doc.getLineData(2, 0) != 0);
 
-    Q_ASSERT(doc.getLineData( 1, 0 )==0);
-    Q_ASSERT(doc.getLineData( 2, 0 ));
+    Q_ASSERT(doc.getLineData(1, 0) == 0);
+    Q_ASSERT(doc.getLineData(2, 0));
 
-    data = dynamic_cast<QStringTextLineData*>( doc.getLineData(2,0) );
+    data = dynamic_cast<QStringTextLineData*>(doc.getLineData(2, 0));
     Q_ASSERT(data);
-    testEqual( data->value(), "new-test" );
+    testEqual(data->value(), "new-test");
 
     // removing a line should 'shift' the data to the previous line
-    buf->replaceText(0,4,"");
-    testBuffer( buf, "\nbbb\nccc","0,1,5");
-    testTrue( doc.getLineData( 0, 0 ) == 0 );
-    testTrue( doc.getLineData( 1, 0 ) != 0 );
-    testTrue( doc.getLineData( 2, 0 ) == 0 );
+    buf->replaceText(0, 4, "");
+    testBuffer(buf, "\nbbb\nccc","0,1,5");
+    testTrue(doc.getLineData(0, 0) == 0);
+    testTrue(doc.getLineData(1, 0) != 0);
+    testTrue(doc.getLineData(2, 0) == 0);
 
     // replacing a line with a new line should remove the field
-    buf->replaceText(0,3,"\n");
-    testBuffer( buf, "\nb\nccc","0,1,3");
-    testTrue( doc.getLineData( 0, 0 ) == 0 );
-    testTrue( doc.getLineData( 1, 0 ) == 0 );
+    buf->replaceText(0, 3, "\n");
+    testBuffer(buf, "\nb\nccc","0,1,3");
+    testTrue(doc.getLineData(0, 0) == 0);
+    testTrue(doc.getLineData(1, 0) == 0);
 
     // remove all items
-    buf->replaceText(0,100,"");
-    testBuffer( buf, "","0");
-    testTrue( doc.getLineData( 0, 0 ) == 0 );
+    buf->replaceText(0, 100, "");
+    testBuffer(buf, "", "0");
+    testTrue(doc.getLineData(0, 0) == 0);
 }
 
 
@@ -92,17 +92,17 @@ void TextDocumentTest::testReplaceRangeSet_simple()
     ranges.addRange(1,2);
 
     // execute the replace, this should also move the ranges
-    doc.replaceRangeSet( ranges, "X" );
-    testEqual( doc.text(), "aXcd");
-    testEqual( ranges.rangesAsString(), "2>2");
+    doc.replaceRangeSet(ranges, "X");
+    testEqual(doc.text(), "aXcd");
+    testEqual(ranges.rangesAsString(), "2>2");
 
     // next test multiple carets
     /// b) "a[X]b[c]d => "aR[]bSd
-    ranges.setRange(1,2);
-    ranges.addRange(3,4);
-    doc.replaceRangeSet( ranges, QStringLiteral("R,S").split(",") );
-    testEqual( doc.text(), "aRcS");
-    testEqual( ranges.rangesAsString(), "2>2,4>4");
+    ranges.setRange(1, 2);
+    ranges.addRange(3, 4);
+    doc.replaceRangeSet(ranges, QStringLiteral("R,S").split(","));
+    testEqual(doc.text(), "aRcS");
+    testEqual(ranges.rangesAsString(), "2>2,4>4");
 }
 
 
@@ -115,12 +115,12 @@ void TextDocumentTest::testReplaceRangeSet_sizeDiff()
 
     // create the ranges
     TextRangeSet ranges(&doc);
-    ranges.addRange(1,3);
-    ranges.addRange(5,7);
+    ranges.addRange(1, 3);
+    ranges.addRange(5, 7);
 
     // execute the replace, this should move the ranges
-    doc.replaceRangeSet( ranges, QStringLiteral("X,Y").split(",") );
-    testEqual( doc.text(), "aXdeYh");
+    doc.replaceRangeSet(ranges, QStringLiteral("X,Y").split(","));
+    testEqual(doc.text(), "aXdeYh");
 }
 
 
@@ -133,13 +133,12 @@ void TextDocumentTest::testReplaceRangeSet_simpleInsert()
 
     // create the ranges
     TextRangeSet ranges(&doc);
-    ranges.addRange(1,1);
-    ranges.addRange(2,2);
+    ranges.addRange(1, 1);
+    ranges.addRange(2, 2);
 
-    doc.replaceRangeSet( ranges, QStringLiteral("X,Y").split(",") );
-    testEqual( doc.text(), "aXbYcd");
-    testEqual( ranges.rangesAsString(), "2>2,4>4" );
-
+    doc.replaceRangeSet(ranges, QStringLiteral("X,Y").split(","));
+    testEqual(doc.text(), "aXbYcd");
+    testEqual(ranges.rangesAsString(), "2>2,4>4");
 }
 
 
@@ -152,14 +151,27 @@ void TextDocumentTest::testReplaceRangeSet_delete()
 
     // create the ranges
     TextRangeSet ranges(&doc);
-    ranges.addRange(1,2);
-    ranges.addRange(5,6);
+    ranges.addRange(1, 2);
+    ranges.addRange(5, 6);
 
-    doc.replaceRangeSet( ranges, "" );
-    testEqual( doc.text(), "ab2cd4" );
-    testEqual( ranges.rangesAsString(), "1>1,4>4" );
+    doc.replaceRangeSet(ranges, "" );
+    testEqual(doc.text(), "ab2cd4");
+    testEqual(ranges.rangesAsString(), "1>1,4>4");
 }
 
+/// Tests a delete operation
+/// a[1] =>  ""
+void TextDocumentTest::testReplaceRangeSet_delete2()
+{
+    CharTextDocument doc;
+    doc.append("r");
 
+    // create the ranges
+    TextRangeSet ranges(&doc);
+    ranges.addRange(1, 0);
+
+    doc.replaceRangeSet(ranges, "");
+    testEqual( doc.text(), "");
+}
 
 } // edbee

--- a/edbee-test/edbee/models/textdocumenttest.h
+++ b/edbee-test/edbee/models/textdocumenttest.h
@@ -18,10 +18,9 @@ private slots:
     void testReplaceRangeSet_sizeDiff();
     void testReplaceRangeSet_simpleInsert();
     void testReplaceRangeSet_delete();
+    void testReplaceRangeSet_delete2();
 };
 
-
 } // edbee
-
 
 DECLARE_TEST(edbee::TextDocumentTest);

--- a/edbee-test/edbee/models/textlinedatatest.cpp
+++ b/edbee-test/edbee/models/textlinedatatest.cpp
@@ -98,30 +98,20 @@ void TextLineDataTest::testSetTextLineDataIssue66()
     TextEditorController* controller = widget.controller();
     TextLineDataManager* tdm = doc->lineDataManager();
 
-
-qDebug()<<"\n ========================================";
-qDebug()<< "setText(a\\nb\\nc)" ;
     doc->setText("a\nb\nc");
     testEqual(filledTestString(*tdm), "---");
     qDebug() << "- a:" <<  filledTestString(*tdm);
 
-qDebug()<<"\n ========================================";
-qDebug()<< "setText(a\\nb)" ;
     doc->setText("a\nb");
     testEqual(filledTestString(*tdm), "--");
     qDebug() << "- b:" <<  filledTestString(*tdm);
     qDebug() << "G";
 
-qDebug()<<"\n ========================================";
-qDebug()<< "undo()";
     controller->undo();
     testEqual( filledTestString(*tdm), "---");
     qDebug() << "- c:" <<  filledTestString(*tdm);
     qDebug() << "H";
 
-//    exit(1);
-qDebug()<<"\n ========================================";
-qDebug()<< "setText(a)";
     doc->setText("a");
     qDebug() << "I";
 }

--- a/edbee-test/edbee/models/textlinedatatest.cpp
+++ b/edbee-test/edbee/models/textlinedatatest.cpp
@@ -13,11 +13,11 @@
 
 namespace edbee {
 
-static QString filledTestString( const TextLineDataManager& ldm )
+static QString filledTestString( const TextLineDataManager& ldm)
 {
     QString str;
-    for( int i=0; i<ldm.length(); ++i ) {
-        if( ldm.at(i) ) {
+    for (size_t i = 0; i < ldm.length(); ++i) {
+        if (ldm.at(i)) {
             str.append("X");
         } else {
             str.append("-");
@@ -26,71 +26,82 @@ static QString filledTestString( const TextLineDataManager& ldm )
     return str;
 }
 
-/// A special class for detecting 'destructor' and destroy calls
+
+/// Detecting 'destructor' and destroy calls
 class DestructorTestList : public TextLineDataList
 {
 public:
-    DestructorTestList( int& destroyRef, int& destructorRef) : destroyCallCountRef_(destroyRef), destructorCallCountRef_(destructorRef) {}
-    virtual ~DestructorTestList() { ++destructorCallCountRef_; }
-    virtual void destroy( TextLineDataManager* manager ) { Q_UNUSED(manager); ++destroyCallCountRef_; }
+    DestructorTestList(int& destroyRef, int& destructorRef)
+        : destroyCallCountRef_(destroyRef)
+        , destructorCallCountRef_(destructorRef) {}
+
+    virtual ~DestructorTestList()
+    {
+        ++destructorCallCountRef_;
+    }
+
+    virtual void destroy(TextLineDataManager* manager)
+    {
+        Q_UNUSED(manager);
+        ++destroyCallCountRef_;
+    }
+
 private:
     int& destroyCallCountRef_;
     int& destructorCallCountRef_;
 };
 
 
-
 /// Tests the line data manager
 void TextLineDataTest::testLineDataManager()
 {
     TextLineDataManager ldm;
-    testEqual( filledTestString(ldm ), "-");
+    testEqual(filledTestString(ldm ), "-");
 
     // insert a line
-    ldm.fillWithEmpty(0,0,2);
-    testEqual( filledTestString(ldm ), "---");
+    ldm.fillWithEmpty(0, 0, 2);
+    testEqual(filledTestString(ldm ), "---");
 
     // set an item
-    int destroyCount=0;
-    int destructCount=0;
+    int destroyCount = 0;
+    int destructCount = 0;
     DestructorTestList* list = new DestructorTestList(destroyCount, destructCount);
-    ldm.giveList(1, list );
-    testEqual( filledTestString(ldm ), "-X-");
-    testEqual( destroyCount, 0 );
-    testEqual( destructCount, 0 );
-
+    ldm.giveList(1, list);
+    testEqual(filledTestString(ldm), "-X-");
+    testEqual(destroyCount, 0);
+    testEqual(destructCount, 0);
 
     // inserting an item should move the data items
-    ldm.fillWithEmpty(1,0,1);
-    testEqual( filledTestString(ldm ), "--X-");
-    testEqual( destroyCount, 0 );
-    testEqual( destructCount, 0 );
+    ldm.fillWithEmpty(1, 0, 1);
+    testEqual(filledTestString(ldm), "--X-");
+    testEqual(destroyCount, 0);
+    testEqual(destructCount, 0);
 
     // taking a list item sould not call the destructor or destroy method
-    testEqual( (quintptr)list, (quintptr)ldm.takeList(2) );
-    testEqual( filledTestString(ldm ), "----");
-    testEqual( destroyCount, 0 );
-    testEqual( destructCount, 0 );
+    testEqual((quintptr)list, (quintptr)ldm.takeList(2));
+    testEqual(filledTestString(ldm ), "----");
+    testEqual(destroyCount, 0);
+    testEqual(destructCount, 0);
 
     // giving a list back should work
-    ldm.giveList(1, list );
-    testEqual( filledTestString(ldm ), "-X--");
-    testEqual( destroyCount, 0 );
-    testEqual( destructCount, 0 );
+    ldm.giveList(1, list);
+    testEqual( filledTestString(ldm), "-X--");
+    testEqual(destroyCount, 0);
+    testEqual(destructCount, 0);
 
     // fill with empty call destroy and the destructor of the list
-    ldm.fillWithEmpty(1,2,0);
-    testEqual( filledTestString(ldm ), "--");
-    testEqual( destroyCount, 1 );
-    testEqual( destructCount, 1 );
+    ldm.fillWithEmpty(1, 2, 0);
+    testEqual(filledTestString(ldm), "--");
+    testEqual(destroyCount, 1 );
+    testEqual( destructCount, 1);
     qDebug() << "E";
 }
 
 /// References issue #66 github
 /// Calling setText() with a shorter text (less lines) then the original
-//Undo it
-//Cut a text (I suspect multiple lines)
-//And call setText() again with a shorter text
+/// - Undo it
+/// - Cut a text (I suspect multiple lines)
+/// - And call setText() again with a shorter text
 void TextLineDataTest::testSetTextLineDataIssue66()
 {
     TextEditorWidget widget;
@@ -100,20 +111,14 @@ void TextLineDataTest::testSetTextLineDataIssue66()
 
     doc->setText("a\nb\nc");
     testEqual(filledTestString(*tdm), "---");
-    qDebug() << "- a:" <<  filledTestString(*tdm);
 
     doc->setText("a\nb");
     testEqual(filledTestString(*tdm), "--");
-    qDebug() << "- b:" <<  filledTestString(*tdm);
-    qDebug() << "G";
 
     controller->undo();
-    testEqual( filledTestString(*tdm), "---");
-    qDebug() << "- c:" <<  filledTestString(*tdm);
-    qDebug() << "H";
+    testEqual(filledTestString(*tdm), "---");
 
     doc->setText("a");
-    qDebug() << "I";
 }
 
 } // edbee

--- a/edbee-test/edbee/models/textlinedatatest.h
+++ b/edbee-test/edbee/models/textlinedatatest.h
@@ -14,10 +14,7 @@ class TextLineDataTest : public edbee::test::TestCase
 private slots:
 
     void testLineDataManager();
-
     void testSetTextLineDataIssue66();
-
-
 };
 
 } // edbee

--- a/edbee-test/edbee/models/textrangetest.cpp
+++ b/edbee-test/edbee/models/textrangetest.cpp
@@ -18,7 +18,7 @@
 namespace edbee {
 
 
-#define testRanges( expected ) \
+#define testRanges(expected) \
 do { \
     QString ranges = selRef_->rangesAsString(); \
     testEqual( ranges, expected ); \
@@ -28,14 +28,14 @@ do { \
 /// Creates a selection object
 /// @param doc the document to use
 /// @param definition the definition. In the format  anchor>caret,anchor>caret
-static void addRanges( TextRangeSet* sel, const QString& definition )
+static void addRanges(TextRangeSet* sel, const QString& definition)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QStringList ranges = definition.split(",", Qt::SkipEmptyParts);
 #else
     QStringList ranges = definition.split(",", QString::SkipEmptyParts);
 #endif
-    foreach( QString range, ranges ) {
+    foreach(QString range, ranges) {
         QStringList values = range.split(">");
         Q_ASSERT(values.length() == 2);
         int anchor = values.at(0).trimmed().toInt();
@@ -47,11 +47,11 @@ static void addRanges( TextRangeSet* sel, const QString& definition )
 
 /// Inializes this testcase
 TextRangeTest::TextRangeTest()
-    : doc_(0)
-    ,bufRef_(0)
+    : doc_(nullptr)
+    ,bufRef_(nullptr)
 {
-
 }
+
 
 void TextRangeTest::init()
 {
@@ -63,9 +63,9 @@ void TextRangeTest::init()
 /// cleansup this test case
 void TextRangeTest::clean()
 {
-    bufRef_ = 0;
+    bufRef_ = nullptr;
     delete doc_;
-    doc_ = 0;
+    doc_ = nullptr;
 }
 
 
@@ -74,21 +74,21 @@ void TextRangeTest::testMoveCaret()
 {
     bufRef_->appendText("regel 1.\n   leading whitespace\n   \n trailing  whitespace   \neof");
 
-    TextRange range(0,0);
+    TextRange range(0, 0);
     range.setCaret(4);
 
-    range.moveCaret(doc_,-1);
-    testEqual( range.caret(), 3 );
+    range.moveCaret(doc_, -1);
+    testEqual(range.caret(), 3);
 
-    range.moveCaret(doc_,-2);
-    testEqual( range.caret(), 1 );
+    range.moveCaret(doc_, -2);
+    testEqual(range.caret(), 1);
 
-    range.moveCaret(doc_,-2);
-    testEqual( range.caret(), 0 );
+    range.moveCaret(doc_, -2);
+    testEqual(range.caret(), 0);
 
-    range.setCaret(doc_->length()-2);
-    range.moveCaret(doc_,10);
-    testEqual( range.caret(), bufRef_->length() );
+    range.setCaret(doc_->length() - 2);
+    range.moveCaret(doc_, 10);
+    testEqual(range.caret(), bufRef_->length());
 }
 
 
@@ -99,133 +99,129 @@ void TextRangeTest::testMoveCaretOrDeselect()
     bufRef_->setText("abcdefghijklmnop");
 
     // test normal move left
-    TextRange range(1,1);
-    range.moveCaretOrDeselect(doc_,-1);
-    testEqual( range.caret(), 0);
-    testEqual( range.anchor(), 1);
+    TextRange range(1, 1);
+    range.moveCaretOrDeselect(doc_, -1);
+    testEqual(range.caret(), 0);
+    testEqual(range.anchor(), 1);
 
     // test normal move right
-    range.moveCaretOrDeselect(doc_,1);
+    range.moveCaretOrDeselect(doc_, 1);
     testEqual( range.caret(), 1);
     testEqual( range.anchor(), 1);
 
     // when there's a range is should be placed to the left
-    range.set( 1, 2 );
-    range.moveCaretOrDeselect(doc_,-1);
-    testEqual( range.caret(), 1);
-    testEqual( range.anchor(), 1);
+    range.set(1, 2);
+    range.moveCaretOrDeselect(doc_, -1);
+    testEqual(range.caret(), 1);
+    testEqual(range.anchor(), 1);
 
     // and test the reverse
-    range.set( 2, 1 );
-    range.moveCaretOrDeselect(doc_,-1);
-    testEqual( range.caret(), 1);
-    testEqual( range.anchor(), 1);
+    range.set(2, 1);
+    range.moveCaretOrDeselect(doc_, -1);
+    testEqual(range.caret(), 1);
+    testEqual(range.anchor(), 1);
 
 
     // when there's a range is should be placed to the left
-    range.set( 1, 2 );
-    range.moveCaretOrDeselect(doc_,1);
-    testEqual( range.caret(), 2);
-    testEqual( range.anchor(), 2);
+    range.set(1, 2);
+    range.moveCaretOrDeselect(doc_, 1);
+    testEqual(range.caret(), 2);
+    testEqual(range.anchor(), 2);
 
     // test the reverse
-    range.set( 2, 1 );
-    range.moveCaretOrDeselect(doc_,1);
-    testEqual( range.caret(), 2);
-    testEqual( range.anchor(), 2);
+    range.set(2, 1);
+    range.moveCaretOrDeselect(doc_, 1);
+    testEqual(range.caret(), 2);
+    testEqual(range.anchor(), 2);
 
 }
-
 
 
 /// This method moves the caret while the current character is the given values
 void TextRangeTest::testMoveCaretWhileChar()
 {
-    bufRef_->replaceText(0,0,"  abacdx!");
+    bufRef_->replaceText(0, 0,"  abacdx!");
 
-    TextRange range(0,0);
-    testEqual( range.caret(), 0 );
+    TextRange range(0, 0);
+    testEqual(range.caret(), 0);
 
-    range.moveCaretWhileChar( doc_, 1, "a" );
-    testEqual( range.caret(), 0 );
+    range.moveCaretWhileChar(doc_, 1, "a");
+    testEqual(range.caret(), 0 );
 
-    range.moveCaretWhileChar( doc_, 1, "\t x" );
-    testEqual( range.caret(), 2 );
+    range.moveCaretWhileChar(doc_, 1, "\t x");
+    testEqual(range.caret(), 2 );
 
-    range.moveCaretWhileChar( doc_, 1, "abc" );
-    testEqual( range.caret(), 6 );
+    range.moveCaretWhileChar(doc_, 1, "abc");
+    testEqual(range.caret(), 6 );
 
-    range.moveCaretWhileChar( doc_, 1, "de xyz" );
-    testEqual( range.caret(), 8 );
+    range.moveCaretWhileChar(doc_, 1, "de xyz");
+    testEqual(range.caret(), 8 );
 
-    range.moveCaretWhileChar( doc_, 1, "#!" );
-    testEqual( range.caret(), 9 );
-    testEqual( range.caret(), doc_->length() );
+    range.moveCaretWhileChar(doc_, 1, "#!");
+    testEqual(range.caret(), 9 );
+    testEqual(range.caret(), doc_->length());
 
+    range.moveCaretWhileChar(doc_, -1, "#!");
+    testEqual(range.caret(), 8 );
 
-    range.moveCaretWhileChar( doc_, -1, "#!" );
-    testEqual( range.caret(), 8 );
+    range.moveCaretWhileChar(doc_, -1, "abcdx");
+    testEqual(range.caret(), 2 );
 
-    range.moveCaretWhileChar( doc_, -1, "abcdx" );
-    testEqual( range.caret(), 2 );
-
-    range.moveCaretWhileChar( doc_, -1, "a c" );
-    testEqual( range.caret(), 0 );
+    range.moveCaretWhileChar(doc_, -1, "a c");
+    testEqual(range.caret(), 0);
 }
 
 
 void TextRangeTest::testMoveCaretUntilChar()
 {
-    bufRef_->replaceText(0,0,"  abacdx!");
+    bufRef_->replaceText(0, 0,"  abacdx!");
 
     TextRange range(0,0);
-    testEqual( range.caret(), 0 );
+    testEqual(range.caret(), 0);
 
-    range.moveCaretUntilChar( doc_, 1, "bc" );
-    testEqual( range.caret(), 3 );
+    range.moveCaretUntilChar(doc_, 1, "bc");
+    testEqual(range.caret(), 3);
 
-    range.moveCaretUntilChar( doc_, 1, "xyz" );
-    testEqual( range.caret(), 7 );
+    range.moveCaretUntilChar(doc_, 1, "xyz");
+    testEqual(range.caret(), 7);
 
-    range.moveCaretUntilChar( doc_, 1, "$" );
-    testEqual( range.caret(), doc_->length() );
+    range.moveCaretUntilChar(doc_, 1, "$");
+    testEqual(range.caret(), doc_->length());
 
-    range.moveCaretUntilChar( doc_, -1, "b" );
-    testEqual( range.caret(), 4 );
+    range.moveCaretUntilChar(doc_, -1, "b");
+    testEqual(range.caret(), 4);
 
-    range.moveCaretUntilChar( doc_, -1, "$" );
-    testEqual( range.caret(), 0 );
-
+    range.moveCaretUntilChar(doc_, -1, "$");
+    testEqual(range.caret(), 0);
 }
 
 
 void TextRangeTest::testMoveCaretByCharGroup()
 {
-    bufRef_->replaceText(0,bufRef_->length(),"");
-    bufRef_->replaceText(0,0,"something !! in @@ the ## water $$ does %% not ^^ compute\n   something!!in@@the##water$$does%%not^^compute");
+    bufRef_->replaceText(0, bufRef_->length(), "");
+    bufRef_->replaceText(0, 0, "something !! in @@ the ## water $$ does %% not ^^ compute\n   something!!in@@the##water$$does%%not^^compute");
     //                     0123456789012345678901234567890
     //"regel 1.|   leading whitespace|   | trailing  whitespace   |eof"
 
-    TextRange range(0,0);
+    TextRange range(0, 0);
     QStringList sep("!@#$%^");
     QString ws("\n\t ");
 
-    range.moveCaretByCharGroup( doc_, 1, ws, sep );
-    testEqual( range.caret(), 9 );
+    range.moveCaretByCharGroup(doc_, 1, ws, sep);
+    testEqual(range.caret(), 9 );
 
-    range.moveCaretByCharGroup( doc_, 2, ws, sep );
-    testEqual( range.caret(), 15 );
+    range.moveCaretByCharGroup(doc_, 2, ws, sep);
+    testEqual(range.caret(), 15 );
 
-    range.moveCaretByCharGroup( doc_, 1, ws, sep );
-    testEqual( range.caret(), 18);
+    range.moveCaretByCharGroup(doc_, 1, ws, sep);
+    testEqual(range.caret(), 18);
 
-    range.moveCaretByCharGroup( doc_, -1, ws, sep );
-    testEqual( range.caret(), 16);
+    range.moveCaretByCharGroup(doc_, -1, ws, sep);
+    testEqual(range.caret(), 16);
 
-    range.moveCaretByCharGroup( doc_, -2, ws, sep );
-    testEqual( range.caret(), 10);
+    range.moveCaretByCharGroup(doc_, -2, ws, sep);
+    testEqual(range.caret(), 10);
 }
-
 
 
 /// moves the caret to the line boundary
@@ -233,73 +229,71 @@ void TextRangeTest::testMoveCaretToLineBoundary()
 {
     bufRef_->appendText("regel 1.\n   leading whitespace\n   \n trailing  whitespace   \neof");
 
-    TextRange range(0,0);
+    TextRange range(0, 0);
     QString ws = "\t ";
-    testEqual( range.caret(), 0 );
+    testEqual(range.caret(), 0);
 
     // test move to EOL (normal line)
-    range.moveCaretToLineBoundary( doc_, 1, ws );
-    testEqual( range.caret(), 8 );
+    range.moveCaretToLineBoundary(doc_, 1, ws);
+    testEqual(range.caret(), 8);
 
-    range.moveCaretToLineBoundary( doc_, 1, ws );   // moving again should stay there
-    testEqual( range.caret(), 8 );
+    range.moveCaretToLineBoundary(doc_, 1, ws);   // moving again should stay there
+    testEqual(range.caret(), 8);
 
     // test move to start of first word
     range.setCaret(9);  // second line
-    range.moveCaretToLineBoundary( doc_, -1, ws );
-    testEqual( range.caret(), 12 );
+    range.moveCaretToLineBoundary(doc_, -1, ws);
+    testEqual(range.caret(), 12 );
 
-    range.moveCaretToLineBoundary( doc_, -1, ws );  // test movement to start of lie from first word
-    testEqual( range.caret(), 9 );
+    range.moveCaretToLineBoundary(doc_, -1, ws);  // test movement to start of lie from first word
+    testEqual(range.caret(), 9 );
 
     range.setCaret(14);  // second line
-    range.moveCaretToLineBoundary( doc_, -1, ws );  // test movement to start of word from half line
-    testEqual( range.caret(), 12 );
+    range.moveCaretToLineBoundary(doc_, -1, ws);  // test movement to start of word from half line
+    testEqual(range.caret(), 12 );
 
     // test eol specials
     int endDocPos = doc_->length();
     range.setCaret(endDocPos);
-    range.moveCaretToLineBoundary( doc_, 1, ws );  // movement to the end at the end should stay at the end
-    testEqual( range.caret(), endDocPos );
+    range.moveCaretToLineBoundary(doc_, 1, ws);  // movement to the end at the end should stay at the end
+    testEqual(range.caret(), endDocPos );
 
-    range.moveCaretToLineBoundary( doc_, -1, ws );  // movement to the end at the end should stay at the end
-    testEqual( range.caret(), 60 );
+    range.moveCaretToLineBoundary(doc_, -1, ws);  // movement to the end at the end should stay at the end
+    testEqual(range.caret(), 60 );
 
-    range.moveCaretToLineBoundary( doc_, -1, ws );  // moving again should stay there
-    testEqual( range.caret(), 60 );
+    range.moveCaretToLineBoundary(doc_, -1, ws);  // moving again should stay there
+    testEqual(range.caret(), 60 );
 
-    range.moveCaretToLineBoundary( doc_, 1, ws );  // And should move to the end again
-    testEqual( range.caret(), endDocPos );
+    range.moveCaretToLineBoundary(doc_, 1, ws);  // And should move to the end again
+    testEqual(range.caret(), endDocPos );
 
-    range.set( endDocPos, endDocPos );
-    range.moveCaretToLineBoundary( doc_, 1, ws );  // And should move to the end again
-    testEqual( range.caret(), endDocPos );
+    range.set(endDocPos, endDocPos );
+    range.moveCaretToLineBoundary(doc_, 1, ws);  // And should move to the end again
+    testEqual(range.caret(), endDocPos);
 
     // test issue #77
     bufRef_->setText("a\nb\n");
     range.set(2,2);
     range.moveCaretToLineBoundary( doc_, 1, ws );
     testEqual( range.caret(), 3 );
-
-
 }
+
 
 void TextRangeTest::testMoveNonBmpCharacters()
 {
     bufRef_->appendText("a😂aa");
 
-    TextRange range(0,0);
+    TextRange range(0, 0);
     range.setCaret(0);
 
-    range.moveCaret(doc_,1);
-    testEqual( range.caret(), 1 );
+    range.moveCaret(doc_, 1);
+    testEqual(range.caret(), 1);
 
-    range.moveCaret(doc_,1);
-    testEqual( range.caret(), 3 );
+    range.moveCaret(doc_, 1);
+    testEqual(range.caret(), 3);
 
-    range.moveCaret(doc_,-1);
-    testEqual( range.caret(), 1 );
-
+    range.moveCaret(doc_, -1);
+    testEqual(range.caret(), 1);
 }
 
 
@@ -313,7 +307,7 @@ void TextRangeSetTest::init()
     docRef_ = controller_->textDocument();
     bufRef_ = docRef_->buffer();
     selRef_ = dynamic_cast<TextRangeSet*>( controller_->textSelection() );
-    selRef_->clear();   // remove all ranges
+    selRef_->clear();  // remove all ranges
 }
 
 
@@ -321,9 +315,9 @@ void TextRangeSetTest::init()
 void TextRangeSetTest::clean()
 {
     delete controller_;
-    selRef_= 0;
-    docRef_ = 0;
-    controller_ = 0;
+    selRef_= nullptr;
+    docRef_ = nullptr;
+    controller_ = nullptr;
 }
 
 
@@ -337,24 +331,24 @@ void TextRangeSetTest::testConstructor()
 /// This method test the overlapping ranges
 void TextRangeSetTest::testAddRange()
 {
-    selRef_->addRange(0,0);
-    selRef_->addRange(2,4);
+    selRef_->addRange(0, 0);
+    selRef_->addRange(2, 4);
     testRanges("0>0,2>4");
 
     // right 'overlap'  /////XX\\\\ .
-    selRef_->addRange(3,6);
+    selRef_->addRange(3, 6);
     testRanges("0>0,2>6");
 
     // overlap is ignored
-    selRef_->addRange(6,4);
+    selRef_->addRange(6, 4);
     testRanges("0>0,2>6");
 
     // check border conditions
-    selRef_->addRange(6,10);
+    selRef_->addRange(6, 10);
     testRanges("0>0,2>6,6>10");
 
     // replace the complete center part
-    selRef_->addRange(8,1);
+    selRef_->addRange(8, 1);
     testRanges("0>0,1>10");
 }
 
@@ -362,29 +356,29 @@ void TextRangeSetTest::testAddRange()
 /// test the range between offsets functions
 void TextRangeSetTest::testRangesBetweenOffsets()
 {
-    addRanges( selRef_, "0>0,2>6,8>10" );
+    addRanges(selRef_, "0>0,2>6,8>10");
 
-    int first=-1, last=-1;
-    testFalse( selRef_->rangesBetweenOffsets( 12, 25, first, last ) );
+    size_t first = std::string::npos, last = std::string::npos;
+    testFalse(selRef_->rangesBetweenOffsets(12, 25, first, last));
 
-    testTrue( selRef_->rangesBetweenOffsets( 9, 11, first, last ) );
-    testEqual( first, 2 );
-    testEqual( last, 2 );
+    testTrue( selRef_->rangesBetweenOffsets(9, 11, first, last));
+    testEqual(first, 2);
+    testEqual(last, 2);
 
     // test the 'border
-    testTrue( selRef_->rangesBetweenOffsets( 10, 11, first, last ) );
-    testEqual( first, 2 );
-    testEqual( last, 2 );
+    testTrue(selRef_->rangesBetweenOffsets(10, 11, first, last));
+    testEqual(first, 2);
+    testEqual(last, 2);
 
     // mutliple ranges
-    testTrue( selRef_->rangesBetweenOffsets( 3, 9, first, last ) );
-    testEqual( first, 1 );
-    testEqual( last, 2 );
+    testTrue(selRef_->rangesBetweenOffsets(3, 9, first, last));
+    testEqual(first, 1);
+    testEqual(last, 2);
 
     // position 0 should work
-    testTrue( selRef_->rangesBetweenOffsets( 0, 4, first, last ) );
-    testEqual( first, 0 );
-    testEqual( last, 1);
+    testTrue(selRef_->rangesBetweenOffsets(0, 4, first, last));
+    testEqual(first, 0 );
+    testEqual(last, 1);
 }
 
 
@@ -392,55 +386,55 @@ void TextRangeSetTest::testRangesBetweenOffsets()
 void TextRangeSetTest::testMoveCarets()
 {
     bufRef_->appendText("a1\nbb2\nccc3\n...\n");
-    selRef_->addRange(0,0);    // reset the selection
+    selRef_->addRange(0, 0);    // reset the selection
     testRanges("0>0");
 
     // basic tests
     //------------
 
-        // moving the caret to the right should work
-        selRef_->moveCarets(1);
-        testRanges("0>1");
+    // moving the caret to the right should work
+    selRef_->moveCarets(1);
+    testRanges("0>1");
 
-        // try to move past the end
-        selRef_->moveCarets(100);
-        testRanges("0>16");
+    // try to move past the end
+    selRef_->moveCarets(100);
+    testRanges("0>16");
 
-        // try move before the start of the document
-        selRef_->moveCarets(-100);
-        testRanges("0>0");
+    // try move before the start of the document
+    selRef_->moveCarets(-100);
+    testRanges("0>0");
 
     // multiple cursor tests
     //----------------------
 
-        selRef_->addRange(4,2);
-        testRanges("0>0,4>2");
+    selRef_->addRange(4, 2);
+    testRanges("0>0,4>2");
 
-        selRef_->moveCarets(-1);
-        testRanges("0>0,4>1");
+    selRef_->moveCarets(-1);
+    testRanges("0>0,4>1");
 
-        // check if the cursor is merged (the 0th cursor is special, because it cannot have any selection before it)
-        selRef_->moveCarets(-1);
-        testRanges("4>0");
+    // check if the cursor is merged (the 0th cursor is special, because it cannot have any selection before it)
+    selRef_->moveCarets(-1);
+    testRanges("4>0");
 
-        selRef_->resetAnchors();
-        testRanges("0>0");
+    selRef_->resetAnchors();
+    testRanges("0>0");
 
     // next test if rangings in the middle are placed next to eachother
 
-        selRef_->addRange(4,6);
-        selRef_->addRange(8,10);
-        testRanges("0>0,4>6,8>10");
+    selRef_->addRange(4, 6);
+    selRef_->addRange(8, 10);
+    testRanges("0>0,4>6,8>10");
 
-        selRef_->moveCarets(1);
-        testRanges("0>1,4>7,8>11");
+    selRef_->moveCarets(1);
+    testRanges("0>1,4>7,8>11");
 
-        // selections should only merge if they truely overlap
-        selRef_->moveCarets(1);
-        testRanges("0>2,4>8,8>12");
+    // selections should only merge if they truely overlap
+    selRef_->moveCarets(1);
+    testRanges("0>2,4>8,8>12");
 
-        selRef_->moveCarets(1);
-        testRanges("0>3,4>13");
+    selRef_->moveCarets(1);
+    testRanges("0>3,4>13");
 }
 
 
@@ -449,69 +443,63 @@ void TextRangeSetTest::testChangeSpatial()
 {
     bufRef_->appendText("a1\nbb2\nccc3\n...\n");
 
-    selRef_->addRange(0,0);
+    selRef_->addRange(0, 0);
     // range (0,0)
-    selRef_->addRange(4,6);
-    selRef_->addRange(8,13);
+    selRef_->addRange(4, 6);
+    selRef_->addRange(8, 13);
     testRanges("0>0,4>6,8>13");
 
     // "|a1#b[b2]#c[cc3#.]..#" => "|Xa1#b[b2]#c[cc3#.]..#"
-    selRef_->changeSpatial(0,0,1);
+    selRef_->changeSpatial(0, 0, 1);
     testRanges("1>1,5>7,9>14");
 
     // "|Xa1#b[b2]#c[cc3#.]..#" => "Xa1#[b2]#c[cc3#.]..#" );
-    selRef_->changeSpatial(4,2,0);
+    selRef_->changeSpatial(4, 2, 0);
     testRanges("1>1,4>5,7>12");
-
-//    sel_->addRange(0,0);
-//    sel_->changeSpatial(0, 1);
-
 }
 
 
 void TextRangeSetTest::testGetSelectedTextExpandedToFullLines()
 {
     bufRef_->appendText("aaa\nbbb\ncccc");
-    selRef_->addRange(0,0);
+    selRef_->addRange(0, 0);
     testEqual( selRef_->getSelectedTextExpandedToFullLines(), "aaa\n");
 
-    selRef_->setRange(1,1,0);
+    selRef_->setRange(1, 1, 0);
     testEqual( selRef_->getSelectedTextExpandedToFullLines(), "aaa\n");
 
-    selRef_->setRange(3,1,0);
+    selRef_->setRange(3, 1, 0);
     testEqual( selRef_->getSelectedTextExpandedToFullLines(), "aaa\n");
 
-    selRef_->setRange(4,4,0);
+    selRef_->setRange(4, 4, 0);
     testEqual( selRef_->getSelectedTextExpandedToFullLines(), "bbb\n");
 
-    selRef_->setRange(4,2,0);
+    selRef_->setRange(4, 2, 0);
     testEqual( selRef_->getSelectedTextExpandedToFullLines(), "aaa\nbbb\n");
 }
-
 
 
 /// Test substract rnage
 void TextRangeSetTest::testSubstractRange()
 {
     bufRef_->appendText("hier moet een lange genoege tekst staan.");
-    selRef_->addRange(2,5);
-    selRef_->addRange(8,10);
+    selRef_->addRange(2, 5);
+    selRef_->addRange(8, 10);
     testRanges("2>5,8>10");
 
     // test empty range
-    selRef_->substractRange(0,2);
+    selRef_->substractRange(0, 2);
     testRanges("2>5,8>10");
 
-    selRef_->substractRange(4,9);
+    selRef_->substractRange(4, 9);
     testRanges("2>4,9>10");
 
-    selRef_->substractRange(7,12);
+    selRef_->substractRange(7, 12);
     testRanges("2>4");
 
-    selRef_->setRange(2,10,0);
-    selRef_->substractRange(4,6);
+    selRef_->setRange(2, 10, 0);
+    selRef_->substractRange(4, 6);
     testRanges("2>4,6>10");
-
 }
 
 
@@ -519,9 +507,9 @@ void TextRangeSetTest::testSubstractRange()
 void TextRangeSetTest::testMergeOverlappingRanges()
 {
     selRef_->beginChanges();
-    selRef_->addRange(2,0);
-    selRef_->addRange(4,0);
-    selRef_->addRange(8,0);
+    selRef_->addRange(2, 0);
+    selRef_->addRange(4, 0);
+    selRef_->addRange(8, 0);
     testRanges("2>0,4>0,8>0");
     selRef_->mergeOverlappingRanges(false);
     testRanges("8>0");
@@ -540,36 +528,35 @@ void DynamicTextRangeSetTest::testDynamicChanges()
     doc->setText("abcdefg");
 
     DynamicTextRangeSet set(doc);
-    set.addRange(0,0);
-    set.addRange(1,1);
-    set.addRange(2,3);
-    testEqual( set.rangesAsString(), "0>0,1>1,2>3" );
-//    doc->replace(1,0,"123");
+    set.addRange(0, 0);
+    set.addRange(1, 1);
+    set.addRange(2, 3);
+    testEqual(set.rangesAsString(), "0>0,1>1,2>3");
 
     // insert the string
-    doc->replace(1,0,"123");
-    testEqual( doc->text(), "a123bcdefg" );
-    testEqual( set.rangesAsString(), "0>0,4>4,5>6" );
+    doc->replace(1, 0, "123");
+    testEqual(doc->text(), "a123bcdefg");
+    testEqual(set.rangesAsString(), "0>0,4>4,5>6");
 
     // test removing an item
-    set.range(0).set(1,2);
-    testEqual( set.rangesAsString(), "1>2,4>4,5>6" );
+    set.range(0).set(1, 2);
+    testEqual(set.rangesAsString(), "1>2,4>4,5>6");
 
     // test if a replace results in the deleton of a range
-    doc->replace(1,3,"");
-    testEqual( doc->text(), "abcdefg" );
-    testEqual( set.rangesAsString(), "1>1,2>3" );
+    doc->replace(1, 3, "");
+    testEqual(doc->text(), "abcdefg");
+    testEqual(set.rangesAsString(), "1>1,2>3");
 
     // in non-sticky mode this should move the caret
-    doc->replace(1,0,"X");
-    testEqual( doc->text(), "aXbcdefg" );
-    testEqual( set.rangesAsString(), "2>2,3>4" );
+    doc->replace(1, 0, "X");
+    testEqual(doc->text(), "aXbcdefg");
+    testEqual(set.rangesAsString(), "2>2,3>4");
 
     // in non-sticky mode this should not move the caret
     set.setStickyMode(true);
-    doc->replace(2,0,"Y");
-    testEqual( doc->text(), "aXYbcdefg" );
-    testEqual( set.rangesAsString(), "2>2,4>5" );
+    doc->replace(2, 0, "Y");
+    testEqual(doc->text(), "aXYbcdefg");
+    testEqual(set.rangesAsString(), "2>2,4>5");
 }
 
 
@@ -584,15 +571,15 @@ void DynamicTextRangeSetTest::testDeleteMode()
     {
         DynamicTextRangeSet set(doc);
         set.setDeleteMode(true);
-        set.addRange(0,0);
-        set.addRange(2,2);
-        set.addRange(4,4);
-        testEqual( set.rangesAsString(), "0>0,2>2,4>4" );
+        set.addRange(0, 0);
+        set.addRange(2, 2);
+        set.addRange(4, 4);
+        testEqual(set.rangesAsString(), "0>0,2>2,4>4");
 
         // replace
-        doc->replace(1,2,"");
-        testEqual( doc->text(), "adefg" );
-        testEqual( set.rangesAsString(), "0>0,2>2" );
+        doc->replace(1, 2, "");
+        testEqual(doc->text(), "adefg");
+        testEqual( set.rangesAsString(), "0>0,2>2");
     }
 
     // when delete mode is disabled the range should not be deleted
@@ -600,18 +587,16 @@ void DynamicTextRangeSetTest::testDeleteMode()
         doc->setText("abcdefg");
         DynamicTextRangeSet set(doc);
         set.setDeleteMode(false);
-        set.addRange(0,0);
-        set.addRange(2,2);
-        set.addRange(4,4);
-        testEqual( set.rangesAsString(), "0>0,2>2,4>4" );
+        set.addRange(0, 0);
+        set.addRange(2, 2);
+        set.addRange(4, 4);
+        testEqual(set.rangesAsString(), "0>0,2>2,4>4");
 
         // replace
-        doc->replace(1,2,"");
-        testEqual( doc->text(), "adefg" );
-        testEqual( set.rangesAsString(), "0>0,1>1,2>2" );
+        doc->replace(1, 2, "");
+        testEqual(doc->text(), "adefg");
+        testEqual(set.rangesAsString(), "0>0,1>1,2>2");
     }
-
 }
-
 
 } // edbee

--- a/edbee-test/edbee/models/textrangetest.h
+++ b/edbee-test/edbee/models/textrangetest.h
@@ -20,7 +20,6 @@ class TextRangeTest : public edbee::test::TestCase
 public:
     TextRangeTest();
 
-
 private slots:
     void init();
     void clean();
@@ -60,7 +59,6 @@ private slots:
     void testSubstractRange();
     void testMergeOverlappingRanges();
 
-
 private:
     TextEditorController* controller_;
     TextDocument* docRef_;
@@ -77,9 +75,7 @@ class DynamicTextRangeSetTest : public edbee::test::TestCase
 private slots:
     void testDynamicChanges();
     void testDeleteMode();
-
 };
-
 
 } // edbee
 

--- a/edbee-test/edbee/models/textundostacktest.cpp
+++ b/edbee-test/edbee/models/textundostacktest.cpp
@@ -33,47 +33,45 @@ void TextUndoStackTest::testMultiCaretUndoIssue196()
     TextEditorWidget widget;
     TextDocument* doc = widget.textDocument();
     TextEditorController* controller = widget.controller();
-//    TextUndoStack* undoStack = doc->textUndoStack();
+    //  TextUndoStack* undoStack = doc->textUndoStack();
 
     controller->replace(0,0,"1a2b3c4d",0);                  // 1a|2b|3c4d
     controller->moveCaretToOffset(2,false);
     controller->addCaretAtOffset(4);
 
-    testEqual( doc->text(), "1a2b3c4d" );
-    testEqual( controller->textSelection()->rangesAsString(), "2>2,4>4");
+    testEqual(doc->text(), "1a2b3c4d");
+    testEqual(controller->textSelection()->rangesAsString(), "2>2,4>4");
 
     RemoveCommand del( RemoveCommand::RemoveChar, RemoveCommand::Right );
 
     del.execute(controller);
-    testEqual( doc->text(), "1abc4d" );                          // 1a|b|c4d
-    testEqual( controller->textSelection()->rangesAsString(), "2>2,3>3");
+    testEqual(doc->text(), "1abc4d" );                          // 1a|b|c4d
+    testEqual(controller->textSelection()->rangesAsString(), "2>2,3>3");
 
     del.execute(controller);
-    testEqual( controller->textSelection()->rangesAsString(), "2>2");
-    testEqual( doc->text(), "1a4d" );                       // 1a||4d
-
-
+    testEqual(controller->textSelection()->rangesAsString(), "2>2");
+    testEqual(doc->text(), "1a4d" );                       // 1a||4d
 
     del.execute(controller);
-    testEqual( doc->text(), "1ad" );
-    testEqual( controller->textSelection()->rangesAsString(), "2>2");
+    testEqual(doc->text(), "1ad" );
+    testEqual(controller->textSelection()->rangesAsString(), "2>2");
 
     del.execute(controller);
-    testEqual( doc->text(), "1a" );
-    testEqual( controller->textSelection()->rangesAsString(), "2>2");
+    testEqual(doc->text(), "1a" );
+    testEqual(controller->textSelection()->rangesAsString(), "2>2");
 
     del.execute(controller);
-    testEqual( doc->text(), "1a" );
-    testEqual( controller->textSelection()->rangesAsString(), "2>2");
+    testEqual(doc->text(), "1a" );
+    testEqual(controller->textSelection()->rangesAsString(), "2>2");
 
-//qlog_info() << "STACK: ---------------------------------------";
-//qlog_info() << doc->textUndoStack()->dumpStack();
-//qlog_info() << "----------------------------------------------";
+    //qlog_info() << "STACK: ---------------------------------------";
+    //qlog_info() << doc->textUndoStack()->dumpStack();
+    //qlog_info() << "----------------------------------------------";
 
     controller->undo();
 
-    testEqual( doc->text(), "1a2b3c4d" );
-    testEqual( controller->textSelection()->rangesAsString(), "2>2,4>4");
+    testEqual(doc->text(), "1a2b3c4d");
+    testEqual(controller->textSelection()->rangesAsString(), "2>2,4>4");
 
 
 /*
@@ -126,15 +124,15 @@ void TextUndoStackTest::testClearUndoStackCrashIssue24()
     TextDocument* doc = widget.textDocument();
     TextEditorController* controller = widget.controller();
 
-    controller->replace(0,0,"1a2b3c4d",0);
-    testEqual(doc->text(),"1a2b3c4d");
+    controller->replace(0, 0, "1a2b3c4d", 0);
+    testEqual(doc->text(), "1a2b3c4d");
 
     // clear the undo stack
     doc->textUndoStack()->clear();
-    testEqual(doc->text(),"1a2b3c4d");
+    testEqual(doc->text(), "1a2b3c4d");
 
     // move the caret (this seems to crash the undostack)
-    controller->moveCaretTo(0,4,false);
+    controller->moveCaretTo(static_cast<size_t>(0), static_cast<size_t>(4), false);
 }
 
 
@@ -144,12 +142,12 @@ void TextUndoStackTest::testClearUndoStackShouldnotUnregisterTheControllerIssue2
     TextDocument* doc = widget.textDocument();
     TextEditorController* controller = widget.controller();
 
-    testTrue( doc->textUndoStack()->isControllerRegistered(controller));
+    testTrue(doc->textUndoStack()->isControllerRegistered(controller));
 
     // clearing the undo stack should NOT unregister a controller
     doc->textUndoStack()->clear();
 
-    testTrue( doc->textUndoStack()->isControllerRegistered(controller));
+    testTrue(doc->textUndoStack()->isControllerRegistered(controller));
 }
 
 

--- a/edbee-test/edbee/util/lineoffsetvectortest.cpp
+++ b/edbee-test/edbee/util/lineoffsetvectortest.cpp
@@ -12,58 +12,165 @@
 namespace edbee {
 
 #define testLov(v,expected) testEqual(v.toUnitTestString(),expected)
+#define testLov2(v,expected,expectedRaw) { testEqual(v.toUnitTestString(),expected); testEqual(v.toUnitTestFilledString(),expectedRaw); }
+
+void apply(LineOffsetVector& v, size_t line, size_t removeCount, size_t addCount, ptrdiff_t* data, ptrdiff_t offsetDelta)
+{
+    {
+        QDebug dbg(QtDebugMsg);
+        dbg << " - " << v.toUnitTestString() << "=>" << v.toUnitTestFilledString();
+        dbg << "\n";
+        dbg << " > apply(line:" << line << ", del:" << removeCount << ", add:" << addCount << ", {";
+        for (size_t i = 0; i < addCount; ++i) {
+            dbg << data[i];
+        }
+        dbg << "},"<< offsetDelta << ")";
+        dbg << "\n";
+    }
+
+    v.applyChange(line, removeCount, addCount, data, offsetDelta);
+    qDebug() << " - " << v.toUnitTestString() << "=>" << v.toUnitTestFilledString();
+}
+
+
+void LineOffsetVectorTest::applyChange()
+{
+    LineOffsetVector v;
+
+    // Offset only changes
+    //====================
+    // qDebug() << "===" << "test change offset before delta ==";
+    {
+        // Positive Delta
+        v.initForUnitTesting(3, 2, 2, 4, 6, 8, std::string::npos); // => "2,4,[3>6,8" => "2,4,9,11"
+        apply(v, 0, 0, 0, nullptr, 10);
+        testLov2(v, "2,[13>1,6,8", "2,14,19,21");
+
+        // Negative Delta
+        v.initForUnitTesting(3, 2, 2, 4, 6, 8, std::string::npos); // => "2,4,[3>6,8" => "2,4,9,11"
+        apply(v, 0, 0, 0, nullptr, -1);
+        testLov2(v, "2,[2>1,6,8", "2,3,8,10");
+
+        // Invalid Negative Delta
+        // * This fails the asserton (because the inserted offset needs bigger the the offset before, so we don't invoke it
+        // v.initForUnitTesting(3, 2, 2, 4, 6, 8, std::string::npos); // => "2,4,[3>6,8" => "2,4,9,11"
+        // apply(v, 0, 0, 0, nullptr, -5);
+        // testLov2(v, "2,[-2>1,6,8", "2,-1,4,6");
+    }
+    // qDebug() << "===" << "test change offset at delta ==";
+    {
+        // Positive Delta
+        v.initForUnitTesting(3, 2, 2, 4, 6, 8, std::string::npos); // => "2,4,[3>6,8" => "2,4,9,11"
+        apply(v, 1, 0, 0, nullptr, 10);
+        testLov2(v, "2,4,[13>6,8", "2,4,19,21");
+
+        // Negative Delta
+        v.initForUnitTesting(3, 2, 2, 4, 6, 8, std::string::npos); // => "2,4,[3>6,8" => "2,4,9,11"
+        apply(v, 1, 0, 0, nullptr, -1);
+        testLov2(v, "2,4,[2>6,8", "2,4,8,10");
+
+        // Invalid Negative Delta
+        // * This fails the asserton (because the inserted offset needs bigger the the offset before, so we don't invoke it
+        // apply(v, 1, 0, 0, nullptr, -5);
+        // testLov2(v, "2,4,[-2>6,8", "2,4,4,6");
+    }
+
+    qDebug() << "===" << "test change offset past delta ==";
+    {
+        // Positvie Delta
+        v.initForUnitTesting(3, 2, 2, 4, 6, 8, 10, std::string::npos); // => "2,4,[3>6,8,10" => "2,4,9,11,13"
+        apply(v, 3, 0, 0, nullptr, 10);
+        testLov2(v, "2,4,9,11,[13>10", "2,4,9,11,23");
+
+        // Negative delta
+        v.initForUnitTesting(3, 2, 2, 4, 6, 8, 10, std::string::npos); // => "2,4,[3>6,8,10" => "2,4,9,11,13"
+        apply(v, 2, 0, 0, nullptr, -1);
+        testLov2(v, "2,4,9,[2>8,10", "2,4,9,10,12");
+
+        // Invalid Negative Delta
+        // * This fails the asserton (because the inserted offset needs bigger the the offset before, so we don't invoke it
+        // v.initForUnitTesting(3, 2, 2, 4, 6, 8, 10, std::string::npos); // => "2,4,[3>6,8,10" => "2,4,9,11,13"
+        // apply(v, 2, 0, 0, nullptr, -2);
+        // testLov2(v, "2,4,9,[1>8,10", "2,4,9,9,12");
+    }
+
+/*
+
+    // Line Changes
+    //=============
+
+    // test change offset before delta (not passing past delta)
+    qDebug() << "===" << "test change offset before delta (not passing past delta) ==";
+    {
+        v.initForUnitTesting(3, 2, 2, 4, 6, 8, 10, std::string::npos); // => "2,4,[3>6,8,10" => "2,4,9,11,13"
+
+        size_t newOffsets[] = { 3 };
+        apply(v, 0, 0, 1, newOffsets, 4);
+        testLov2(v,"3,[4>2,4,9,11", "3,6,13,15,17");
+    }
+
+    // test change offset after delta
+    qDebug() << "===" << "test change offset after delta ==";
+    {
+        v.initForUnitTesting(3, 2, 2, 4, 6, 8, 10, std::string::npos); // => "2,4[3>6,8"
+
+        size_t newOffsets[] = { 14 };
+        apply(v, 3, 0, 1, newOffsets, 10);
+        testLov(v,"2,4,9,14[6>8,10");
+    }
+*/
+}
 
 
 void LineOffsetVectorTest::testMoveDeltaToIndex()
 {
     LineOffsetVector v;
     v.initForUnitTesting(3, 2, 2, 4, 6, 8, std::string::npos);
-    testLov(v,"2,4[3>6,8");
+    testLov2(v, "2,4,[3>6,8", "2,4,9,11");
 
     // move to the left
     v.moveDeltaToIndex(1);
-    testLov(v,"2[3>1,6,8");
+    testLov2(v, "2,[3>1,6,8", "2,4,9,11");
 
     // move to the right
     v.moveDeltaToIndex(2);
-    testLov(v,"2,4[3>6,8");
+    testLov2(v, "2,4,[3>6,8", "2,4,9,11");
 
     // one step further
     v.moveDeltaToIndex(3);
-    testLov(v,"2,4,9[3>8");
+    testLov2(v, "2,4,9,[3>8", "2,4,9,11");
 
     // moving to the left 2 steps should force the delta-0 rule (2>1)
     v.moveDeltaToIndex(1);
-    testLov(v,"2[0>4,9,11");
+    testLov2(v,"2,[0>4,9,11", "2,4,9,11");
 }
 
 
 void LineOffsetVectorTest::testChangeOffsetDelta()
 {
     LineOffsetVector v;
-    v.initForUnitTesting( 3, 2, 2, 4, 6, 8, std::string::npos);
-    testLov(v,"2,4[3>6,8");
+    v.initForUnitTesting(3, 2, 2, 4, 6, 8, std::string::npos); // offsetdelta, offsetindex, offsets...
+    testLov2(v,"2,4,[3>6,8", "2,4,9,11");
 
     // test the same location
-    v.changeOffsetDelta(2,4);
-    testLov(v,"2,4[7>6,8");
+    v.changeOffsetDelta(2, 4);
+    testLov2(v, "2,4,[7>6,8", "2,4,13,15");
 
     // test an offset before the current location
-    v.changeOffsetDelta(1, -1);
-    testLov(v,"2[6>-2,6,8");
-
-qDebug() << "RICK: Fix dit, dit zijn ongeldige waardes!";
-
-    // test the same location with an Incorrect -4 values (1). NOTE, this usually doesn't happen, only in this unit test
-    // This now removes all incorrect offsets after the delta
     v.changeOffsetDelta(1, -4);
+    //testLov(v,"2[6>-2,6,8");
+    // testLov(v,"2[6>6,8");
+    testLov2(v, "2,[3>1,6,8", "2,4,9,11");
+
+    // test a change
+    v.changeOffsetDelta(1, 1);
     // testLov(v,"2[2>-2,6,8");
-    testLov(v,"2[2>6,8");
+    testLov2(v, "2,[4>1,6,8", "2,5,10,12");
 
     // test an offset after the current location
-    v.changeOffsetDelta(3, -2);
+    v.changeOffsetDelta(4, -1);
     //testLov(v,"2,0,8[0>8");  // <<< THIS Seems like a bug!!!! (offset need to increase?)
-    testLov(v,"2,8,10[0>");
+    testLov2(v, "2,5,10,12,[0>", "2,5,10,12");
 
 }
 
@@ -79,21 +186,20 @@ void LineOffsetVectorTest::testTextReplaced()
 {
     LineOffsetVector v;
     V_TEXT_REPLACED(0,0,"a\nb\nc\nd\ne");
-    testLov(v,"0,2,4,6,8[0>");
+    testLov2(v, "0,2,4,6,8,[0>", "0,2,4,6,8");
 
     // next insert a newline
     V_TEXT_REPLACED(3,0,"\n");
-    testLov(v,"0,2,4[1>4,6,8");
+    testLov2(v, "0,2,4,[1>4,6,8", "0,2,4,5,7,9");
 
     v.moveDeltaToIndex(0);
-    testLov(v,"[0>0,2,4,5,7,9");
+    testLov2(v, "[0>0,2,4,5,7,9", "0,2,4,5,7,9");
 
     V_TEXT_REPLACED(0,0,"\n");
-    testLov(v,"0,1[1>2,4,5,7,9");
-
+    testLov2(v, "0,1,[1>2,4,5,7,9", "0,1,3,5,6,8,10");
 
     V_TEXT_REPLACED(0,11,"");
-    testLov(v,"0[0>");
+    testLov2(v, "0,[0>", "0");
 
 }
 
@@ -102,24 +208,21 @@ void LineOffsetVectorTest::testFindLineFromOffset()
     LineOffsetVector v;
 
     // offset 0,4
-    v.initForUnitTesting(0,0, 0,4,-1);
-    testEqual( v.findLineFromOffset(0), 0 );
-    testEqual( v.findLineFromOffset(1), 0 );
-    testEqual( v.findLineFromOffset(2), 0 );
-    testEqual( v.findLineFromOffset(3), 0 );
-    testEqual( v.findLineFromOffset(4), 1 );
+    v.initForUnitTesting(0, 0, 0, 4, std::string::npos);
+    testEqual(v.findLineFromOffset(0), 0);
+    testEqual(v.findLineFromOffset(1), 0);
+    testEqual(v.findLineFromOffset(2), 0);
+    testEqual(v.findLineFromOffset(3), 0);
+    testEqual(v.findLineFromOffset(4), 1);
 
 
     // offsets: 0,4
-    v.initForUnitTesting(2,1, 0,2,-1);
-    testEqual( v.findLineFromOffset(0), 0 );
-    testEqual( v.findLineFromOffset(1), 0 );
-    testEqual( v.findLineFromOffset(2), 0 );
-    testEqual( v.findLineFromOffset(3), 0 );
-    testEqual( v.findLineFromOffset(4), 1 );
-
-
+    v.initForUnitTesting(2, 1, 0, 2, std::string::npos);
+    testEqual(v.findLineFromOffset(0), 0);
+    testEqual(v.findLineFromOffset(1), 0);
+    testEqual(v.findLineFromOffset(2), 0);
+    testEqual(v.findLineFromOffset(3), 0);
+    testEqual(v.findLineFromOffset(4), 1);
 }
-
 
 } // edbee

--- a/edbee-test/edbee/util/lineoffsetvectortest.cpp
+++ b/edbee-test/edbee/util/lineoffsetvectortest.cpp
@@ -49,15 +49,21 @@ void LineOffsetVectorTest::testChangeOffsetDelta()
     testLov(v,"2,4[7>6,8");
 
     // test an offset before the current location
-    // v.changeOffsetDelta(1, -1); => Negative is invalid and results in assertation!!
-    // testLov(v,"2[6>-2,6,8");
+    v.changeOffsetDelta(1, -1);
+    testLov(v,"2[6>-2,6,8");
 
-     v.changeOffsetDelta(1, -4);
-     testLov(v,"2[3>1,6,8");
+qDebug() << "RICK: Fix dit, dit zijn ongeldige waardes!";
+
+    // test the same location with an Incorrect -4 values (1). NOTE, this usually doesn't happen, only in this unit test
+    // This now removes all incorrect offsets after the delta
+    v.changeOffsetDelta(1, -4);
+    // testLov(v,"2[2>-2,6,8");
+    testLov(v,"2[2>6,8");
 
     // test an offset after the current location
     v.changeOffsetDelta(3, -2);
-    testLov(v,"2,4,9[1>8");
+    //testLov(v,"2,0,8[0>8");  // <<< THIS Seems like a bug!!!! (offset need to increase?)
+    testLov(v,"2,8,10[0>");
 
 }
 

--- a/edbee-test/edbee/util/lineoffsetvectortest.cpp
+++ b/edbee-test/edbee/util/lineoffsetvectortest.cpp
@@ -17,7 +17,7 @@ namespace edbee {
 void LineOffsetVectorTest::testMoveDeltaToIndex()
 {
     LineOffsetVector v;
-    v.initForUnitTesting( 3, 2, 2,4,6,8,-1);
+    v.initForUnitTesting(3, 2, 2, 4, 6, 8, std::string::npos);
     testLov(v,"2,4[3>6,8");
 
     // move to the left
@@ -41,7 +41,7 @@ void LineOffsetVectorTest::testMoveDeltaToIndex()
 void LineOffsetVectorTest::testChangeOffsetDelta()
 {
     LineOffsetVector v;
-    v.initForUnitTesting( 3, 2, 2,4,6,8,-1);
+    v.initForUnitTesting( 3, 2, 2, 4, 6, 8, std::string::npos);
     testLov(v,"2,4[3>6,8");
 
     // test the same location
@@ -49,12 +49,15 @@ void LineOffsetVectorTest::testChangeOffsetDelta()
     testLov(v,"2,4[7>6,8");
 
     // test an offset before the current location
-    v.changeOffsetDelta(1,-1);
-    testLov(v,"2[6>-2,6,8");
+    // v.changeOffsetDelta(1, -1); => Negative is invalid and results in assertation!!
+    // testLov(v,"2[6>-2,6,8");
+
+     v.changeOffsetDelta(1, -4);
+     testLov(v,"2[3>1,6,8");
 
     // test an offset after the current location
-    v.changeOffsetDelta(3,-2);
-    testLov(v,"2,4,12[4>8");
+    v.changeOffsetDelta(3, -2);
+    testLov(v,"2,4,9[1>8");
 
 }
 

--- a/edbee-test/edbee/util/lineoffsetvectortest.h
+++ b/edbee-test/edbee/util/lineoffsetvectortest.h
@@ -15,6 +15,7 @@ class LineOffsetVectorTest : public edbee::test::TestCase
 
 private slots:
 
+    void applyChange();
     void testMoveDeltaToIndex();
     void testChangeOffsetDelta();
     void testTextReplaced();

--- a/edbee-test/edbee/util/lineoffsetvectortest.h
+++ b/edbee-test/edbee/util/lineoffsetvectortest.h
@@ -19,7 +19,6 @@ private slots:
     void testChangeOffsetDelta();
     void testTextReplaced();
     void testFindLineFromOffset();
-
 };
 
 

--- a/edbee-test/edbee/util/rangelineiteratortest.cpp
+++ b/edbee-test/edbee/util/rangelineiteratortest.cpp
@@ -15,22 +15,21 @@ namespace edbee {
 void RangeLineIteratorTest::testBasicIteration()
 {
     CharTextDocument doc;
-    doc.setText( QStringLiteral("a1|b2|c3|d4|e5|f6").replace("|","\n"));
+    doc.setText(QStringLiteral("a1|b2|c3|d4|e5|f6").replace("|","\n"));
     TextRange range(4,15);
 
-    RangeLineIterator itr( &doc, range);
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 1 );
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 2 );
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 3 );
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 4 );
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 5 );
-    testFalse( itr.hasNext() );
-
+    RangeLineIterator itr(&doc, range);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 1);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 2);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 3);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 4);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 5);
+    testFalse(itr.hasNext());
 }
 
 
@@ -40,15 +39,12 @@ void RangeLineIteratorTest::testSingleLineIteration()
 {
     CharTextDocument doc;
     doc.setText( QStringLiteral("line1|line").replace("|","\n"));
-    TextRange range(1,1);
+    TextRange range(1, 1);
 
-    RangeLineIterator itr( &doc, range);
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 0 );
-
+    RangeLineIterator itr(&doc, range);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 0);
 }
-
-
 
 
 } // edbee

--- a/edbee-test/edbee/util/rangesetlineiteratortest.cpp
+++ b/edbee-test/edbee/util/rangesetlineiteratortest.cpp
@@ -15,27 +15,27 @@ namespace edbee {
 void RangeSetLineIteratorTest::testBasicIteration()
 {
     CharTextDocument doc;
-    doc.setText( QStringLiteral("a1|b2|c3|d4|e5|f6").replace("|","\n"));
+    doc.setText(QStringLiteral("a1|b2|c3|d4|e5|f6").replace("|", "\n"));
     TextRangeSet ranges(&doc);
-    ranges.addRange(0,0);   // line: 0
-    ranges.addRange(1,1);   // line: 0
-    ranges.addRange(2,7);   // line: 0-2
-    ranges.addRange(12,15); // line: 4-5
+    ranges.addRange(0, 0);   // line: 0
+    ranges.addRange(1, 1);   // line: 0
+    ranges.addRange(2, 7);   // line: 0-2
+    ranges.addRange(12, 15); // line: 4-5
 
     RangeSetLineIterator itr(&ranges);
 
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 0 );
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 1 );
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 2 );
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 4 );
-    testTrue( itr.hasNext() );
-    testEqual( itr.next(), 5 );
-    testFalse( itr.hasNext() );
-    testEqual( itr.next(), -1 );
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 0);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 1);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 2);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 4);
+    testTrue(itr.hasNext());
+    testEqual(itr.next(), 5);
+    testFalse(itr.hasNext());
+    testEqual(itr.next(), std::string::npos);
 }
 
 

--- a/edbee-test/edbee/util/regexptest.cpp
+++ b/edbee-test/edbee/util/regexptest.cpp
@@ -12,22 +12,16 @@ namespace edbee {
 void RegExpTest::testRegExp()
 {
     RegExp* regExp = new RegExp( "a+(b*)c*");
-    int idx = regExp->indexIn("xxxaaabccccddddd");
-    testEqual( idx, 3 );
-    testEqual( regExp->pos(0), 3 );
-    testEqual( regExp->len(0), 8 );
+    size_t idx = regExp->indexIn("xxxaaabccccddddd");
+    testEqual(idx, 3 );
+    testEqual(regExp->pos(0), 3);
+    testEqual(regExp->len(0), 8);
 
-    testEqual( regExp->pos(1), 6 ); // the b is at the 6th position
-    testEqual( regExp->len(1), 1 );
+    testEqual(regExp->pos(1), 6); // the b is at the 6th position
+    testEqual(regExp->len(1), 1);
 
-    testEqual( regExp->pos(2), -1 ); // the b is at the 6th position
-    testEqual( regExp->len(2), -1 );
-
-
-//    qlog_info() << "pos-0: " << regExp->pos(0);
-//    qlog_info() << "pos-1: " << regExp->pos(1);
-//    qlog_info() << "pos-2: " << regExp->pos(2);
-
+    testEqual(regExp->pos(2), std::string::npos); // the b is at the 6th position
+    testEqual(regExp->len(2), std::string::npos);
 
     delete regExp;
 }

--- a/edbee-test/edbee/util/utiltest.cpp
+++ b/edbee-test/edbee/util/utiltest.cpp
@@ -37,12 +37,12 @@ void UtilTest::testConvertTabsToSpaces()
 
 
 /// helper function to convert a QVector<int> to a string list
-static QString str( const QList<int>& list )
+static QString str(const QList<size_t>& list)
 {
     QString result;
-    foreach( int val, list ) {
-        if( !result.isEmpty() ) { result.append(","); }
-        result.append( QString::number(val) );
+    foreach(size_t val, list) {
+        if (!result.isEmpty()) { result.append(","); }
+        result.append(QString::number(val));
     }
     return result;
 }

--- a/edbee-test/main.cpp
+++ b/edbee-test/main.cpp
@@ -23,14 +23,14 @@ int main(int argc, char* argv[])
     //==================================
     QList<QString> tests;
 
-    tests.append( "edbee::TextChangeTest");
-    tests.append( "edbee::MergableChangeGroupTest");
-    tests.append( "edbee::LineOffsetVectorTest");
-    tests.append( "edbee::LineDataListChangeTest");
-    tests.append( "edbee::PlainTextDocumentTest");
-    tests.append( "edbee::TextLineDataTest");
-    tests.append( "edbee::TextRangeSetTest");
-    tests.append( "edbee::TextUndoStackTest");
+    // tests.append( "edbee::TextChangeTest");
+    // tests.append( "edbee::MergableChangeGroupTest");
+    // tests.append( "edbee::LineOffsetVectorTest");
+    // tests.append( "edbee::LineDataListChangeTest");
+    // tests.append( "edbee::PlainTextDocumentTest");
+    // tests.append( "edbee::TextLineDataTest");
+    // tests.append( "edbee::TextRangeSetTest");
+    // tests.append( "edbee::TextUndoStackTest");
 
     tests.clear();      // when the tests lists is empty all tests are run
 


### PR DESCRIPTION
A big refactor of the edbee code. 
Using strict type casting tests. 

Converted some essential types from `int` to `size_t` (with sometimes `ptrdiff_t` if required). (TextDocument, TextBuffer etc.)
Some places uses `qsizetype` for types, if it's Qt vector.
The screen coordinates have stayed `int` because that's the way Qt expects it.

Some important incompatibility is caused by these changes.

Methods which returned -1 (<0) for not found or/error, have changed so they will return `std::string::npos`.

In the last commits some Qt5 incompatibilities have been fixe.

Before moving these to the main branch, it's essential to test it thoroughly.
It's has only been tested on:
- Mac OS X, with QtCreateClang QT6
- Mac OS X, with Cmake, QT5

Btw. A bug in tabcommand has been discovered and fixed (In rare cases a back-tab/indent) was not performed. (If the offset == endOffset of the line)

