### PR TITLE
Fix: dead code removal

### DIFF
--- a/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
+++ b/edbee-lib/edbee/views/accessibletexteditorwidget.cpp
@@ -117,15 +117,11 @@ static const QString VTEXT(TextDocument* doc)
 static const QString VTEXT_PART(TextDocument* doc, size_t offset, size_t length)
 {
 #if ! defined(WINDOWS_END_LINE_READ_ERROR_FIX)
-    if(length < 0) {
-        return QString();
-    }
-
     return doc->textPart(offset, qMin(length, doc->length() - offset));
 #else
     size_t docLength = doc->length();
 #if defined(WINDOWS_LAST_LINE_ERROR_FIX)
-        size_t endOffset = qMin(offset + length, docLength + 2);
+    size_t endOffset = qMin(offset + length, docLength + 2);
 #endif // WINDOWS_LAST_LINE_ERROR_FIX - First use
     //qDebug() << "VTEXT_PART: " << offset << ", " << length << " :: docLength: " << docLength << ", endOffset: " << endOffset;
 


### PR DESCRIPTION
With the change to (the unsigned) `size_t` type in e3481090b9a9e5707c67c040d0460d8bb36cdf97 a value can now never be less than zero so a check for that is functionally dead code.