### PR TITLE
ref #152, Autocomplete Improvements for Screenreaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+- (2025-11-19) #152, Autocomplete Improvements for Screenreaders
+  - When autocomplete is shown the focus is moved to the internal QListWidget 
+  - ScreenReader NVDA now reacts better on the autocomplete 
+  - The autocomplete list has the accessibility label 'autocomplete'
 - (2025-11-12) #73, Stray Pixel at the bottom of the cursor (again)
 - (2025-11-04) #169, Retain clipboard when invoking CopyCommand without selection on a blank line.
 

--- a/edbee-lib/edbee/texteditorwidget.cpp
+++ b/edbee-lib/edbee/texteditorwidget.cpp
@@ -38,6 +38,7 @@
 #include "edbee/views/texttheme.h"
 
 #include "edbee/debug.h"
+#include "qlistwidget.h"
 
 
 
@@ -301,6 +302,11 @@ bool TextEditorWidget::readonly() const
 void TextEditorWidget::setReadonly(bool value)
 {
     readonly_ = value;
+}
+
+bool TextEditorWidget::isFocusedOrChildHasFocus()
+{
+    return hasFocus() || editCompRef_->hasFocus() || autoCompleteCompRef_->listWidget()->hasFocus();
 }
 
 

--- a/edbee-lib/edbee/texteditorwidget.h
+++ b/edbee-lib/edbee/texteditorwidget.h
@@ -72,6 +72,8 @@ public:
     virtual bool readonly() const;
     void setReadonly(bool readonly);
 
+    bool isFocusedOrChildHasFocus();
+
 
 protected:
 

--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
@@ -50,12 +50,9 @@ TextEditorAutoCompleteComponent::TextEditorAutoCompleteComponent(TextEditorContr
     this->setAttribute(Qt::WA_ShowWithoutActivating);
 
     menuRef_ = new QMenu(this);
-    menuRef_->setFocusPolicy(Qt::NoFocus);
-    menuRef_->setAttribute(Qt::WA_ShowWithoutActivating);
+    menuRef_->setAccessibleName("Autocomplete");
 
     listWidgetRef_ = new QListWidget(menuRef_);
-    listWidgetRef_->setFocusPolicy(Qt::NoFocus);
-    listWidgetRef_->setAttribute(Qt::WA_ShowWithoutActivating);
 
     listWidgetRef_->installEventFilter(this);
 
@@ -69,7 +66,7 @@ TextEditorAutoCompleteComponent::TextEditorAutoCompleteComponent(TextEditorContr
     wAction->setDefaultWidget(listWidgetRef_);
     menuRef_->addAction(wAction);
 
-    listWidgetRef_->setFocus();
+
 
     infoTipRef_ = new FakeToolTip(controllerRef_, this);
 
@@ -430,7 +427,7 @@ void TextEditorAutoCompleteComponent::updateList()
     // fills the autocomplete list with the curent word
     if (fillAutoCompleteList(doc, range, currentWord_)) {
         menuRef_->popup(menuRef_->pos());
-        editorComponentRef_->setFocus();
+        listWidgetRef_->setFocus();
 
         // position the widget
         showInfoTip();

--- a/edbee-lib/edbee/views/components/texteditorcomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorcomponent.cpp
@@ -576,7 +576,7 @@ void TextEditorComponent::contextMenuEvent(QContextMenuEvent* event)
 void TextEditorComponent::repaintCarets()
 {
     bool visible = textRenderer()->isCaretVisible();
-    bool focus = hasFocus();
+    bool focus = textRenderer()->textWidget()->isFocusedOrChildHasFocus();
 
     if (focus != visible) {
         textRenderer()->setCaretVisible(focus);


### PR DESCRIPTION
- When autocomplete is shown the focus is moved to the internal QListWidget
- ScreenReader NVDA now reacts better on the autocomplete
- The autocomplete list has the accessibility label 'autocomplete'